### PR TITLE
Etapa 2 PR1: pluggable EvalHook foundation for DAP/LSP

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alexflint/go-arg"
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/repl"
+	"github.com/jig/lisp/runtime"
 	"github.com/jig/lisp/types"
 )
 
@@ -76,7 +77,7 @@ func Execute(cmdArgs []string, repl_env types.EnvType) error {
 
 	// Enable DEBUG-EVAL if flag is set
 	if parsedArgs.Debug {
-		lisp.DebugEvalEnabled = true
+		runtime.Hook = runtime.PrintEvalHook{}
 	}
 
 	if parsedArgs.Eval != "" && (parsedArgs.Version || parsedArgs.Test != "") {

--- a/command/command.go
+++ b/command/command.go
@@ -11,7 +11,6 @@ import (
 	"github.com/alexflint/go-arg"
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/repl"
-	"github.com/jig/lisp/runtime"
 	"github.com/jig/lisp/types"
 )
 
@@ -75,9 +74,13 @@ func Execute(cmdArgs []string, repl_env types.EnvType) error {
 		}
 	}
 
-	// Enable DEBUG-EVAL if flag is set
+	// Enable DEBUG-EVAL if flag is set. setupDebugHook is gated by the
+	// `lispdebug` build tag: in release builds it returns an error so the
+	// flag cannot accidentally enable hook code that was compiled out.
 	if parsedArgs.Debug {
-		runtime.Hook = runtime.PrintEvalHook{}
+		if err := setupDebugHook(); err != nil {
+			return err
+		}
 	}
 
 	if parsedArgs.Eval != "" && (parsedArgs.Version || parsedArgs.Test != "") {

--- a/command/debug_debug.go
+++ b/command/debug_debug.go
@@ -1,0 +1,12 @@
+//go:build lispdebug
+
+package command
+
+import "github.com/jig/lisp/runtime"
+
+// setupDebugHook installs the legacy DEBUG-EVAL print hook. Only compiled
+// into `lispdebug` builds.
+func setupDebugHook() error {
+	runtime.Hook = runtime.PrintEvalHook{}
+	return nil
+}

--- a/command/debug_debug_test.go
+++ b/command/debug_debug_test.go
@@ -1,0 +1,37 @@
+//go:build lispdebug
+
+package command
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core"
+	"github.com/jig/lisp/runtime"
+)
+
+func TestExecute_DebugFlagInstallsHook(t *testing.T) {
+	prev := runtime.Hook
+	t.Cleanup(func() { runtime.Hook = prev })
+	runtime.Hook = nil
+
+	ns := env.NewEnv()
+	core.Load(ns)
+	core.LoadInput(ns)
+	ctx := context.Background()
+	if _, err := lisp.REPL(ctx, ns, core.HeaderBasic(), nil); err != nil {
+		t.Fatalf("preamble failed: %v", err)
+	}
+	if _, err := lisp.REPL(ctx, ns, core.HeaderLoadFile(), nil); err != nil {
+		t.Fatalf("preamble failed: %v", err)
+	}
+
+	if err := Execute([]string{"lisp", "--debug", "-e", "(do 1 2)"}, ns); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := runtime.Hook.(runtime.PrintEvalHook); !ok {
+		t.Fatalf("expected --debug to install PrintEvalHook, got %T", runtime.Hook)
+	}
+}

--- a/command/debug_release.go
+++ b/command/debug_release.go
@@ -1,0 +1,11 @@
+//go:build !lispdebug
+
+package command
+
+import "errors"
+
+// setupDebugHook fails in release builds. Rebuild with `-tags lispdebug`
+// to enable the --debug flag.
+func setupDebugHook() error {
+	return errors.New("--debug requires a debug build: rebuild with -tags lispdebug")
+}

--- a/command/debug_release_test.go
+++ b/command/debug_release_test.go
@@ -1,0 +1,34 @@
+//go:build !lispdebug
+
+package command
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core"
+)
+
+func TestExecute_DebugFlagRequiresDebugBuild(t *testing.T) {
+	ns := env.NewEnv()
+	core.Load(ns)
+	core.LoadInput(ns)
+	ctx := context.Background()
+	if _, err := lisp.REPL(ctx, ns, core.HeaderBasic(), nil); err != nil {
+		t.Fatalf("preamble failed: %v", err)
+	}
+	if _, err := lisp.REPL(ctx, ns, core.HeaderLoadFile(), nil); err != nil {
+		t.Fatalf("preamble failed: %v", err)
+	}
+
+	err := Execute([]string{"lisp", "--debug", "-e", "(do 1 2)"}, ns)
+	if err == nil {
+		t.Fatal("expected --debug to fail in release build")
+	}
+	if !strings.Contains(err.Error(), "lispdebug") {
+		t.Fatalf("expected error to mention lispdebug build tag, got %v", err)
+	}
+}

