### PR TITLE
Feature/pre go.1.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+lib/core/marshalingexample_test.go
+lib/core/runtest_test.go
+lib/core/tests

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,10 +9,7 @@
             "type": "go",
             "request": "launch",
             "mode": "test",
-            "program": "${workspaceFolder}",
-            "args": [
-                "--test.run", "TryCatchFinally"
-            ]
+            "program": "${workspaceFolder}"
         },
         {
             "name": "Lisp REPL",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
             "type": "go",
             "request": "launch",
             "mode": "test",
-            "program": "${workspaceFolder}"
+            "program": "${workspaceFolder}",
+            "args":["./..."]
         },
         {
             "name": "Lisp REPL",

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ go test -benchmem -benchtime 5s -bench '^.+$' github.com/jig/lisp
 - `(rename-keys hm hmAlterKeys)` as in Clojure
 - `(get-in m ks)` to access nested values from a `m` map; `ks` must be a vector of hash map keys
 - `(uuid)` returns an 128 bit rfc4122 random UUID
-- `(split string cutset)` returns a lisp Vector of the elements splitted by the cutset (see [./test/stepH_strings](./test/stepH_strings.mal) for examples)
-- support of (hashed, unordered) sets. Only sets of strings or keywords supported. Use `#{}` for literal sets. Functions supported for sets: `set`, `set?`, `conj`, `get`, `assoc`, `dissoc`, `contains?`, `empty?`. `meta`, `with-meta` (see [./test/stepA_mal](./test/stepF_set.mal) and (see [./test/stepA_mal](./test/stepF_set.mal) for examples). `json-encode` will encode a set to a JSON array.
+- `(split string cutset)` returns a lisp Vector of the elements splitted by the cutset (see [./tests/stepH_strings](./tests/stepH_strings.mal) for examples)
+- support of (hashed, unordered) sets. Only sets of strings or keywords supported. Use `#{}` for literal sets. Functions supported for sets: `set`, `set?`, `conj`, `get`, `assoc`, `dissoc`, `contains?`, `empty?`. `meta`, `with-meta` (see [./tests/stepA_mal](./tests/stepF_set.mal) and (see [./tests/stepA_mal](./tests/stepF_set.mal) for examples). `json-encode` will encode a set to a JSON array.
 - `update`, `update-in` and `assoc-in` supported for hash maps and vectors.
 - Go function `READ_WithPreamble` works like `READ` but supports placeholders to be filled on READ time (see [./placeholder_test.go](./placeholder_test.go) for som samples).
 - Added support for `finally` inside `try`. `finally` expression is evaluated for side effects only.

--- a/command/command.go
+++ b/command/command.go
@@ -23,10 +23,10 @@ func Execute(args []string, repl_env types.EnvType) error {
 	case 1:
 		// repl loop
 		ctx := context.Background()
-		if _, err := lisp.REPL(repl_env, `(println (str "Lisp Mal [" *host-language* "]"))`, &ctx); err != nil {
+		if _, err := lisp.REPL(ctx, repl_env, `(println (str "Lisp Mal [" *host-language* "]"))`); err != nil {
 			return fmt.Errorf("internal error: %s", err)
 		}
-		if err := repl.Execute(repl_env, &ctx); err != nil {
+		if err := repl.Execute(ctx, repl_env); err != nil {
 			return err
 		}
 		return nil
@@ -39,10 +39,12 @@ func Execute(args []string, repl_env types.EnvType) error {
 				if !info.IsDir() {
 					if strings.HasSuffix(info.Name(), "_test.mal") {
 						testParams := fmt.Sprintf(`(def *test-params* {:test-file %q :test-absolute-path %q})`, info.Name(), path)
-						if _, err := lisp.REPL(repl_env, testParams, nil); err != nil {
+
+						ctx := context.Background()
+						if _, err := lisp.REPL(ctx, repl_env, testParams); err != nil {
 							return err
 						}
-						if _, err := lisp.REPLPosition(repl_env, `(load-file "`+path+`")`, nil, &types.Position{
+						if _, err := lisp.REPLPosition(ctx, repl_env, `(load-file "`+path+`")`, &types.Position{
 							Module: &path,
 							Row:    -3, // "ugly hack: load-file implementation is 4 lines long"
 						}); err != nil {
@@ -70,7 +72,7 @@ func Execute(args []string, repl_env types.EnvType) error {
 // ExecuteFile executes a file on the given path
 func ExecuteFile(fileName string, repl_env types.EnvType) (types.MalType, error) {
 	ctx := context.Background()
-	result, err := lisp.REPLPosition(repl_env, `(load-file "`+fileName+`")`, &ctx, &types.Position{
+	result, err := lisp.REPLPosition(ctx, repl_env, `(load-file "`+fileName+`")`, &types.Position{
 		Module: &fileName,
 		Row:    -3, // "ugly hack: load-file implementation is 4 lines long"
 	})

--- a/cursor2_test.go
+++ b/cursor2_test.go
@@ -16,21 +16,22 @@ func TestCursor2(t *testing.T) {
 	}
 	// core.go: defined using go
 	for k, v := range core.NS {
-		bootEnv.Set(types.Symbol{Val: k}, types.Func{Fn: v.(func([]types.MalType, *context.Context) (types.MalType, error))})
+		bootEnv.Set(types.Symbol{Val: k}, types.Func{Fn: v.(func(context.Context, []types.MalType) (types.MalType, error))})
 	}
 	for k, v := range core.NSInput {
-		bootEnv.Set(types.Symbol{Val: k}, types.Func{Fn: v.(func([]types.MalType, *context.Context) (types.MalType, error))})
+		bootEnv.Set(types.Symbol{Val: k}, types.Func{Fn: v.(func(context.Context, []types.MalType) (types.MalType, error))})
 	}
-	bootEnv.Set(types.Symbol{Val: "eval"}, types.Func{Fn: func(a []types.MalType, ctx *context.Context) (types.MalType, error) {
-		return EVAL(a[0], bootEnv, ctx)
+	bootEnv.Set(types.Symbol{Val: "eval"}, types.Func{Fn: func(ctx context.Context, a []types.MalType) (types.MalType, error) {
+		return EVAL(ctx, a[0], bootEnv)
 	}})
 	bootEnv.Set(types.Symbol{Val: "*ARGV*"}, types.List{})
 
-	_, err = REPLPosition(bootEnv, codeMacro, nil, &types.Position{})
+	ctx := context.Background()
+	_, err = REPLPosition(ctx, bootEnv, codeMacro, &types.Position{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = REPLPosition(bootEnv, testCode, nil, &types.Position{})
+	_, err = REPLPosition(ctx, bootEnv, testCode, &types.Position{})
 	switch err := err.(type) {
 	case nil:
 		t.Error("unexpected: no error returned")

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -16,18 +16,19 @@ func TestCursor(t *testing.T) {
 	}
 	// core.go: defined using go
 	for k, v := range core.NS {
-		bootEnv.Set(types.Symbol{Val: k}, types.Func{Fn: v.(func([]types.MalType, *context.Context) (types.MalType, error))})
+		bootEnv.Set(types.Symbol{Val: k}, types.Func{Fn: v.(func(context.Context, []types.MalType) (types.MalType, error))})
 	}
 	for k, v := range core.NSInput {
-		bootEnv.Set(types.Symbol{Val: k}, types.Func{Fn: v.(func([]types.MalType, *context.Context) (types.MalType, error))})
+		bootEnv.Set(types.Symbol{Val: k}, types.Func{Fn: v.(func(context.Context, []types.MalType) (types.MalType, error))})
 	}
-	bootEnv.Set(types.Symbol{Val: "eval"}, types.Func{Fn: func(a []types.MalType, ctx *context.Context) (types.MalType, error) {
-		return EVAL(a[0], bootEnv, ctx)
+	bootEnv.Set(types.Symbol{Val: "eval"}, types.Func{Fn: func(ctx context.Context, a []types.MalType) (types.MalType, error) {
+		return EVAL(ctx, a[0], bootEnv)
 	}})
 	bootEnv.Set(types.Symbol{Val: "*ARGV*"}, types.List{})
 
+	ctx := context.Background()
 	// core.mal: defined using the language itself
-	_, err = REPL(bootEnv, `(def *host-language* "go")`, nil)
+	_, err = REPL(ctx, bootEnv, `(def *host-language* "go")`)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +93,7 @@ func TestCursor(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		ast, err := REPLPosition(subEnv, "(do\n"+testCase.Code+"\na)", nil, &types.Position{
+		ast, err := REPLPosition(ctx, subEnv, "(do\n"+testCase.Code+"\na)", &types.Position{
 			Module: &testCase.Module,
 			Row:    0,
 		})

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -1,6 +1,7 @@
 package example
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -39,7 +40,7 @@ func ExampleEVAL() {
 	}
 
 	// eval AST
-	result, err := lisp.EVAL(ast, newEnv, nil)
+	result, err := lisp.EVAL(context.TODO(), ast, newEnv)
 	if err != nil {
 		log.Fatalf("EVAL error: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	github.com/google/uuid v1.3.0
 )
 
-require golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e // indirect
+require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,5 +9,5 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e h1:NHvCuwuS43lGnYhten69ZWqi2QOj/CiDNcKbVqwVoew=
-golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/helloworldlnotationexample_test.go
+++ b/helloworldlnotationexample_test.go
@@ -18,7 +18,7 @@ func ExampleL() {
 	)
 	sampleCode := L(prn, L(str, "hello", " ", "world!"))
 
-	result, err := EVAL(sampleCode, newTestEnv(), nil)
+	result, err := EVAL(context.TODO(), sampleCode, newTestEnv())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func newTestEnv() types.EnvType {
 		log.Fatalf("Environment Setup Error: %v\n", err)
 	}
 	for k, v := range core.NS {
-		newEnv.Set(types.Symbol{Val: k}, types.Func{Fn: v.(func([]types.MalType, *context.Context) (types.MalType, error))})
+		newEnv.Set(types.Symbol{Val: k}, types.Func{Fn: v.(func(context.Context, []types.MalType) (types.MalType, error))})
 	}
 	return newEnv
 }

--- a/lib/call-helper/call.go
+++ b/lib/call-helper/call.go
@@ -8,66 +8,66 @@ import (
 )
 
 // Call0e returns a function that checks there are 0 arguments and calls f
-func Call0e(f func([]MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func Call0e(f func() (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
 	return func(args []MalType, _ *context.Context) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 0 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 0)", len(args))
 		}
-		return f(args)
+		return f()
 	}
 }
 
 // Call1e returns a function that checks there is 1 argument and calls f
-func Call1e(f func([]MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func Call1e(f func(MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
 	return func(args []MalType, _ *context.Context) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 1 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 1)", len(args))
 		}
-		return f(args)
+		return f(args[0])
 	}
 }
 
 // Call2e returns a function that checks there are 2 arguments and calls f
-func Call2e(f func([]MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func Call2e(f func(MalType, MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
 	return func(args []MalType, _ *context.Context) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 2 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 2)", len(args))
 		}
-		return f(args)
+		return f(args[0], args[1])
 	}
 }
 
 // Call3e returns a function that checks there are 3 arguments and calls f
-func Call3e(f func([]MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func Call3e(f func(MalType, MalType, MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
 	return func(args []MalType, _ *context.Context) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 3 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 3)", len(args))
 		}
-		return f(args)
+		return f(args[0], args[1], args[2])
 	}
 }
 
 // CallNe returns a function that checks there are N arguments and calls f... so it does not check anything
-func CallNe(f func([]MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func CallNe(f func(...MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
 	// just for documenting purposes, does not check anything
 	return func(args []MalType, _ *context.Context) (result MalType, err error) {
 		defer malRecover(&err)
-		return f(args)
+		return f(args...)
 	}
 }
 
 // CallVe returns a function that checks there are a variable number of arguments between minArg and maxArg (both of them included)
-func CallVe(minArg, maxArg int, f func([]MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func CallVe(minArg, maxArg int, f func(...MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
 	return func(args []MalType, _ *context.Context) (result MalType, err error) {
 		defer malRecover(&err)
 		if l := len(args); l > maxArg || l < minArg {
 			return nil, fmt.Errorf("wrong number of arguments (%d is out of range [%d,%d])", len(args), minArg, maxArg)
 		}
-		return f(args)
+		return f(args...)
 	}
 }
 
@@ -94,66 +94,77 @@ func Call2b(f func(MalType, MalType) bool) func([]MalType, *context.Context) (Ma
 }
 
 // CallNeC returns a function that checks there are N arguments and calls f (that requires *context.Context)
-func CallNeC(f func([]MalType, *context.Context) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func CallNeC(f func(context.Context, ...MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
 	// just for documenting purposes, does not check anything
 	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
 		defer malRecover(&err)
-		return f(args, ctx)
+		return f(*ctx, args...)
 	}
 }
 
 // Call0eC returns a function that checks there are 0 arguments and calls f (that requires *context.Context)
-func Call0eC(f func([]MalType, *context.Context) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func Call0eC(f func(context.Context) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
 	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 0 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 0", len(args))
 		}
-		return f(args, ctx)
+		return f(*ctx)
 	}
 }
 
 // Call1eC returns a function that checks there is 1 argument and calls f (that requires *context.Context)
-func Call1eC(f func([]MalType, *context.Context) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func Call1eC(f func(context.Context, MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
 	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 1 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 1)", len(args))
 		}
-		return f(args, ctx)
+		return f(*ctx, args[0])
 	}
 }
 
 // Call2eC returns a function that checks there are 2 arguments and calls f (that requires *context.Context)
-func Call2eC(f func([]MalType, *context.Context) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func Call2eC(f func(context.Context, MalType, MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
 	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 2 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 2)", len(args))
 		}
-		return f(args, ctx)
+		return f(*ctx, args[0], args[1])
 	}
 }
 
 // Call3eC returns a function that checks there are 2 arguments and calls f (that requires *context.Context)
-func Call3eC(f func([]MalType, *context.Context) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func Call3eC(f func(context.Context, MalType, MalType, MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
 	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 3 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 3)", len(args))
 		}
-		return f(args, ctx)
+		return f(*ctx, args[0], args[1], args[2])
 	}
 }
 
 // Call4eC returns a function that checks there are 2 arguments and calls f (that requires *context.Context)
-func Call4eC(f func([]MalType, *context.Context) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func Call4eC(f func(context.Context, MalType, MalType, MalType, MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
 	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 4 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 4)", len(args))
 		}
-		return f(args, ctx)
+		return f(*ctx, args[0], args[1], args[2], args[3])
+	}
+}
+
+// CallVeC returns a function that checks there are a variable number of arguments between minArg and maxArg (both of them included)
+func CallVeC(minArg, maxArg int, f func(context.Context, ...MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
+		defer malRecover(&err)
+		if l := len(args); l > maxArg || l < minArg {
+			return nil, fmt.Errorf("wrong number of arguments (%d is out of range [%d,%d])", len(args), minArg, maxArg)
+		}
+		return f(*ctx, args...)
 	}
 }
 

--- a/lib/call-helper/call.go
+++ b/lib/call-helper/call.go
@@ -8,8 +8,8 @@ import (
 )
 
 // Call0e returns a function that checks there are 0 arguments and calls f
-func Call0e(f func() (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, _ *context.Context) (result MalType, err error) {
+func Call0e(f func() (MalType, error)) func(context.Context, []MalType) (MalType, error) {
+	return func(_ context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 0 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 0)", len(args))
@@ -19,8 +19,8 @@ func Call0e(f func() (MalType, error)) func([]MalType, *context.Context) (MalTyp
 }
 
 // Call1e returns a function that checks there is 1 argument and calls f
-func Call1e(f func(MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, _ *context.Context) (result MalType, err error) {
+func Call1e(f func(MalType) (MalType, error)) func(context.Context, []MalType) (MalType, error) {
+	return func(_ context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 1 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 1)", len(args))
@@ -30,8 +30,8 @@ func Call1e(f func(MalType) (MalType, error)) func([]MalType, *context.Context) 
 }
 
 // Call2e returns a function that checks there are 2 arguments and calls f
-func Call2e(f func(MalType, MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, _ *context.Context) (result MalType, err error) {
+func Call2e(f func(MalType, MalType) (MalType, error)) func(context.Context, []MalType) (MalType, error) {
+	return func(_ context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 2 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 2)", len(args))
@@ -41,8 +41,8 @@ func Call2e(f func(MalType, MalType) (MalType, error)) func([]MalType, *context.
 }
 
 // Call3e returns a function that checks there are 3 arguments and calls f
-func Call3e(f func(MalType, MalType, MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, _ *context.Context) (result MalType, err error) {
+func Call3e(f func(MalType, MalType, MalType) (MalType, error)) func(context.Context, []MalType) (MalType, error) {
+	return func(_ context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 3 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 3)", len(args))
@@ -52,17 +52,17 @@ func Call3e(f func(MalType, MalType, MalType) (MalType, error)) func([]MalType, 
 }
 
 // CallNe returns a function that checks there are N arguments and calls f... so it does not check anything
-func CallNe(f func(...MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func CallNe(f func(...MalType) (MalType, error)) func(context.Context, []MalType) (MalType, error) {
 	// just for documenting purposes, does not check anything
-	return func(args []MalType, _ *context.Context) (result MalType, err error) {
+	return func(_ context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		return f(args...)
 	}
 }
 
 // CallVe returns a function that checks there are a variable number of arguments between minArg and maxArg (both of them included)
-func CallVe(minArg, maxArg int, f func(...MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, _ *context.Context) (result MalType, err error) {
+func CallVe(minArg, maxArg int, f func(...MalType) (MalType, error)) func(context.Context, []MalType) (MalType, error) {
+	return func(_ context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if l := len(args); l > maxArg || l < minArg {
 			return nil, fmt.Errorf("wrong number of arguments (%d is out of range [%d,%d])", len(args), minArg, maxArg)
@@ -72,8 +72,8 @@ func CallVe(minArg, maxArg int, f func(...MalType) (MalType, error)) func([]MalT
 }
 
 // Call1b returns a function that checks there is 1 argument and calls f func() bool
-func Call1b(f func(MalType) bool) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, _ *context.Context) (result MalType, err error) {
+func Call1b(f func(MalType) bool) func(context.Context, []MalType) (MalType, error) {
+	return func(_ context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 1 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 1)", len(args))
@@ -83,8 +83,8 @@ func Call1b(f func(MalType) bool) func([]MalType, *context.Context) (MalType, er
 }
 
 // Call2b returns a function that checks there are 2 arguments and calls f func() bool
-func Call2b(f func(MalType, MalType) bool) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, _ *context.Context) (result MalType, err error) {
+func Call2b(f func(MalType, MalType) bool) func(context.Context, []MalType) (MalType, error) {
+	return func(_ context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 2 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 2)", len(args))
@@ -94,77 +94,77 @@ func Call2b(f func(MalType, MalType) bool) func([]MalType, *context.Context) (Ma
 }
 
 // CallNeC returns a function that checks there are N arguments and calls f (that requires *context.Context)
-func CallNeC(f func(context.Context, ...MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
+func CallNeC(f func(context.Context, ...MalType) (MalType, error)) func(context.Context, []MalType) (MalType, error) {
 	// just for documenting purposes, does not check anything
-	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
+	return func(ctx context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
-		return f(*ctx, args...)
+		return f(ctx, args...)
 	}
 }
 
 // Call0eC returns a function that checks there are 0 arguments and calls f (that requires *context.Context)
-func Call0eC(f func(context.Context) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
+func Call0eC(f func(context.Context) (MalType, error)) func(context.Context, []MalType) (MalType, error) {
+	return func(ctx context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 0 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 0", len(args))
 		}
-		return f(*ctx)
+		return f(ctx)
 	}
 }
 
 // Call1eC returns a function that checks there is 1 argument and calls f (that requires *context.Context)
-func Call1eC(f func(context.Context, MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
+func Call1eC(f func(context.Context, MalType) (MalType, error)) func(context.Context, []MalType) (MalType, error) {
+	return func(ctx context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 1 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 1)", len(args))
 		}
-		return f(*ctx, args[0])
+		return f(ctx, args[0])
 	}
 }
 
 // Call2eC returns a function that checks there are 2 arguments and calls f (that requires *context.Context)
-func Call2eC(f func(context.Context, MalType, MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
+func Call2eC(f func(context.Context, MalType, MalType) (MalType, error)) func(context.Context, []MalType) (MalType, error) {
+	return func(ctx context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 2 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 2)", len(args))
 		}
-		return f(*ctx, args[0], args[1])
+		return f(ctx, args[0], args[1])
 	}
 }
 
 // Call3eC returns a function that checks there are 2 arguments and calls f (that requires *context.Context)
-func Call3eC(f func(context.Context, MalType, MalType, MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
+func Call3eC(f func(context.Context, MalType, MalType, MalType) (MalType, error)) func(context.Context, []MalType) (MalType, error) {
+	return func(ctx context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 3 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 3)", len(args))
 		}
-		return f(*ctx, args[0], args[1], args[2])
+		return f(ctx, args[0], args[1], args[2])
 	}
 }
 
 // Call4eC returns a function that checks there are 2 arguments and calls f (that requires *context.Context)
-func Call4eC(f func(context.Context, MalType, MalType, MalType, MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
+func Call4eC(f func(context.Context, MalType, MalType, MalType, MalType) (MalType, error)) func(context.Context, []MalType) (MalType, error) {
+	return func(ctx context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if len(args) != 4 {
 			return nil, fmt.Errorf("wrong number of arguments (%d instead of 4)", len(args))
 		}
-		return f(*ctx, args[0], args[1], args[2], args[3])
+		return f(ctx, args[0], args[1], args[2], args[3])
 	}
 }
 
 // CallVeC returns a function that checks there are a variable number of arguments between minArg and maxArg (both of them included)
-func CallVeC(minArg, maxArg int, f func(context.Context, ...MalType) (MalType, error)) func([]MalType, *context.Context) (MalType, error) {
-	return func(args []MalType, ctx *context.Context) (result MalType, err error) {
+func CallVeC(minArg, maxArg int, f func(context.Context, ...MalType) (MalType, error)) func(context.Context, []MalType) (MalType, error) {
+	return func(ctx context.Context, args []MalType) (result MalType, err error) {
 		defer malRecover(&err)
 		if l := len(args); l > maxArg || l < minArg {
 			return nil, fmt.Errorf("wrong number of arguments (%d is out of range [%d,%d])", len(args), minArg, maxArg)
 		}
-		return f(*ctx, args...)
+		return f(ctx, args...)
 	}
 }
 

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -266,13 +266,13 @@ func update(ctx context.Context, hm, pos, f MalType) (MalType, error) {
 func _update(ctx context.Context, argMapOrVector, index, f MalType) (MalType, error) {
 	switch argMapOrVector := argMapOrVector.(type) {
 	case HashMap:
-		res, err := Apply(f, []MalType{argMapOrVector.Val[index.(string)]}, &ctx)
+		res, err := Apply(ctx, f, []MalType{argMapOrVector.Val[index.(string)]})
 		if err != nil {
 			return nil, err
 		}
 		return assoc(argMapOrVector, index, res)
 	case Vector:
-		res, err := Apply(f, []MalType{argMapOrVector.Val[index.(int)]}, &ctx)
+		res, err := Apply(ctx, f, []MalType{argMapOrVector.Val[index.(int)]})
 		if err != nil {
 			return nil, err
 		}
@@ -539,7 +539,7 @@ func apply(ctx context.Context, a ...MalType) (MalType, error) {
 		return nil, e
 	}
 	args = append(args, last...)
-	return Apply(f, args, &ctx)
+	return Apply(ctx, f, args)
 }
 
 func do_map(ctx context.Context, f, seq MalType) (MalType, error) {
@@ -549,7 +549,7 @@ func do_map(ctx context.Context, f, seq MalType) (MalType, error) {
 		return nil, e
 	}
 	for _, arg := range args {
-		res, e := Apply(f, []MalType{arg}, &ctx)
+		res, e := Apply(ctx, f, []MalType{arg})
 		if e != nil {
 			return nil, e
 		}
@@ -704,7 +704,7 @@ func swap_BANG(ctx context.Context, a ...MalType) (MalType, error) {
 	args := []MalType{atm.Val}
 	f := a[1]
 	args = append(args, a[2:]...)
-	res, e := Apply(f, args, &ctx)
+	res, e := Apply(ctx, f, args)
 	if e != nil {
 		return nil, e
 	}

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -981,12 +981,12 @@ func JSONDecode(obj, bytesIn MalType) (MalType, error) {
 	case marshaler.FactoryJSON:
 		return value.FromJSON(b)
 	case List:
-		var v MalType
+		v := []interface{}{}
 		err := json.Unmarshal(b, &v)
 		if err != nil {
 			return nil, err
 		}
-		return v, nil
+		return array2list(v), nil
 	case Vector:
 		v := []interface{}{}
 		err := json.Unmarshal(b, &v)
@@ -1035,6 +1035,24 @@ func map2hashmap(m map[string]interface{}) MalType {
 
 func array2vector(a []interface{}) MalType {
 	l := Vector{
+		Val:  []MalType{},
+		Meta: nil,
+	}
+	for _, v := range a {
+		switch v := v.(type) {
+		case map[string]interface{}:
+			l.Val = append(l.Val, map2hashmap(v))
+		case []interface{}:
+			l.Val = append(l.Val, array2vector(v))
+		default:
+			l.Val = append(l.Val, v)
+		}
+	}
+	return l
+}
+
+func array2list(a []interface{}) MalType {
+	l := List{
 		Val:  []MalType{},
 		Meta: nil,
 	}

--- a/lib/core/nscore/nscore.go
+++ b/lib/core/nscore/nscore.go
@@ -32,19 +32,20 @@ const (
 
 func Load(repl_env EnvType) error {
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
-	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(a []MalType, ctx *context.Context) (MalType, error) {
-		return lisp.EVAL(a[0], repl_env, ctx)
+	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
+		return lisp.EVAL(ctx, a[0], repl_env)
 	}})
 
-	if _, err := lisp.REPL(repl_env, malHostLanguage, nil); err != nil {
+	ctx := context.Background()
+	if _, err := lisp.REPL(ctx, repl_env, malHostLanguage); err != nil {
 		return err
 	}
-	if _, err := lisp.REPL(repl_env, malNot, nil); err != nil {
+	if _, err := lisp.REPL(ctx, repl_env, malNot); err != nil {
 		return err
 	}
-	if _, err := lisp.REPL(repl_env, malCond, nil); err != nil {
+	if _, err := lisp.REPL(ctx, repl_env, malCond); err != nil {
 		return err
 	}
 	return nil
@@ -52,13 +53,14 @@ func Load(repl_env EnvType) error {
 
 func LoadInput(repl_env EnvType) error {
 	for k, v := range core.NSInput {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
-	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(a []MalType, ctx *context.Context) (MalType, error) {
-		return lisp.EVAL(a[0], repl_env, ctx)
+	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
+		return lisp.EVAL(ctx, a[0], repl_env)
 	}})
 
-	if _, err := lisp.REPL(repl_env, malLoadFile, nil); err != nil {
+	ctx := context.Background()
+	if _, err := lisp.REPL(ctx, repl_env, malLoadFile); err != nil {
 		return err
 	}
 	return nil

--- a/lib/coreextented/nscoreextended/nscoreextended.go
+++ b/lib/coreextented/nscoreextended/nscoreextended.go
@@ -1,11 +1,14 @@
 package nscoreextended
 
 import (
+	"context"
+
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/types"
 )
 
 func Load(repl_env types.EnvType) error {
+	ctx := context.Background()
 	for _, symbols := range []string{
 		trivial,
 		benchmark,
@@ -19,7 +22,7 @@ func Load(repl_env types.EnvType) error {
 		test_cascade,
 		load_file_once,
 	} {
-		if _, err := lisp.REPL(repl_env, `(eval (read-string (str "(do "`+symbols+`" nil)")))`, nil); err != nil {
+		if _, err := lisp.REPL(ctx, repl_env, `(eval (read-string (str "(do "`+symbols+`" nil)")))`); err != nil {
 			return err
 		}
 	}

--- a/lib/test/nstest/nstest.go
+++ b/lib/test/nstest/nstest.go
@@ -1,12 +1,15 @@
 package nstest
 
 import (
+	"context"
+
 	"github.com/jig/lisp"
 	. "github.com/jig/lisp/types"
 )
 
 func Load(repl_env EnvType) error {
-	if _, err := lisp.REPL(repl_env, `(eval (read-string (str "(do "`+AssertMacros+`" nil)")))`, nil); err != nil {
+	ctx := context.Background()
+	if _, err := lisp.REPL(ctx, repl_env, `(eval (read-string (str "(do "`+AssertMacros+`" nil)")))`); err != nil {
 		return err
 	}
 	return nil

--- a/lnotation/lnotation_test.go
+++ b/lnotation/lnotation_test.go
@@ -1,6 +1,7 @@
 package lnotation
 
 import (
+	"context"
 	"log"
 	"testing"
 
@@ -16,7 +17,7 @@ import (
 
 func TestLNotationMinimalExample(t *testing.T) {
 	sampleCode := LS("range", 0, 4)
-	lr, err := lisp.EVAL(sampleCode, NewTestEnv(), nil)
+	lr, err := lisp.EVAL(context.TODO(), sampleCode, NewTestEnv())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +36,7 @@ func TestLNotationMinimalExample(t *testing.T) {
 
 func TestLNotation(t *testing.T) {
 	sampleCode := LS("reduce", S("+"), 0, LS("range", 0, 10000))
-	lr, err := lisp.EVAL(sampleCode, NewTestEnv(), nil)
+	lr, err := lisp.EVAL(context.TODO(), sampleCode, NewTestEnv())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +70,7 @@ func TestLNotationFibonacci(t *testing.T) {
 	iF := S("if")
 
 	env := NewTestEnv()
-	lr, err := lisp.EVAL(
+	lr, err := lisp.EVAL(context.TODO(),
 		L(do,
 			L(def, fib, L(fn, V(n),
 				L(iF, LS("=", n, 0),
@@ -80,7 +81,6 @@ func TestLNotationFibonacci(t *testing.T) {
 							L(fib, LS("-", n, 2))))))),
 			L(fib, 15)),
 		env,
-		nil,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/mal_test.go
+++ b/mal_test.go
@@ -208,12 +208,13 @@ func TestAtomParallel(t *testing.T) {
 	if _, err := REPL(repl_env, "(def inc (fn [x] (+ 1 x)))", nil); err != nil {
 		t.Fatal(err)
 	}
+	ctx := context.Background()
 	wd := sync.WaitGroup{}
 	for i := 0; i < 100; i++ {
 		wd.Add(1)
 		go func() {
 			for j := 0; j < 1000; j++ {
-				if _, err := REPL(repl_env, "(swap! count inc)", nil); err != nil {
+				if _, err := REPL(repl_env, "(swap! count inc)", &ctx); err != nil {
 					return
 				}
 			}

--- a/mal_test.go
+++ b/mal_test.go
@@ -14,7 +14,7 @@ func BenchmarkLoadSymbols(b *testing.B) {
 	repl_env, _ := NewEnv(nil, nil, nil)
 	for i := 0; i < b.N; i++ {
 		for k, v := range core.NS {
-			repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+			repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 		}
 	}
 }
@@ -22,25 +22,26 @@ func BenchmarkLoadSymbols(b *testing.B) {
 func BenchmarkMAL1(b *testing.B) {
 	repl_env, _ := NewEnv(nil, nil, nil)
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
+	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
-		repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(a []MalType, ctx *context.Context) (MalType, error) {
-			return EVAL(a[0], repl_env, ctx)
+		repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
+			return EVAL(ctx, a[0], repl_env)
 		}})
 		repl_env.Set(Symbol{Val: "*ARGV*"}, List{})
 
 		// core.mal: defined using the language itself
-		if _, err := REPL(repl_env, `(def *host-language* "go")`, nil); err != nil {
+		if _, err := REPL(ctx, repl_env, `(def *host-language* "go")`); err != nil {
 			b.Fatal(err)
 		}
-		if _, err := REPL(repl_env, `(def not (fn (a) (if a false true)))`, nil); err != nil {
+		if _, err := REPL(ctx, repl_env, `(def not (fn (a) (if a false true)))`); err != nil {
 			b.Fatal(err)
 		}
-		if _, err := REPL(repl_env, `(def load-file (fn (f) (eval (read-string (str "(do " (slurp f) "\nnil)")))))`, nil); err != nil {
+		if _, err := REPL(ctx, repl_env, `(def load-file (fn (f) (eval (read-string (str "(do " (slurp f) "\nnil)")))))`); err != nil {
 			b.Fatal(err)
 		}
-		if _, err := REPL(repl_env, `(defmacro cond (fn (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw "odd number of forms to cond")) (cons 'cond (rest (rest xs)))))))`, nil); err != nil {
+		if _, err := REPL(ctx, repl_env, `(defmacro cond (fn (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw "odd number of forms to cond")) (cons 'cond (rest (rest xs)))))))`); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -49,14 +50,15 @@ func BenchmarkMAL1(b *testing.B) {
 func BenchmarkMAL2(b *testing.B) {
 	repl_env, _ := NewEnv(nil, nil, nil)
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
-	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(a []MalType, ctx *context.Context) (MalType, error) {
-		return EVAL(a[0], repl_env, ctx)
+	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
+		return EVAL(ctx, a[0], repl_env)
 	}})
 	repl_env.Set(Symbol{Val: "*ARGV*"}, List{})
+	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
-		if _, err := REPL(repl_env, `(def not (fn (a) (if a false true)))`, nil); err != nil {
+		if _, err := REPL(ctx, repl_env, `(def not (fn (a) (if a false true)))`); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -65,10 +67,10 @@ func BenchmarkMAL2(b *testing.B) {
 func BenchmarkParallelREAD(b *testing.B) {
 	repl_env, _ := NewEnv(nil, nil, nil)
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
-	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(a []MalType, ctx *context.Context) (MalType, error) {
-		return EVAL(a[0], repl_env, ctx)
+	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
+		return EVAL(ctx, a[0], repl_env)
 	}})
 	repl_env.Set(Symbol{Val: "*ARGV*"}, List{})
 	b.RunParallel(func(pb *testing.PB) {
@@ -87,15 +89,16 @@ func BenchmarkParallelREAD(b *testing.B) {
 func BenchmarkParallelREP(b *testing.B) {
 	repl_env, _ := NewEnv(nil, nil, nil)
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
-	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(a []MalType, ctx *context.Context) (MalType, error) {
-		return EVAL(a[0], repl_env, ctx)
+	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
+		return EVAL(ctx, a[0], repl_env)
 	}})
 	repl_env.Set(Symbol{Val: "*ARGV*"}, List{})
+	ctx := context.Background()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			if _, err := REPL(repl_env, `(def not (fn (a) (if a false true)))`, nil); err != nil {
+			if _, err := REPL(ctx, repl_env, `(def not (fn (a) (if a false true)))`); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -105,14 +108,15 @@ func BenchmarkParallelREP(b *testing.B) {
 func BenchmarkREP(b *testing.B) {
 	repl_env, _ := NewEnv(nil, nil, nil)
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
-	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(a []MalType, ctx *context.Context) (MalType, error) {
-		return EVAL(a[0], repl_env, ctx)
+	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
+		return EVAL(ctx, a[0], repl_env)
 	}})
 	repl_env.Set(Symbol{Val: "*ARGV*"}, List{})
+	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
-		if _, err := REPL(repl_env, `(def not (fn (a) (if a false true)))`, nil); err != nil {
+		if _, err := REPL(ctx, repl_env, `(def not (fn (a) (if a false true)))`); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -121,16 +125,17 @@ func BenchmarkREP(b *testing.B) {
 func BenchmarkFibonacci(b *testing.B) {
 	repl_env, _ := NewEnv(nil, nil, nil)
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
+	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
-		if _, err := REPL(repl_env, `(do
+		if _, err := REPL(ctx, repl_env, `(do
 				(def fib
 				(fn [n]                              ; non-negative number
 				(if (<= n 1)
 					n
 					(+ (fib (- n 1)) (fib (- n 2))))))
-				(fib 10))`, nil); err != nil {
+				(fib 10))`); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -139,17 +144,18 @@ func BenchmarkFibonacci(b *testing.B) {
 func BenchmarkParallelFibonacci(b *testing.B) {
 	repl_env, _ := NewEnv(nil, nil, nil)
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
+	ctx := context.Background()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			if _, err := REPL(repl_env, `(do
+			if _, err := REPL(ctx, repl_env, `(do
 					(def fib
 					(fn [n]                              ; non-negative number
 					(if (<= n 1)
 						n
 						(+ (fib (- n 1)) (fib (- n 2))))))
-					(fib 0))`, nil); err != nil {
+					(fib 0))`); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -159,17 +165,18 @@ func BenchmarkParallelFibonacci(b *testing.B) {
 func BenchmarkParallelFibonacciExec(b *testing.B) {
 	repl_env, _ := NewEnv(nil, nil, nil)
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
+	ctx := context.Background()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			if _, err := REPL(repl_env, `(do
+			if _, err := REPL(ctx, repl_env, `(do
 				(def fib
 				(fn [n]                              ; non-negative number
 				(if (<= n 1)
 					n
 					(+ (fib (- n 1)) (fib (- n 2))))))
-				(fib 0))`, nil); err != nil {
+				(fib 0))`); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -181,40 +188,40 @@ func TestAtomParallel(t *testing.T) {
 
 	// core.go: defined using go
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
-	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(a []MalType, ctx *context.Context) (MalType, error) {
-		return EVAL(a[0], repl_env, ctx)
+	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
+		return EVAL(ctx, a[0], repl_env)
 	}})
 	repl_env.Set(Symbol{Val: "*ARGV*"}, List{})
-
-	// core.mal: defined using the language itself
-	if _, err := REPL(repl_env, "(def *host-language* \"go\")", nil); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := REPL(repl_env, "(def not (fn (a) (if a false true)))", nil); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := REPL(repl_env, "(def load-file (fn (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))", nil); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := REPL(repl_env, "(defmacro cond (fn (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))", nil); err != nil {
-		t.Fatal(err)
-	}
-
-	if _, err := REPL(repl_env, "(def count (atom 0))", nil); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := REPL(repl_env, "(def inc (fn [x] (+ 1 x)))", nil); err != nil {
-		t.Fatal(err)
-	}
 	ctx := context.Background()
+	// core.mal: defined using the language itself
+	if _, err := REPL(ctx, repl_env, "(def *host-language* \"go\")"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := REPL(ctx, repl_env, "(def not (fn (a) (if a false true)))"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := REPL(ctx, repl_env, "(def load-file (fn (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := REPL(ctx, repl_env, "(defmacro cond (fn (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := REPL(ctx, repl_env, "(def count (atom 0))"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := REPL(ctx, repl_env, "(def inc (fn [x] (+ 1 x)))"); err != nil {
+		t.Fatal(err)
+	}
+
 	wd := sync.WaitGroup{}
 	for i := 0; i < 100; i++ {
 		wd.Add(1)
 		go func() {
 			for j := 0; j < 1000; j++ {
-				if _, err := REPL(repl_env, "(swap! count inc)", &ctx); err != nil {
+				if _, err := REPL(ctx, repl_env, "(swap! count inc)"); err != nil {
 					return
 				}
 			}
@@ -222,8 +229,8 @@ func TestAtomParallel(t *testing.T) {
 		}()
 	}
 	wd.Wait()
-	if _, err := REPL(repl_env, "(if (not (= @count 100000)) (throw @count))", nil); err != nil {
-		t.Fatal(REPL(repl_env, `(println "@count != " @count)`, nil))
+	if _, err := REPL(ctx, repl_env, "(if (not (= @count 100000)) (throw @count))"); err != nil {
+		t.Fatal(REPL(ctx, repl_env, `(println "@count != " @count)`))
 	}
 }
 
@@ -232,37 +239,38 @@ func BenchmarkAtomParallel(b *testing.B) {
 
 	// core.go: defined using go
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
-	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(a []MalType, ctx *context.Context) (MalType, error) {
-		return EVAL(a[0], repl_env, ctx)
+	repl_env.Set(Symbol{Val: "eval"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
+		return EVAL(ctx, a[0], repl_env)
 	}})
 	repl_env.Set(Symbol{Val: "*ARGV*"}, List{})
+	ctx := context.Background()
 
 	// core.mal: defined using the language itself
-	if _, err := REPL(repl_env, "(def *host-language* \"go\")", nil); err != nil {
+	if _, err := REPL(ctx, repl_env, "(def *host-language* \"go\")"); err != nil {
 		b.Fatal(err)
 	}
-	if _, err := REPL(repl_env, "(def not (fn (a) (if a false true)))", nil); err != nil {
+	if _, err := REPL(ctx, repl_env, "(def not (fn (a) (if a false true)))"); err != nil {
 		b.Fatal(err)
 	}
-	if _, err := REPL(repl_env, "(def load-file (fn (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))", nil); err != nil {
+	if _, err := REPL(ctx, repl_env, "(def load-file (fn (f) (eval (read-string (str \"(do \" (slurp f) \"\nnil)\")))))"); err != nil {
 		b.Fatal(err)
 	}
-	if _, err := REPL(repl_env, "(defmacro cond (fn (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))", nil); err != nil {
+	if _, err := REPL(ctx, repl_env, "(defmacro cond (fn (& xs) (if (> (count xs) 0) (list 'if (first xs) (if (> (count xs) 1) (nth xs 1) (throw \"odd number of forms to cond\")) (cons 'cond (rest (rest xs)))))))"); err != nil {
 		b.Fatal(err)
 	}
 
-	if _, err := REPL(repl_env, "(def count (atom 0))", nil); err != nil {
+	if _, err := REPL(ctx, repl_env, "(def count (atom 0))"); err != nil {
 		b.Fatal(err)
 	}
-	if _, err := REPL(repl_env, "(def inc (fn [x] (+ 1 x)))", nil); err != nil {
+	if _, err := REPL(ctx, repl_env, "(def inc (fn [x] (+ 1 x)))"); err != nil {
 		b.Fatal(err)
 	}
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			if _, err := REPL(repl_env, "(swap! count inc)", nil); err != nil {
+			if _, err := REPL(ctx, repl_env, "(swap! count inc)"); err != nil {
 				b.Fatal(err)
 			}
 			// exp, err := READ("(swap! count inc)")

--- a/marshalingexample_test.go
+++ b/marshalingexample_test.go
@@ -33,7 +33,7 @@ type LispMarshalExampleFactory struct {
 	Type MarshalExample
 }
 
-func newLispMarshalExample(a []types.MalType) (types.MalType, error) {
+func newLispMarshalExample() (types.MalType, error) {
 	return LispMarshalExampleFactory{}, nil
 }
 

--- a/placeholder_test.go
+++ b/placeholder_test.go
@@ -24,7 +24,7 @@ func TestPlaceholders(t *testing.T) {
 	for k, v := range core.NS {
 		repl_env.Set(
 			Symbol{Val: k},
-			Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))},
+			Func{Fn: v.(func(context.Context, []MalType) (MalType, error))},
 		)
 	}
 
@@ -56,7 +56,8 @@ func TestPlaceholders(t *testing.T) {
 
 	// fmt.Println(PRINT(exp))
 
-	res, err := EVAL(exp, repl_env, nil)
+	ctx := context.Background()
+	res, err := EVAL(ctx, exp, repl_env)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +114,7 @@ func TestREADWithPreamble(t *testing.T) {
 	for k, v := range core.NS {
 		repl_env.Set(
 			Symbol{Val: k},
-			Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))},
+			Func{Fn: v.(func(context.Context, []MalType) (MalType, error))},
 		)
 	}
 
@@ -139,8 +140,8 @@ func TestREADWithPreamble(t *testing.T) {
 	}
 
 	// fmt.Println(PRINT(exp))
-
-	res, err := EVAL(exp, repl_env, nil)
+	ctx := context.Background()
+	res, err := EVAL(ctx, exp, repl_env)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +213,7 @@ func TestAddPreamble(t *testing.T) {
 	for k, v := range core.NS {
 		repl_env.Set(
 			Symbol{Val: k},
-			Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))},
+			Func{Fn: v.(func(context.Context, []MalType) (MalType, error))},
 		)
 	}
 
@@ -250,7 +251,8 @@ func TestAddPreamble(t *testing.T) {
 
 	// fmt.Println(PRINT(exp))
 
-	res, err := EVAL(exp, repl_env, nil)
+	ctx := context.Background()
+	res, err := EVAL(ctx, exp, repl_env)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -319,7 +321,7 @@ func TestPlaceholdersEmbeddedWrong1(t *testing.T) {
 	for k, v := range core.NS {
 		repl_env.Set(
 			Symbol{Val: k},
-			Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))},
+			Func{Fn: v.(func(context.Context, []MalType) (MalType, error))},
 		)
 	}
 
@@ -353,7 +355,7 @@ func TestPlaceholdersEmbeddedNoBlankLine(t *testing.T) {
 	for k, v := range core.NS {
 		repl_env.Set(
 			Symbol{Val: k},
-			Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))},
+			Func{Fn: v.(func(context.Context, []MalType) (MalType, error))},
 		)
 	}
 
@@ -368,7 +370,8 @@ func TestPlaceholdersEmbeddedNoBlankLine(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := EVAL(exp, repl_env, nil)
+	ctx := context.Background()
+	res, err := EVAL(ctx, exp, repl_env)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,7 +412,7 @@ var notOptimiseBenchFunc2 MalType
 func BenchmarkAddPreambleAlternative(b *testing.B) {
 	repl_env, _ := env.NewEnv(nil, nil, nil)
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
 
 	for n := 0; n < b.N; n++ {
@@ -464,7 +467,7 @@ func BenchmarkREADWithPreamble(b *testing.B) {
 func BenchmarkNewEnv(b *testing.B) {
 	repl_env, _ := env.NewEnv(nil, nil, nil)
 	for k, v := range core.NS {
-		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+		repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 	}
 	sourceWithPreamble := `(do
 		(def v0 $EXAMPLESTRING)
@@ -489,8 +492,9 @@ func BenchmarkNewEnv(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	ctx := context.Background()
 	for n := 0; n < b.N; n++ {
-		res, err := EVAL(ast, repl_env, nil)
+		res, err := EVAL(ctx, ast, repl_env)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -533,9 +537,10 @@ func BenchmarkCompleteSendingWithPreamble(b *testing.B) {
 
 		repl_env, _ := env.NewEnv(nil, nil, nil)
 		for k, v := range core.NS {
-			repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+			repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 		}
-		res, err := EVAL(ast, repl_env, nil)
+		ctx := context.Background()
+		res, err := EVAL(ctx, ast, repl_env)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -587,9 +592,10 @@ func BenchmarkCompleteSendingWithPreambleSolved(b *testing.B) {
 
 		repl_env, _ := env.NewEnv(nil, nil, nil)
 		for k, v := range core.NS {
-			repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))})
+			repl_env.Set(Symbol{Val: k}, Func{Fn: v.(func(context.Context, []MalType) (MalType, error))})
 		}
-		res, err := EVAL(ast, repl_env, nil)
+		ctx := context.Background()
+		res, err := EVAL(ctx, ast, repl_env)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -604,7 +610,7 @@ func TestHashMapMarshalers(t *testing.T) {
 	for k, v := range core.NS {
 		repl_env.Set(
 			Symbol{Val: k},
-			Func{Fn: v.(func([]MalType, *context.Context) (MalType, error))},
+			Func{Fn: v.(func(context.Context, []MalType) (MalType, error))},
 		)
 	}
 
@@ -627,8 +633,8 @@ func TestHashMapMarshalers(t *testing.T) {
 	}
 
 	// fmt.Println(PRINT(exp))
-
-	res, err := EVAL(exp, repl_env, nil)
+	ctx := context.Background()
+	res, err := EVAL(ctx, exp, repl_env)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/placeholder_test.go
+++ b/placeholder_test.go
@@ -3,6 +3,7 @@ package lisp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/jig/lisp/env"
@@ -372,6 +373,8 @@ func TestPlaceholdersEmbeddedNoBlankLine(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !res.(bool) {
+		fmt.Println(PRINT(exp))
+		fmt.Println(PRINT(res))
 		t.Fatal("failed")
 	}
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Execute executes the main REPL loop
-func Execute(repl_env types.EnvType, ctx *context.Context) error {
+func Execute(ctx context.Context, repl_env types.EnvType) error {
 	dirname, err := os.UserHomeDir()
 	if err != nil {
 		return err
@@ -49,7 +49,8 @@ func Execute(repl_env types.EnvType, ctx *context.Context) error {
 		line = strings.TrimSpace(line)
 		lines = append(lines, line)
 		completeLine := strings.Join(lines, "\n")
-		out, err := lisp.REPL(repl_env, completeLine, ctx)
+
+		out, err := lisp.REPL(ctx, repl_env, completeLine)
 		if err != nil {
 			if err.Error() == "<empty line>" {
 				continue

--- a/testlib/testlib.go
+++ b/testlib/testlib.go
@@ -47,8 +47,8 @@ func File(t *testing.T, entryName, testFile string, packages PackageDecl) {
 	if err != nil {
 		t.Fatalf("%s/READ Error: %s", entryName, err)
 	}
-	ctxt := context.Background()
-	res, err := lisp.EVAL(expr, tenv, &ctxt)
+	ctx := context.Background()
+	res, err := lisp.EVAL(ctx, expr, tenv)
 	if err != nil {
 		t.Fatalf("%s/EVAL Error: %s", entryName, err)
 	}

--- a/tests/step4_if_fn_do.mal
+++ b/tests/step4_if_fn_do.mal
@@ -501,3 +501,26 @@ a
 ;=>true
 (= [1 2 (list 3 4 [5 6])] (list 1 2 [3 4 (list 5 6)]))
 ;=>true
+
+(empty? nil)
+;=>true
+;; invalid:
+(empty? "hello")
+;=>nil
+(empty? {})
+;=>true
+(def hm {})
+(empty? hm)
+;=>true
+(count hm)
+;=>0
+(def hm {:a 1})
+(empty? hm)
+;=>false
+(count hm)
+;=>1
+(def hm {:a 1 :b {}})
+(empty? hm)
+;=>false
+(count hm)
+;=>2

--- a/tests/stepE_merge_assert.mal
+++ b/tests/stepE_merge_assert.mal
@@ -99,3 +99,14 @@
 ;/^.+{:3 3}$
 (assert nil 'assert)
 ;/^.+assert$
+
+(rename-keys {} {})
+;=>{}
+(rename-keys {:a 1} {})
+;=>{:a 1}
+(rename-keys {:a 1} {:a "mimi"})
+;=>{"mimi" 1}
+(get (rename-keys {:a 1 :b 3} {:a "mimi"}) "mimi")
+;=>1
+(get (rename-keys {:a 1 :b 3} {:a "mimi"}) :b)
+;=>3

--- a/tests/stepE_merge_assert.mal
+++ b/tests/stepE_merge_assert.mal
@@ -40,7 +40,7 @@
 
 ;; assert
 (assert)
-;/one or two parameters required
+;/Error: wrong number of arguments
 (assert true)
 ;=>nil
 ;/^$

--- a/tests/stepG_infunctions.mal
+++ b/tests/stepG_infunctions.mal
@@ -6,6 +6,8 @@
 (assoc [0 1 2 3] 2 "hello")
 ;=>[0 1 "hello" 3]
 
+(assoc-in {} [:a] "hello")
+;=>{:a "hello"}
 (get (assoc-in {:a 1 :b {:c 2}} [:a] "hello") :a)
 ;=>"hello"
 (get (assoc-in {:a 1 :b {:c 2}} [:b] "hello") :b)

--- a/tests/stepG_infunctions.mal
+++ b/tests/stepG_infunctions.mal
@@ -75,12 +75,13 @@
 ;=>33
 
 ;; update for vectors
-(def vu (update [0 1 [22 33] 3] 2 (fn [_] 22)))
+(def v [0 1 [22 33] 3])
+(def vu (update v 1 (fn [_] 1111)))
+(get vu 1)
+;=>1111
+(def vu (update v 2 (fn [_] 5555)))
 (get vu 2)
-;=>22
-(def mu (update m :x (fn [_] 33)))
-(get mu :x)
-;=>33
+;=>5555
 
 ;; update-in for maps
 (def mu (update-in m [:b :c] (fn [x] (+ 1000 x))))
@@ -93,6 +94,20 @@
 
 (def mu (update-in m [] (fn [x] (+ x 2000))))
 (get-in mu [:b :c])
+;=>2
+
+;; update-in for vectors
+(def v2 [0 1 [22 33] 3])
+(def vu2 (update-in v2 [2 1] (fn [x] (+ 1000 x))))
+(get vu2 2)
+;=>[22 1033]
+(get-in vu2 [2 1])
+;=>1033
+(get-in vu2 [0])
+;=>0
+
+(def vu (update-in m [] (fn [x] (+ x 2000))))
+(get-in vu [:b :c])
 ;=>2
 
 ;; fn gots x=nil

--- a/tests/stepI_marshaling.mal
+++ b/tests/stepI_marshaling.mal
@@ -54,6 +54,12 @@
 (json-encode false)
 ;=>"false"
 
+(get (json-decode [] "[1984, 1011, 4004]") 1)
+;=>1011
+
+(get (json-decode () "[1984, 1011, 4004]") 1)
+;=>1011
+
 ;; TODO(jig): deprecate this:
 (hash-map)
 ;=>{}
@@ -82,3 +88,4 @@
 ;=>1
 (get (hash-map (json-decode (new-marshalexample) ¬{"a":1,"b":"patapam!"}¬)) :b)
 ;=>"patapam!"
+

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -12,7 +12,7 @@ func TestContextTimeoutFiresOnTime(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	if _, err := REPL(newEnv(), `(sleep 1000)`, &ctx); err == nil {
+	if _, err := REPL(ctx, newEnv(), `(sleep 1000)`); err == nil {
 		t.Fatalf("Must fail")
 	} else {
 		if err.(types.RuntimeError).ErrorVal.Error() != "timeout while evaluating expression" {
@@ -25,7 +25,7 @@ func TestContextNoTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	if _, err := REPL(newEnv(), `(sleep 1)`, &ctx); err != nil {
+	if _, err := REPL(ctx, newEnv(), `(sleep 1)`); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/trycatchfinally_test.go
+++ b/trycatchfinally_test.go
@@ -18,15 +18,15 @@ func TestTryCatchFinally(t *testing.T) {
 	for k, v := range core.NS {
 		repl_env.Set(
 			types.Symbol{Val: k},
-			types.Func{Fn: v.(func([]types.MalType, *context.Context) (types.MalType, error))},
+			types.Func{Fn: v.(func(context.Context, []types.MalType) (types.MalType, error))},
 		)
 	}
-
+	ctx := context.Background()
 	exp, err := READ(trycatchfinally_test, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	exp, err = EVAL(exp, repl_env, nil)
+	exp, err = EVAL(ctx, exp, repl_env)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -97,7 +97,7 @@ func String_Q(obj MalType) bool {
 
 // Functions
 type Func struct {
-	Fn     func([]MalType, *context.Context) (MalType, error)
+	Fn     func(context.Context, []MalType) (MalType, error)
 	Meta   MalType
 	Cursor *Position
 }
@@ -108,7 +108,7 @@ func Func_Q(obj MalType) bool {
 }
 
 type MalFunc struct {
-	Eval    func(MalType, EnvType, *context.Context) (MalType, error)
+	Eval    func(context.Context, MalType, EnvType) (MalType, error)
 	Exp     MalType
 	Env     EnvType
 	Params  MalType
@@ -134,16 +134,16 @@ func (f MalFunc) GetMacro() bool {
 
 // Take either a MalFunc or regular function and apply it to the
 // arguments
-func Apply(f_mt MalType, a []MalType, ctx *context.Context) (MalType, error) {
+func Apply(ctx context.Context, f_mt MalType, a []MalType) (MalType, error) {
 	switch f := f_mt.(type) {
 	case MalFunc:
 		env, e := f.GenEnv(f.Env, f.Params, List{a, nil, f.Cursor})
 		if e != nil {
 			return nil, e
 		}
-		return f.Eval(f.Exp, env, ctx)
+		return f.Eval(ctx, f.Exp, env)
 	case Func:
-		return f.Fn(a, ctx)
+		return f.Fn(ctx, a)
 	case func([]MalType) (MalType, error):
 		return f(a)
 	default:

--- a/types/types.go
+++ b/types/types.go
@@ -180,11 +180,11 @@ func Vector_Q(obj MalType) bool {
 }
 
 func GetSlice(seq MalType) ([]MalType, error) {
-	switch obj := seq.(type) {
+	switch seq := seq.(type) {
 	case List:
-		return obj.Val, nil
+		return seq.Val, nil
 	case Vector:
-		return obj.Val, nil
+		return seq.Val, nil
 	default:
 		return nil, errors.New("GetSlice called on non-sequence")
 	}
@@ -289,7 +289,7 @@ func Sequential_Q(seq MalType) bool {
 		(reflect.TypeOf(seq).Name() == "Vector")
 }
 
-func Equal_Q(a MalType, b MalType) bool {
+func Equal_Q(a, b MalType) bool {
 	ota := reflect.TypeOf(a)
 	otb := reflect.TypeOf(b)
 	if !((ota == otb) || (Sequential_Q(a) && Sequential_Q(b))) {


### PR DESCRIPTION
Some corrections and preparation to move code to generics that would improve the calls from lisp to Go functions.

It will require Go 1.18 when those changes were made.

Till this commit Go 1.17 is still supported.