--- a/mal.go
+++ b/mal.go
@@ -40,6 +40,7 @@ import (
 	"github.com/jig/lisp/lisperror"
 	"github.com/jig/lisp/printer"
 	"github.com/jig/lisp/reader"
+	"github.com/jig/lisp/runtime"
 	. "github.com/jig/lisp/types"
 )
 
@@ -47,14 +48,13 @@ var placeholderRE = regexp.MustCompile(`^(;; \$[\-\d\w]+)+\s(.+)`)
 
 const preamblePrefix = ";; $"
 
-// DebugEvalEnabled controls whether DEBUG-EVAL support is active.
-// When false, the DEBUG-EVAL check is skipped entirely for better performance.
-// Set this to true before evaluation if you need DEBUG-EVAL functionality.
+// DebugEvalEnabled is a deprecated shim for the legacy DEBUG-EVAL print
+// behaviour. Setting it to true installs runtime.PrintEvalHook on the next
+// EVAL call if no other hook is active.
 //
-// This is also the public extension point for external debuggers: when
-// enabled, EVAL inspects the DEBUG-EVAL binding before evaluating each form
-// (see EVAL in this file). A future DAP/LSP integration will hook here.
-// Do not remove or rename without coordinating with the debugger work.
+// Deprecated: install a runtime.EvalHook directly via
+// `runtime.Hook = runtime.PrintEvalHook{}` (or your own implementation).
+// New code in this repo wires --debug through runtime.Hook.
 var DebugEvalEnabled = false
 
 // READ reads Lisp source code and generates an AST that might be evaled by [EVAL] or printed by [PRINT].
@@ -352,21 +352,14 @@ func EVAL(ctx context.Context, ast MalType, env EnvType) (res MalType, e error) 
 			}
 		}
 
-		// DEBUG-EVAL support: print AST if DEBUG-EVAL is set and truthy
-		if DebugEvalEnabled {
-			if dbgEval, err := env.Get(Symbol{Val: "DEBUG-EVAL"}); err == nil {
-				// Print if DEBUG-EVAL exists and is not nil or false
-				switch dbgEval := dbgEval.(type) {
-				case bool:
-					if dbgEval {
-						pos := lisperror.GetPosition(ast)
-						if pos != nil {
-							fmt.Printf("\033[38;5;208m%s\033[0m: %s\n", pos, PRINT(ast))
-						}
-					}
-				default:
-					// do nothing
-				}
+		// Pluggable hook: external debuggers / DEBUG-EVAL printing.
+		if DebugEvalEnabled && runtime.Hook == nil {
+			runtime.Hook = runtime.PrintEvalHook{}
+		}
+		if runtime.Hook != nil {
+			ev := runtime.EvalEvent{AST: ast, Env: env, Cursor: lisperror.GetPosition(ast)}
+			if err := runtime.Hook.OnEval(ctx, ev); err != nil {
+				return nil, err
 			}
 		}
 

--- a/mal.go
+++ b/mal.go
@@ -49,12 +49,14 @@ var placeholderRE = regexp.MustCompile(`^(;; \$[\-\d\w]+)+\s(.+)`)
 const preamblePrefix = ";; $"
 
 // DebugEvalEnabled is a deprecated shim for the legacy DEBUG-EVAL print
-// behaviour. Setting it to true installs runtime.PrintEvalHook on the next
-// EVAL call if no other hook is active.
+// behaviour. Setting it to true takes effect only in `lispdebug` builds,
+// where it installs runtime.PrintEvalHook on the next EVAL call. In
+// release builds (the default) the flag has no effect because the hook
+// dispatch in EVAL is compiled out.
 //
-// Deprecated: install a runtime.EvalHook directly via
-// `runtime.Hook = runtime.PrintEvalHook{}` (or your own implementation).
-// New code in this repo wires --debug through runtime.Hook.
+// Deprecated: in `lispdebug` builds, install a runtime.EvalHook directly
+// via `runtime.Hook = runtime.PrintEvalHook{}` (or your own
+// implementation). New code in this repo wires --debug through that path.
 var DebugEvalEnabled = false
 
 // READ reads Lisp source code and generates an AST that might be evaled by [EVAL] or printed by [PRINT].
@@ -352,13 +354,14 @@ func EVAL(ctx context.Context, ast MalType, env EnvType) (res MalType, e error) 
 			}
 		}
 
-		// Pluggable hook: external debuggers / DEBUG-EVAL printing.
-		if DebugEvalEnabled && runtime.Hook == nil {
-			runtime.Hook = runtime.PrintEvalHook{}
-		}
-		if runtime.Hook != nil {
-			ev := runtime.EvalEvent{AST: ast, Env: env, Cursor: lisperror.GetPosition(ast)}
-			if err := runtime.Hook.OnEval(ctx, ev); err != nil {
+		// Pluggable hook (debug builds only). When `runtime.Enabled` is
+		// the compile-time constant `false` (release build), the entire
+		// branch is dead code and the compiler removes it.
+		if runtime.Enabled {
+			if DebugEvalEnabled {
+				installLegacyDebugHook()
+			}
+			if err := runtime.Dispatch(ctx, ast, env, lisperror.GetPosition(ast)); err != nil {
 				return nil, err
 			}
 		}

--- a/mal_hook_test.go
+++ b/mal_hook_test.go
@@ -1,3 +1,5 @@
+//go:build lispdebug
+
 package lisp
 
 import (

--- a/mal_hook_test.go
+++ b/mal_hook_test.go
@@ -1,0 +1,102 @@
+package lisp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/runtime"
+	"github.com/jig/lisp/types"
+)
+
+type recordingHook struct {
+	events []runtime.EvalEvent
+	err    error
+}
+
+func (h *recordingHook) OnEval(_ context.Context, ev runtime.EvalEvent) error {
+	h.events = append(h.events, ev)
+	return h.err
+}
+
+func withHook(t *testing.T, h runtime.EvalHook) {
+	t.Helper()
+	prev := runtime.Hook
+	runtime.Hook = h
+	t.Cleanup(func() { runtime.Hook = prev })
+}
+
+func mustEval(t *testing.T, source string) (types.MalType, error) {
+	t.Helper()
+	ns := env.NewEnv()
+	ast, err := READ(source, types.NewCursorFile("hook-test"), ns)
+	if err != nil {
+		t.Fatalf("READ failed: %v", err)
+	}
+	return EVAL(context.Background(), ast, ns)
+}
+
+func TestEvalHookInvoked(t *testing.T) {
+	h := &recordingHook{}
+	withHook(t, h)
+
+	if _, err := mustEval(t, "(let [a 1 b 2] (do a b))"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(h.events) == 0 {
+		t.Fatal("hook was not invoked")
+	}
+	for i, ev := range h.events {
+		if ev.AST == nil {
+			t.Fatalf("event %d has nil AST", i)
+		}
+		if ev.Env == nil {
+			t.Fatalf("event %d has nil Env", i)
+		}
+	}
+}
+
+func TestEvalHookErrorAborts(t *testing.T) {
+	want := errors.New("aborted by hook")
+	withHook(t, &recordingHook{err: want})
+
+	_, err := mustEval(t, "(do 1 2 3)")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, want) && !strings.Contains(err.Error(), want.Error()) {
+		t.Fatalf("expected error to wrap %q, got %v", want, err)
+	}
+}
+
+func TestEvalHookNilNoOverhead(t *testing.T) {
+	withHook(t, nil)
+
+	res, err := mustEval(t, "(do 1 2 42)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got, _ := res.(int); got != 42 {
+		t.Fatalf("expected 42, got %v (%T)", res, res)
+	}
+}
+
+func TestDebugEvalEnabledShim(t *testing.T) {
+	prevHook := runtime.Hook
+	prevFlag := DebugEvalEnabled
+	runtime.Hook = nil
+	DebugEvalEnabled = true
+	t.Cleanup(func() {
+		runtime.Hook = prevHook
+		DebugEvalEnabled = prevFlag
+	})
+
+	if _, err := mustEval(t, "(do 1 2 3)"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := runtime.Hook.(runtime.PrintEvalHook); !ok {
+		t.Fatalf("expected DebugEvalEnabled to install PrintEvalHook, got %T", runtime.Hook)
+	}
+}

--- a/mal_hookshim_debug.go
+++ b/mal_hookshim_debug.go
@@ -1,0 +1,14 @@
+//go:build lispdebug
+
+package lisp
+
+import "github.com/jig/lisp/runtime"
+
+// installLegacyDebugHook installs runtime.PrintEvalHook on the first EVAL
+// iteration that observes `DebugEvalEnabled = true` and no other hook
+// already active. Only present in `lispdebug` builds.
+func installLegacyDebugHook() {
+	if runtime.Hook == nil {
+		runtime.Hook = runtime.PrintEvalHook{}
+	}
+}

--- a/mal_hookshim_release.go
+++ b/mal_hookshim_release.go
@@ -1,0 +1,7 @@
+//go:build !lispdebug
+
+package lisp
+
+// installLegacyDebugHook is a no-op in release builds. The call site in
+// EVAL is dead code under `if runtime.Enabled` (compile-time false).
+func installLegacyDebugHook() {}

--- a/runtime/active_debug.go
+++ b/runtime/active_debug.go
@@ -1,0 +1,55 @@
+//go:build lispdebug
+
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jig/lisp/printer"
+	"github.com/jig/lisp/types"
+)
+
+// Enabled reports whether hook dispatching is compiled in.
+// Always true in debug builds (`-tags lispdebug`).
+const Enabled = true
+
+// Hook is the active EvalHook. nil disables hooking.
+//
+// Set this once before kicking off EVAL goroutines. Concurrent reads are
+// safe; concurrent writes are not synchronised — callers must coordinate.
+var Hook EvalHook
+
+// Dispatch invokes the active hook if any. EVAL calls this once per
+// iteration when Enabled is true.
+func Dispatch(ctx context.Context, ast types.MalType, env types.EnvType, cursor *types.Position) error {
+	h := Hook
+	if h == nil {
+		return nil
+	}
+	return h.OnEval(ctx, EvalEvent{AST: ast, Env: env, Cursor: cursor})
+}
+
+// PrintEvalHook reproduces the legacy DEBUG-EVAL printing behaviour:
+// when the symbol DEBUG-EVAL is bound to true in the active env, it prints
+// the source position followed by the form being evaluated.
+type PrintEvalHook struct{}
+
+// OnEval implements EvalHook.
+func (PrintEvalHook) OnEval(_ context.Context, ev EvalEvent) error {
+	if ev.Env == nil {
+		return nil
+	}
+	dbg, err := ev.Env.Get(types.Symbol{Val: "DEBUG-EVAL"})
+	if err != nil {
+		return nil
+	}
+	b, ok := dbg.(bool)
+	if !ok || !b {
+		return nil
+	}
+	if ev.Cursor != nil {
+		fmt.Printf("\033[38;5;208m%s\033[0m: %s\n", ev.Cursor, printer.Pr_str(ev.AST, true))
+	}
+	return nil
+}

--- a/runtime/active_release.go
+++ b/runtime/active_release.go
@@ -1,0 +1,20 @@
+//go:build !lispdebug
+
+package runtime
+
+import (
+	"context"
+
+	"github.com/jig/lisp/types"
+)
+
+// Enabled reports whether hook dispatching is compiled in.
+// Always false in release builds. Callers can guard with
+// `if runtime.Enabled { ... }` and the compiler will eliminate the branch.
+const Enabled = false
+
+// Dispatch is a no-op in release builds. The constant `Enabled = false`
+// guarantees this is dead code and the compiler removes the call site.
+func Dispatch(_ context.Context, _ types.MalType, _ types.EnvType, _ *types.Position) error {
+	return nil
+}

--- a/runtime/hook.go
+++ b/runtime/hook.go
@@ -1,19 +1,29 @@
 // Package runtime exposes hooks that external tooling (debuggers, LSP
 // servers) can install to observe or intercept Lisp evaluation.
 //
-// The package is intentionally tiny: it provides a single pre-eval callback
-// that is invoked once per EVAL iteration. Consumers are expected to keep
-// any auxiliary state (call stacks, breakpoint tables, pause channels) in
-// their own implementation of EvalHook.
+// # Build modes
 //
-// When Hook is nil, EVAL pays no overhead beyond a single nil check.
+// The hook machinery is gated by the build tag `lispdebug`:
+//
+//   - **release** (default, no tag): runtime.Enabled == false. The hook
+//     dispatch in EVAL is dead code and the compiler removes it. There is
+//     no way to install a hook in this build, no performance overhead in
+//     the hot path, and no in-process attack surface for an unwanted
+//     observer of evaluation.
+//
+//   - **debug** (`-tags lispdebug`): runtime.Enabled == true. The exported
+//     `Hook` variable accepts an EvalHook implementation. EVAL invokes
+//     `runtime.Dispatch` once per iteration. Use this build for the
+//     `--debug` CLI flag and for the upcoming DAP debugger and LSP
+//     server.
+//
+// Build the production binary with `go build ./cmd/lisp`. Build the
+// debug binary with `go build -tags lispdebug ./cmd/lisp`.
 package runtime
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/jig/lisp/printer"
 	"github.com/jig/lisp/types"
 )
 
@@ -26,37 +36,8 @@ type EvalEvent struct {
 
 // EvalHook is invoked by EVAL before each iteration of its TCO loop.
 // Returning a non-nil error aborts evaluation and propagates the error.
+//
+// Only meaningful in `lispdebug` builds; see package doc.
 type EvalHook interface {
 	OnEval(ctx context.Context, ev EvalEvent) error
-}
-
-// Hook is the active EvalHook. nil disables hooking entirely.
-//
-// Set this once before kicking off EVAL goroutines. Concurrent reads are
-// safe (a single pointer assignment is atomic on supported platforms);
-// concurrent writes are not synchronised — callers must coordinate.
-var Hook EvalHook
-
-// PrintEvalHook reproduces the legacy DEBUG-EVAL printing behaviour:
-// when the symbol DEBUG-EVAL is bound to true in the active env, it prints
-// the source position followed by the form being evaluated.
-type PrintEvalHook struct{}
-
-// OnEval implements EvalHook.
-func (PrintEvalHook) OnEval(_ context.Context, ev EvalEvent) error {
-	if ev.Env == nil {
-		return nil
-	}
-	dbg, err := ev.Env.Get(types.Symbol{Val: "DEBUG-EVAL"})
-	if err != nil {
-		return nil
-	}
-	b, ok := dbg.(bool)
-	if !ok || !b {
-		return nil
-	}
-	if ev.Cursor != nil {
-		fmt.Printf("\033[38;5;208m%s\033[0m: %s\n", ev.Cursor, printer.Pr_str(ev.AST, true))
-	}
-	return nil
 }

--- a/runtime/hook.go
+++ b/runtime/hook.go
@@ -1,0 +1,62 @@
+// Package runtime exposes hooks that external tooling (debuggers, LSP
+// servers) can install to observe or intercept Lisp evaluation.
+//
+// The package is intentionally tiny: it provides a single pre-eval callback
+// that is invoked once per EVAL iteration. Consumers are expected to keep
+// any auxiliary state (call stacks, breakpoint tables, pause channels) in
+// their own implementation of EvalHook.
+//
+// When Hook is nil, EVAL pays no overhead beyond a single nil check.
+package runtime
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jig/lisp/printer"
+	"github.com/jig/lisp/types"
+)
+
+// EvalEvent describes a single EVAL step about to happen.
+type EvalEvent struct {
+	AST    types.MalType
+	Env    types.EnvType
+	Cursor *types.Position
+}
+
+// EvalHook is invoked by EVAL before each iteration of its TCO loop.
+// Returning a non-nil error aborts evaluation and propagates the error.
+type EvalHook interface {
+	OnEval(ctx context.Context, ev EvalEvent) error
+}
+
+// Hook is the active EvalHook. nil disables hooking entirely.
+//
+// Set this once before kicking off EVAL goroutines. Concurrent reads are
+// safe (a single pointer assignment is atomic on supported platforms);
+// concurrent writes are not synchronised — callers must coordinate.
+var Hook EvalHook
+
+// PrintEvalHook reproduces the legacy DEBUG-EVAL printing behaviour:
+// when the symbol DEBUG-EVAL is bound to true in the active env, it prints
+// the source position followed by the form being evaluated.
+type PrintEvalHook struct{}
+
+// OnEval implements EvalHook.
+func (PrintEvalHook) OnEval(_ context.Context, ev EvalEvent) error {
+	if ev.Env == nil {
+		return nil
+	}
+	dbg, err := ev.Env.Get(types.Symbol{Val: "DEBUG-EVAL"})
+	if err != nil {
+		return nil
+	}
+	b, ok := dbg.(bool)
+	if !ok || !b {
+		return nil
+	}
+	if ev.Cursor != nil {
+		fmt.Printf("\033[38;5;208m%s\033[0m: %s\n", ev.Cursor, printer.Pr_str(ev.AST, true))
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

First PR of Etapa 2 (DAP + LSP for VSCode). Introduces a pluggable
`EvalHook` for external debuggers, gated behind the `lispdebug` build
tag so production binaries pay nothing for it.

- New package `runtime/`:
  - `EvalEvent` + `EvalHook` interface (always compiled).
  - `runtime.Enabled` constant: `false` in release builds, `true` with
    `-tags lispdebug`.
  - `Hook` global, `Dispatch` function, and `PrintEvalHook` only in
    `lispdebug` builds.
- `mal.go` calls `runtime.Dispatch` under `if runtime.Enabled { ... }`.
  In release builds this is dead code and the compiler removes it —
  zero hot-path overhead, no in-process surface to install a hook.
- `command/command.go` `--debug` returns an explicit error in release
  builds pointing at the build tag; in `lispdebug` builds it installs
  `runtime.PrintEvalHook` exactly like before.
- `lisp.DebugEvalEnabled` kept as a deprecated shim. In release builds
  the flag has no effect.
- Tests split by build tag:
  - `mal_hook_test.go`, `command/debug_debug_test.go` →
    `//go:build lispdebug`.
  - `command/debug_release_test.go` → `//go:build !lispdebug`,
    asserts `--debug` returns the expected error.

## Why two artefacts via build tag (not two functions)

Per review feedback: the hook check inside the EVAL loop is a
performance and security concern in production. The choices were
(a) two separate artefacts or (b) two separate EVAL functions.
Build tags give us the artefact split *without* duplicating the
~280-line EVAL/TCO loop. The `if runtime.Enabled` is a constant-folded
branch that the compiler eliminates entirely in the release build.

## Build & test

```sh
# Production
go build ./cmd/lisp
go test ./...

# Debug (DAP/LSP)
go build -tags lispdebug ./cmd/lisp
go test -tags lispdebug ./...
```

## Why this PR is small

Phase A in the original Etapa 2 plan covered four sub-items (hook,
live stack, module-path map, def cursors). The latter three only
matter to a specific consumer: live stack and module-path are
DAP-only, def cursors are LSP-only. They land in PR2 (DAP) and PR4
(LSP) instead, keeping each PR consumer-driven.

## User-facing changes

- **CLI**: identical for `-e`, `--test`, `--version`, scripts, REPL.
  `--debug` now requires a `lispdebug` build (was a runtime toggle).
- **Embedders**: `lisp.DebugEvalEnabled = true` no longer takes effect
  in release builds. To enable hook tracing, build the debug artefact
  and set `runtime.Hook = runtime.PrintEvalHook{}` (or your own
  `runtime.EvalHook`).

## Test plan

- [x] `go build ./...`
- [x] `go build -tags lispdebug ./...`
- [x] `go vet ./...` and `go vet -tags lispdebug ./...`
- [x] `go test ./...` — green
- [x] `go test -tags lispdebug ./...` — green
- [x] `go test -race ./...` and `go test -race -tags lispdebug ./...`
  — only the pre-existing `lib/concurrent` race documented in PR #44
  (out of scope)
- [x] Smoke release: `go run ./cmd/lisp -e '(+ 1 2)'` → `3`
- [x] Smoke release: `go run ./cmd/lisp --debug -e ...` → exits with
  "--debug requires a debug build: rebuild with -tags lispdebug"
- [x] Smoke debug: `go run -tags lispdebug ./cmd/lisp --debug -e ...`
  → identical orange-coloured DEBUG-EVAL trace as before
- [x] `gofmt -l .` clean

## Base branch

Re-targeted from `main` to `develop` per review feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)