### PR TITLE
Etapa 2 PR2: DAP backend (live stack, breakpoints, step over/in/out)

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -16,12 +16,14 @@ import (
 
 // args represents command line arguments for the Lisp interpreter
 type args struct {
-	Version bool     `arg:"-v,--version" help:"show version information"`
-	Test    string   `arg:"-t,--test" help:"run test suite from directory" placeholder:"DIR"`
-	Debug   bool     `arg:"--debug" help:"enable DEBUG-EVAL support (may impact performance)"`
-	Eval    string   `arg:"-e,--eval" help:"evaluate expression and exit" placeholder:"EXPR"`
-	Script  string   `arg:"positional" help:"lisp script to execute"`
-	Args    []string `arg:"positional" help:"arguments to pass to the script"`
+	Version   bool     `arg:"-v,--version" help:"show version information"`
+	Test      string   `arg:"-t,--test" help:"run test suite from directory" placeholder:"DIR"`
+	Debug     bool     `arg:"--debug" help:"enable DEBUG-EVAL support (requires lispdebug build)"`
+	Eval      string   `arg:"-e,--eval" help:"evaluate expression and exit" placeholder:"EXPR"`
+	DAP       bool     `arg:"--dap" help:"start a Debug Adapter Protocol server on stdio (requires lispdebug build)"`
+	DAPListen string   `arg:"--dap-listen" help:"start a DAP server on the given TCP address (requires lispdebug build)" placeholder:"HOST:PORT"`
+	Script    string   `arg:"positional" help:"lisp script to execute"`
+	Args      []string `arg:"positional" help:"arguments to pass to the script"`
 }
 
 func (args) Description() string {
@@ -85,6 +87,11 @@ func Execute(cmdArgs []string, repl_env types.EnvType) error {
 
 	if parsedArgs.Eval != "" && (parsedArgs.Version || parsedArgs.Test != "") {
 		return fmt.Errorf("-e cannot be used with --version or --test")
+	}
+
+	// DAP server takes precedence over the rest of the modes when set.
+	if parsedArgs.DAP || parsedArgs.DAPListen != "" {
+		return startDAP(parsedArgs.DAPListen, parsedArgs.Script, repl_env)
 	}
 
 	// Handle --version
@@ -172,6 +179,9 @@ func runTests(dir string, repl_env types.EnvType) error {
 
 // ExecuteFile executes a file on the given path
 func ExecuteFile(fileName string, ns types.EnvType) (types.MalType, error) {
+	if abs, err := filepath.Abs(fileName); err == nil {
+		registerModule(fileName, abs)
+	}
 	ctx := context.Background()
 	result, err := lisp.REPL(ctx, ns, `(load-file "`+fileName+`")`, types.NewCursorHere(fileName, -3, 1))
 	if err != nil {

--- a/command/dap_debug.go
+++ b/command/dap_debug.go
@@ -1,0 +1,56 @@
+//go:build lispdebug
+
+package command
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/debugadapter"
+	"github.com/jig/lisp/types"
+)
+
+// startDAP starts a DAP session. listen is empty for stdio, or a
+// "host:port" TCP address. script is the program to debug; if empty,
+// the session is REPL-style and waits for `evaluate` requests (not yet
+// implemented at MVP).
+func startDAP(listen, script string, env types.EnvType) error {
+	if script == "" {
+		return fmt.Errorf("--dap requires a script positional argument (REPL mode not yet supported)")
+	}
+	abs, err := filepath.Abs(script)
+	if err != nil {
+		return fmt.Errorf("cannot resolve script path: %w", err)
+	}
+	registerModule(script, abs)
+
+	eval := func(ctx context.Context, env types.EnvType) error {
+		_, err := lisp.REPL(ctx, env, `(load-file "`+script+`")`, types.NewCursorHere(script, -3, 1))
+		return err
+	}
+
+	if listen == "" {
+		t := debugadapter.NewTransport(os.Stdin, os.Stdout, nil)
+		srv := debugadapter.NewServer(t, eval, env)
+		return srv.Run(context.Background())
+	}
+
+	ln, err := net.Listen("tcp", listen)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", listen, err)
+	}
+	defer ln.Close()
+	fmt.Fprintf(os.Stderr, "DAP server listening on %s\n", listen)
+	conn, err := ln.Accept()
+	if err != nil {
+		return fmt.Errorf("accept: %w", err)
+	}
+	defer conn.Close()
+	t := debugadapter.NewTransport(conn, conn, conn)
+	srv := debugadapter.NewServer(t, eval, env)
+	return srv.Run(context.Background())
+}

--- a/command/dap_release.go
+++ b/command/dap_release.go
@@ -1,0 +1,16 @@
+//go:build !lispdebug
+
+package command
+
+import (
+	"errors"
+
+	"github.com/jig/lisp/types"
+)
+
+// startDAP fails in release builds. The DAP server is gated behind the
+// `lispdebug` build tag for the same reasons --debug is: zero hot-path
+// overhead and no in-process surface to install a hook.
+func startDAP(_ string, _ string, _ types.EnvType) error {
+	return errors.New("--dap requires a debug build: rebuild with -tags lispdebug")
+}

--- a/command/modules_debug.go
+++ b/command/modules_debug.go
@@ -1,0 +1,13 @@
+//go:build lispdebug
+
+package command
+
+import "github.com/jig/lisp/runtime"
+
+// registerModule maps a module identifier (typically a script filename
+// passed to NewCursorFile / NewCursorHere) to its absolute filesystem
+// path. The DAP server consults this map when emitting `source.path` and
+// when matching `setBreakpoints` requests against incoming Cursors.
+func registerModule(module, absPath string) {
+	runtime.Modules.Register(module, absPath)
+}

--- a/command/modules_release.go
+++ b/command/modules_release.go
@@ -1,0 +1,7 @@
+//go:build !lispdebug
+
+package command
+
+// registerModule is a no-op in release builds. The module-to-path map
+// only exists in `lispdebug` builds where the DAP server consumes it.
+func registerModule(_, _ string) {}

--- a/debugadapter/eval_test.go
+++ b/debugadapter/eval_test.go
@@ -1,0 +1,20 @@
+//go:build lispdebug
+
+package debugadapter
+
+import (
+	"context"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/types"
+)
+
+// evalSimple parses and evaluates source under the given env in the
+// given context. Used by tests to drive the debugger.
+func evalSimple(ctx context.Context, env types.EnvType, source string) (types.MalType, error) {
+	ast, err := lisp.READ(source, types.NewCursorFile("test.lisp"), env)
+	if err != nil {
+		return nil, err
+	}
+	return lisp.EVAL(ctx, ast, env)
+}

--- a/debugadapter/hook.go
+++ b/debugadapter/hook.go
@@ -1,0 +1,70 @@
+//go:build lispdebug
+
+package debugadapter
+
+import (
+	"context"
+
+	"github.com/jig/lisp/runtime"
+)
+
+// StepHook is the runtime.EvalHook installed by the DAP server. It is
+// invoked once per EVAL iteration; it consults the session state to
+// decide whether to pause execution.
+type StepHook struct {
+	st *state
+}
+
+// OnEval implements runtime.EvalHook.
+func (h *StepHook) OnEval(ctx context.Context, ev runtime.EvalEvent) error {
+	s := h.st
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.disconnect {
+		return errDisconnected
+	}
+
+	t := runtime.ThreadFromContext(ctx)
+	depth := 0
+	if t != nil {
+		depth = t.Depth()
+	}
+
+	// Breakpoint check first: a breakpoint always wins over step mode.
+	if s.matchBreakpoint(ev.Cursor) {
+		s.pauseAndWait("breakpoint", "")
+		return nil
+	}
+
+	switch s.mode {
+	case modeStopOnEntry:
+		s.pauseAndWait("entry", "")
+	case modeStepIn:
+		s.pauseAndWait("step", "")
+	case modeStepOver:
+		if depth <= s.targetDepth {
+			s.pauseAndWait("step", "")
+		}
+	case modeStepOut:
+		if depth < s.targetDepth {
+			s.pauseAndWait("step", "")
+		}
+	default:
+		// modeRunning, modePaused → keep running (paused is impossible
+		// here because the goroutine is unblocked).
+	}
+
+	if s.disconnect {
+		return errDisconnected
+	}
+	return nil
+}
+
+// errDisconnected is returned by OnEval to abort EVAL when the client
+// disconnects.
+var errDisconnected = &disconnectError{}
+
+type disconnectError struct{}
+
+func (*disconnectError) Error() string { return "DAP client disconnected" }

--- a/debugadapter/protocol.go
+++ b/debugadapter/protocol.go
@@ -1,0 +1,172 @@
+//go:build lispdebug
+
+// Package debugadapter implements a Debug Adapter Protocol (DAP) server
+// for the Lisp interpreter. It is compiled only into `lispdebug` builds.
+//
+// The server speaks DAP over stdio or a TCP socket. A VSCode extension
+// (or any DAP client) connects, sets breakpoints, launches the program,
+// and steps through the evaluation.
+//
+// Spec reference: https://microsoft.github.io/debug-adapter-protocol/
+package debugadapter
+
+import "encoding/json"
+
+// Message is the common envelope for every DAP packet. Type is
+// "request", "response", or "event"; the discriminating field is read
+// before the rest of the payload.
+type Message struct {
+	Seq  int    `json:"seq"`
+	Type string `json:"type"`
+}
+
+// Request is sent by the client.
+type Request struct {
+	Message
+	Command   string          `json:"command"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+// Response is sent by the server in reply to a Request.
+type Response struct {
+	Message
+	RequestSeq int         `json:"request_seq"`
+	Success    bool        `json:"success"`
+	Command    string      `json:"command"`
+	Message_   string      `json:"message,omitempty"`
+	Body       interface{} `json:"body,omitempty"`
+}
+
+// Event is sent by the server to notify the client.
+type Event struct {
+	Message
+	Event string      `json:"event"`
+	Body  interface{} `json:"body,omitempty"`
+}
+
+// Capabilities advertised in the response to `initialize`.
+type Capabilities struct {
+	SupportsConfigurationDoneRequest bool `json:"supportsConfigurationDoneRequest"`
+	SupportsTerminateRequest         bool `json:"supportsTerminateRequest"`
+	SupportsStepInTargetsRequest     bool `json:"supportsStepInTargetsRequest"`
+}
+
+// Source identifies a script file in DAP terms.
+type Source struct {
+	Name string `json:"name,omitempty"`
+	Path string `json:"path,omitempty"`
+}
+
+// SourceBreakpoint is a breakpoint requested by the client.
+type SourceBreakpoint struct {
+	Line int `json:"line"`
+}
+
+// Breakpoint is the server's confirmation back to the client.
+type Breakpoint struct {
+	Verified bool   `json:"verified"`
+	Line     int    `json:"line,omitempty"`
+	Source   Source `json:"source,omitempty"`
+}
+
+// StackFrame is one entry in the response to `stackTrace`.
+type StackFrame struct {
+	ID     int    `json:"id"`
+	Name   string `json:"name"`
+	Line   int    `json:"line"`
+	Column int    `json:"column"`
+	Source Source `json:"source,omitempty"`
+}
+
+// Scope groups variables visible at a stack frame.
+type Scope struct {
+	Name               string `json:"name"`
+	VariablesReference int    `json:"variablesReference"`
+	Expensive          bool   `json:"expensive"`
+}
+
+// Variable is one entry in the response to `variables`.
+type Variable struct {
+	Name               string `json:"name"`
+	Value              string `json:"value"`
+	Type               string `json:"type,omitempty"`
+	VariablesReference int    `json:"variablesReference"`
+}
+
+// Thread describes a thread of execution. The Lisp DAP server exposes a
+// single thread today.
+type Thread struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// Argument types ----------------------------------------------------------
+
+// LaunchArguments are the parameters sent with a `launch` request.
+type LaunchArguments struct {
+	Program     string `json:"program,omitempty"`
+	StopOnEntry bool   `json:"stopOnEntry,omitempty"`
+}
+
+// SetBreakpointsArguments configures breakpoints in a single source file.
+type SetBreakpointsArguments struct {
+	Source      Source             `json:"source"`
+	Breakpoints []SourceBreakpoint `json:"breakpoints"`
+}
+
+// StackTraceArguments selects a thread and a window of frames.
+type StackTraceArguments struct {
+	ThreadID   int `json:"threadId"`
+	StartFrame int `json:"startFrame"`
+	Levels     int `json:"levels"`
+}
+
+// ScopesArguments selects a stack frame.
+type ScopesArguments struct {
+	FrameID int `json:"frameId"`
+}
+
+// VariablesArguments selects a variables reference (a scope or a
+// composite value previously returned to the client).
+type VariablesArguments struct {
+	VariablesReference int `json:"variablesReference"`
+}
+
+// ContinueArguments selects a thread.
+type ContinueArguments struct {
+	ThreadID int `json:"threadId"`
+}
+
+// NextArguments / StepInArguments / StepOutArguments / PauseArguments all
+// share the same shape today: a thread id.
+type NextArguments = ContinueArguments
+type StepInArguments = ContinueArguments
+type StepOutArguments = ContinueArguments
+type PauseArguments = ContinueArguments
+
+// Event bodies ------------------------------------------------------------
+
+// StoppedEventBody is sent when execution pauses.
+type StoppedEventBody struct {
+	Reason            string `json:"reason"`
+	Description       string `json:"description,omitempty"`
+	ThreadID          int    `json:"threadId"`
+	AllThreadsStopped bool   `json:"allThreadsStopped"`
+}
+
+// ContinuedEventBody is sent when execution resumes.
+type ContinuedEventBody struct {
+	ThreadID            int  `json:"threadId"`
+	AllThreadsContinued bool `json:"allThreadsContinued"`
+}
+
+// OutputEventBody carries program output to the client.
+type OutputEventBody struct {
+	Category string `json:"category,omitempty"`
+	Output   string `json:"output"`
+}
+
+// ExitedEventBody reports the exit code of the debuggee.
+type ExitedEventBody struct {
+	ExitCode int `json:"exitCode"`
+}

--- a/debugadapter/server.go
+++ b/debugadapter/server.go
@@ -1,0 +1,391 @@
+//go:build lispdebug
+
+package debugadapter
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/jig/lisp/printer"
+	"github.com/jig/lisp/runtime"
+	"github.com/jig/lisp/types"
+)
+
+// EvalFunc evaluates the given source under the given context. The DAP
+// server invokes it once `configurationDone` arrives. The function
+// should respect the context for cancellation.
+type EvalFunc func(ctx context.Context, env types.EnvType) error
+
+// Server is the DAP server. One instance handles one debug session.
+type Server struct {
+	t *Transport
+
+	state *state
+
+	seq atomic.Int64
+
+	cfgDone chan struct{}
+
+	evalFn   EvalFunc
+	evalEnv  types.EnvType
+	evalDone chan error
+
+	closeOnce sync.Once
+}
+
+// NewServer constructs a server that will drive `eval` once the client
+// finishes configuration. `env` is passed to eval; the caller has
+// already populated it with the desired libraries.
+func NewServer(t *Transport, eval EvalFunc, env types.EnvType) *Server {
+	s := &Server{
+		t:        t,
+		cfgDone:  make(chan struct{}),
+		evalFn:   eval,
+		evalEnv:  env,
+		evalDone: make(chan error, 1),
+	}
+	s.state = newState(s)
+	return s
+}
+
+// Run blocks reading and dispatching DAP messages until the client
+// disconnects or the debuggee exits.
+func (s *Server) Run(ctx context.Context) error {
+	// Install our hook for the duration of this session.
+	prevHook := runtime.Hook
+	runtime.Hook = &StepHook{st: s.state}
+	defer func() { runtime.Hook = prevHook }()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go s.runEval(ctx)
+
+	for {
+		raw, err := s.t.ReadMessage()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				s.markDisconnect()
+				<-s.evalDone
+				return nil
+			}
+			s.markDisconnect()
+			return err
+		}
+		var hdr Message
+		if err := json.Unmarshal(raw, &hdr); err != nil {
+			continue
+		}
+		if hdr.Type != "request" {
+			continue
+		}
+		var req Request
+		if err := json.Unmarshal(raw, &req); err != nil {
+			continue
+		}
+		s.dispatch(ctx, &req)
+		if req.Command == "disconnect" || req.Command == "terminate" {
+			s.markDisconnect()
+			<-s.evalDone
+			return nil
+		}
+	}
+}
+
+// runEval waits for `configurationDone`, then runs the program.
+func (s *Server) runEval(ctx context.Context) {
+	select {
+	case <-s.cfgDone:
+	case <-ctx.Done():
+		s.evalDone <- ctx.Err()
+		return
+	}
+	evalCtx := runtime.WithThread(ctx, s.state.thread)
+	err := s.evalFn(evalCtx, s.evalEnv)
+
+	if err != nil && !errors.Is(err, errDisconnected) {
+		s.sendEvent("output", OutputEventBody{Category: "stderr", Output: err.Error() + "\n"})
+	}
+	exitCode := 0
+	if err != nil && !errors.Is(err, errDisconnected) {
+		exitCode = 1
+	}
+	s.sendEvent("exited", ExitedEventBody{ExitCode: exitCode})
+	s.sendEvent("terminated", struct{}{})
+	s.evalDone <- err
+}
+
+// markDisconnect signals the EVAL goroutine to abort at the next hook.
+func (s *Server) markDisconnect() {
+	s.state.mu.Lock()
+	s.state.disconnect = true
+	s.state.cond.Broadcast()
+	s.state.mu.Unlock()
+}
+
+// dispatch routes a request to its handler. Each handler builds and
+// sends the response.
+func (s *Server) dispatch(_ context.Context, req *Request) {
+	switch req.Command {
+	case "initialize":
+		s.respond(req, true, "", Capabilities{
+			SupportsConfigurationDoneRequest: true,
+			SupportsTerminateRequest:         true,
+		})
+		s.sendEvent("initialized", struct{}{})
+	case "launch":
+		var args LaunchArguments
+		_ = json.Unmarshal(req.Arguments, &args)
+		s.state.mu.Lock()
+		if args.StopOnEntry {
+			s.state.stopOnEntry = true
+			s.state.mode = modeStopOnEntry
+		}
+		s.state.mu.Unlock()
+		s.respond(req, true, "", nil)
+	case "setBreakpoints":
+		var args SetBreakpointsArguments
+		_ = json.Unmarshal(req.Arguments, &args)
+		bps := s.state.setBreakpoints(args.Source, args.Breakpoints)
+		s.respond(req, true, "", map[string]interface{}{"breakpoints": bps})
+	case "configurationDone":
+		s.respond(req, true, "", nil)
+		select {
+		case <-s.cfgDone:
+		default:
+			close(s.cfgDone)
+		}
+	case "threads":
+		s.respond(req, true, "", map[string]interface{}{
+			"threads": []Thread{{ID: 1, Name: "lisp"}},
+		})
+	case "stackTrace":
+		s.handleStackTrace(req)
+	case "scopes":
+		s.handleScopes(req)
+	case "variables":
+		s.handleVariables(req)
+	case "continue":
+		s.state.mu.Lock()
+		s.state.resume(modeRunning, 0)
+		s.state.mu.Unlock()
+		s.respond(req, true, "", map[string]interface{}{"allThreadsContinued": true})
+	case "next":
+		s.state.mu.Lock()
+		s.state.resume(modeStepOver, s.state.thread.Depth())
+		s.state.mu.Unlock()
+		s.respond(req, true, "", nil)
+	case "stepIn":
+		s.state.mu.Lock()
+		s.state.resume(modeStepIn, 0)
+		s.state.mu.Unlock()
+		s.respond(req, true, "", nil)
+	case "stepOut":
+		s.state.mu.Lock()
+		s.state.resume(modeStepOut, s.state.thread.Depth())
+		s.state.mu.Unlock()
+		s.respond(req, true, "", nil)
+	case "pause":
+		// Cooperative pause: flip mode so the next OnEval blocks. The
+		// goroutine is currently running; OnEval will pick this up.
+		s.state.mu.Lock()
+		s.state.mode = modeStepIn
+		s.state.mu.Unlock()
+		s.respond(req, true, "", nil)
+	case "disconnect":
+		s.respond(req, true, "", nil)
+	case "terminate":
+		s.respond(req, true, "", nil)
+	default:
+		s.respond(req, false, "unsupported command: "+req.Command, nil)
+	}
+}
+
+func (s *Server) handleStackTrace(req *Request) {
+	frames := s.state.thread.Snapshot()
+	out := make([]StackFrame, 0, len(frames))
+	for i := len(frames) - 1; i >= 0; i-- {
+		f := frames[i]
+		var src Source
+		line := 0
+		col := 0
+		if f.Cursor != nil {
+			line = f.Cursor.BeginRow
+			col = f.Cursor.BeginCol
+			if f.Cursor.Module != nil {
+				src = Source{Name: *f.Cursor.Module, Path: runtime.Modules.Resolve(*f.Cursor.Module)}
+			}
+		}
+		name := f.FunctionName
+		if name == "" {
+			name = "<eval>"
+		}
+		out = append(out, StackFrame{
+			ID:     len(frames) - 1 - i,
+			Name:   name,
+			Line:   line,
+			Column: col,
+			Source: src,
+		})
+	}
+	s.respond(req, true, "", map[string]interface{}{
+		"stackFrames": out,
+		"totalFrames": len(out),
+	})
+}
+
+func (s *Server) handleScopes(req *Request) {
+	var args ScopesArguments
+	_ = json.Unmarshal(req.Arguments, &args)
+
+	s.state.mu.Lock()
+	defer s.state.mu.Unlock()
+
+	frames := s.state.thread.Snapshot()
+	// args.FrameID was assigned in handleStackTrace as `len(frames)-1-i`
+	// (top frame → 0). Resolve it back to a slice index.
+	idx := len(frames) - 1 - args.FrameID
+	if idx < 0 || idx >= len(frames) {
+		s.respond(req, true, "", map[string]interface{}{"scopes": []Scope{}})
+		return
+	}
+	ref := s.state.registerVarRef(varRef{kind: varRefScopeLocals, frameIdx: idx})
+	scopes := []Scope{{Name: "Locals", VariablesReference: ref, Expensive: false}}
+	s.respond(req, true, "", map[string]interface{}{"scopes": scopes})
+}
+
+func (s *Server) handleVariables(req *Request) {
+	var args VariablesArguments
+	_ = json.Unmarshal(req.Arguments, &args)
+
+	s.state.mu.Lock()
+	defer s.state.mu.Unlock()
+
+	entry, ok := s.state.varRefs[args.VariablesReference]
+	if !ok {
+		s.respond(req, true, "", map[string]interface{}{"variables": []Variable{}})
+		return
+	}
+	var vars []Variable
+	switch entry.kind {
+	case varRefScopeLocals:
+		vars = s.localsForFrame(entry.frameIdx)
+	case varRefValue:
+		vars = s.childrenOf(entry.value)
+	}
+	s.respond(req, true, "", map[string]interface{}{"variables": vars})
+}
+
+// localsForFrame returns the bindings local to the frame's environment
+// (not the outer chain). We surface only the immediate scope to keep
+// the variables view manageable.
+func (s *Server) localsForFrame(frameIdx int) []Variable {
+	frames := s.state.thread.Snapshot()
+	if frameIdx < 0 || frameIdx >= len(frames) {
+		return nil
+	}
+	env := frames[frameIdx].Env
+	if env == nil {
+		return nil
+	}
+	// Use the prefix-completion API to enumerate local symbols. With an
+	// empty prefix it returns symbols from the current scope (and outers
+	// after that — we slice on the first scope by reading via Get).
+	syms := env.Symbols(nil, "")
+	seen := map[string]bool{}
+	out := make([]Variable, 0, len(syms))
+	for _, r := range syms {
+		name := string(r)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		v, err := env.Get(types.Symbol{Val: name})
+		if err != nil {
+			continue
+		}
+		out = append(out, s.formatVariable(name, v))
+	}
+	return out
+}
+
+func (s *Server) childrenOf(v types.MalType) []Variable {
+	switch v := v.(type) {
+	case types.List:
+		out := make([]Variable, len(v.Val))
+		for i, e := range v.Val {
+			out[i] = s.formatVariable(fmt.Sprintf("[%d]", i), e)
+		}
+		return out
+	case types.Vector:
+		out := make([]Variable, len(v.Val))
+		for i, e := range v.Val {
+			out[i] = s.formatVariable(fmt.Sprintf("[%d]", i), e)
+		}
+		return out
+	case types.HashMap:
+		out := make([]Variable, 0, len(v.Val))
+		for k, val := range v.Val {
+			displayKey := k
+			if strings.HasPrefix(k, "ʞ") {
+				displayKey = ":" + strings.TrimPrefix(k, "ʞ")
+			}
+			out = append(out, s.formatVariable(displayKey, val))
+		}
+		return out
+	case types.Set:
+		out := make([]Variable, 0, len(v.Val))
+		for k := range v.Val {
+			out = append(out, s.formatVariable(k, k))
+		}
+		return out
+	}
+	return nil
+}
+
+// formatVariable produces a DAP Variable for the given name/value pair.
+// Composite values get a fresh variablesReference so the client can
+// expand them lazily.
+func (s *Server) formatVariable(name string, v types.MalType) Variable {
+	value := printer.Pr_str(v, true)
+	typeName := fmt.Sprintf("%T", v)
+	ref := 0
+	switch v.(type) {
+	case types.List, types.Vector, types.HashMap, types.Set:
+		ref = s.state.registerVarRef(varRef{kind: varRefValue, value: v})
+	}
+	return Variable{Name: name, Value: value, Type: typeName, VariablesReference: ref}
+}
+
+// respond marshals a Response and writes it.
+func (s *Server) respond(req *Request, success bool, msg string, body interface{}) {
+	resp := Response{
+		Message:    Message{Seq: int(s.seq.Add(1)), Type: "response"},
+		RequestSeq: req.Seq,
+		Success:    success,
+		Command:    req.Command,
+		Message_:   msg,
+		Body:       body,
+	}
+	if err := s.t.WriteMessage(resp); err != nil {
+		// best-effort; the client will likely time out
+		_ = err
+	}
+}
+
+// sendEvent is the main goroutine-friendly event sender used by the
+// state to notify the client of pause/resume/output.
+func (s *Server) sendEvent(name string, body interface{}) {
+	ev := Event{
+		Message: Message{Seq: int(s.seq.Add(1)), Type: "event"},
+		Event:   name,
+		Body:    body,
+	}
+	_ = s.t.WriteMessage(ev)
+}

--- a/debugadapter/server_test.go
+++ b/debugadapter/server_test.go
@@ -1,0 +1,197 @@
+//go:build lispdebug
+
+package debugadapter
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core"
+	"github.com/jig/lisp/types"
+)
+
+// pair returns two Transports that talk to each other over an in-memory
+// net.Pipe. The first is for the test "client", the second for the
+// server under test.
+func pair() (*Transport, *Transport, func()) {
+	a, b := net.Pipe()
+	client := NewTransport(a, a, a)
+	server := NewTransport(b, b, b)
+	return client, server, func() {
+		_ = a.Close()
+		_ = b.Close()
+	}
+}
+
+// runServer launches srv in its own goroutine and returns a teardown
+// closure that closes the transports and waits for Run to return. This
+// matters because Server.Run mutates the global runtime.Hook on entry
+// and restores it on exit; without waiting, sequential tests race on
+// that variable.
+func runServer(t *testing.T, srv *Server, closeTransports func()) func() {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = srv.Run(context.Background())
+	}()
+	return func() {
+		closeTransports()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatal("server did not stop within 3s")
+		}
+	}
+}
+
+// readUntil reads messages until one matching the predicate is seen.
+// Returns the matched payload and any earlier messages.
+func readUntil(t *testing.T, c *Transport, predicate func(map[string]interface{}) bool) map[string]interface{} {
+	t.Helper()
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for matching message")
+		default:
+		}
+		raw, err := c.ReadMessage()
+		if err != nil {
+			t.Fatalf("ReadMessage: %v", err)
+		}
+		var m map[string]interface{}
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if predicate(m) {
+			return m
+		}
+	}
+}
+
+func sendRequest(t *testing.T, c *Transport, seq int, command string, args interface{}) {
+	t.Helper()
+	req := map[string]interface{}{
+		"seq":     seq,
+		"type":    "request",
+		"command": command,
+	}
+	if args != nil {
+		raw, err := json.Marshal(args)
+		if err != nil {
+			t.Fatalf("encode args: %v", err)
+		}
+		req["arguments"] = json.RawMessage(raw)
+	}
+	if err := c.WriteMessage(req); err != nil {
+		t.Fatalf("WriteMessage: %v", err)
+	}
+}
+
+func newTestEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	core.Load(ns)
+	core.LoadInput(ns)
+	return ns
+}
+
+func TestServer_InitializeLaunchHandshake(t *testing.T) {
+	client, server, closer := pair()
+
+	ns := newTestEnv(t)
+	eval := func(_ context.Context, _ types.EnvType) error { return nil }
+
+	srv := NewServer(server, eval, ns)
+	stop := runServer(t, srv, closer)
+	defer stop()
+
+	sendRequest(t, client, 1, "initialize", map[string]interface{}{})
+	resp := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["type"] == "response" && m["command"] == "initialize"
+	})
+	if ok, _ := resp["success"].(bool); !ok {
+		t.Fatalf("initialize failed: %v", resp)
+	}
+
+	// initialized event arrives after the response
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["type"] == "event" && m["event"] == "initialized"
+	})
+
+	sendRequest(t, client, 2, "launch", map[string]interface{}{"stopOnEntry": false})
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["type"] == "response" && m["command"] == "launch"
+	})
+
+	sendRequest(t, client, 3, "configurationDone", nil)
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["type"] == "response" && m["command"] == "configurationDone"
+	})
+
+	// Empty eval → terminated event soon after.
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["type"] == "event" && m["event"] == "terminated"
+	})
+
+	sendRequest(t, client, 4, "disconnect", nil)
+}
+
+func TestServer_StopOnEntryAndContinue(t *testing.T) {
+	client, server, closer := pair()
+
+	ns := newTestEnv(t)
+	called := make(chan struct{}, 1)
+	eval := func(ctx context.Context, env types.EnvType) error {
+		_, err := evalSimple(ctx, env, "(do 1 2 3)")
+		called <- struct{}{}
+		return err
+	}
+
+	srv := NewServer(server, eval, ns)
+	stop := runServer(t, srv, closer)
+	defer stop()
+
+	sendRequest(t, client, 1, "initialize", nil)
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["event"] == "initialized"
+	})
+	sendRequest(t, client, 2, "launch", map[string]interface{}{"stopOnEntry": true})
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "launch" && m["type"] == "response"
+	})
+	sendRequest(t, client, 3, "configurationDone", nil)
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "configurationDone" && m["type"] == "response"
+	})
+
+	// stopOnEntry → first stopped event
+	stopped := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["event"] == "stopped"
+	})
+	body := stopped["body"].(map[string]interface{})
+	if body["reason"] != "entry" {
+		t.Fatalf("expected stopped reason=entry, got %v", body["reason"])
+	}
+
+	sendRequest(t, client, 4, "continue", map[string]interface{}{"threadId": 1})
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "continue" && m["type"] == "response"
+	})
+
+	select {
+	case <-called:
+	case <-time.After(3 * time.Second):
+		t.Fatal("eval did not finish after continue")
+	}
+
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["event"] == "terminated"
+	})
+	sendRequest(t, client, 5, "disconnect", nil)
+}

--- a/debugadapter/state.go
+++ b/debugadapter/state.go
@@ -1,0 +1,172 @@
+//go:build lispdebug
+
+package debugadapter
+
+import (
+	"path/filepath"
+	"sync"
+
+	"github.com/jig/lisp/runtime"
+	"github.com/jig/lisp/types"
+)
+
+// mode is the execution mode of the debuggee.
+type mode int
+
+const (
+	modeRunning mode = iota
+	modeStopOnEntry
+	modeStepOver
+	modeStepIn
+	modeStepOut
+	modePaused
+)
+
+// varRefKind is the discriminator for a variables reference entry.
+type varRefKind int
+
+const (
+	varRefScopeLocals varRefKind = iota
+	varRefValue
+)
+
+type varRef struct {
+	kind     varRefKind
+	frameIdx int           // for scope-locals
+	value    types.MalType // for value
+}
+
+// state holds the live debug session: mode, breakpoints, the thread
+// being debugged, and the variables reference table consulted by
+// `variables` requests.
+//
+// The mutex protects every field. The condition variable is used by the
+// EVAL goroutine (in the hook) to block while the session is paused; the
+// server goroutine signals it when the client asks to resume.
+type state struct {
+	mu   sync.Mutex
+	cond *sync.Cond
+
+	mode        mode
+	targetDepth int // for stepOver (entered at this depth) / stepOut
+
+	breakpoints map[string]map[int]bool // abs path → line → set
+
+	thread *runtime.Thread
+
+	server *Server
+
+	varRefs    map[int]varRef
+	nextVarRef int
+
+	stopOnEntry bool
+	disconnect  bool
+	exited      bool
+}
+
+func newState(s *Server) *state {
+	st := &state{
+		mode:        modeRunning,
+		breakpoints: map[string]map[int]bool{},
+		thread:      runtime.NewThread(),
+		server:      s,
+		varRefs:     map[int]varRef{},
+	}
+	st.cond = sync.NewCond(&st.mu)
+	return st
+}
+
+// setBreakpoints replaces all breakpoints for src.Path with lines.
+// Returns the verified Breakpoints array to send back to the client.
+func (s *state) setBreakpoints(src Source, requested []SourceBreakpoint) []Breakpoint {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	abs := absolutize(src.Path)
+	if abs == "" {
+		// Without a path we cannot match; mark all as unverified.
+		out := make([]Breakpoint, len(requested))
+		for i, bp := range requested {
+			out[i] = Breakpoint{Verified: false, Line: bp.Line, Source: src}
+		}
+		return out
+	}
+	lines := map[int]bool{}
+	out := make([]Breakpoint, len(requested))
+	for i, bp := range requested {
+		lines[bp.Line] = true
+		out[i] = Breakpoint{Verified: true, Line: bp.Line, Source: Source{Name: src.Name, Path: abs}}
+	}
+	s.breakpoints[abs] = lines
+	return out
+}
+
+// matchBreakpoint reports whether cursor is on a line with a registered
+// breakpoint.
+func (s *state) matchBreakpoint(cursor *types.Position) bool {
+	if cursor == nil || cursor.Module == nil {
+		return false
+	}
+	resolved := runtime.Modules.Resolve(*cursor.Module)
+	abs := absolutize(resolved)
+	if abs == "" {
+		return false
+	}
+	lines := s.breakpoints[abs]
+	if lines == nil {
+		return false
+	}
+	return lines[cursor.BeginRow]
+}
+
+// pauseAndWait sends a `stopped` event and blocks until the client
+// resumes. Caller must hold s.mu.
+func (s *state) pauseAndWait(reason, description string) {
+	s.mode = modePaused
+	s.varRefs = map[int]varRef{}
+	s.nextVarRef = 0
+	body := StoppedEventBody{
+		Reason:            reason,
+		Description:       description,
+		ThreadID:          1,
+		AllThreadsStopped: true,
+	}
+	go s.server.sendEvent("stopped", body)
+	for s.mode == modePaused && !s.disconnect {
+		s.cond.Wait()
+	}
+}
+
+// resume wakes the EVAL goroutine after switching to the given mode.
+// Caller must hold s.mu.
+func (s *state) resume(m mode, depth int) {
+	s.mode = m
+	s.targetDepth = depth
+	s.cond.Signal()
+	go s.server.sendEvent("continued", ContinuedEventBody{
+		ThreadID:            1,
+		AllThreadsContinued: true,
+	})
+}
+
+// registerVarRef stores v in the references table and returns a fresh
+// reference id. Caller must hold s.mu. Returns 0 for non-composite
+// values that have no expandable children.
+func (s *state) registerVarRef(v varRef) int {
+	s.nextVarRef++
+	s.varRefs[s.nextVarRef] = v
+	return s.nextVarRef
+}
+
+func absolutize(p string) string {
+	if p == "" {
+		return ""
+	}
+	if filepath.IsAbs(p) {
+		return p
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return p
+	}
+	return abs
+}

--- a/debugadapter/transport.go
+++ b/debugadapter/transport.go
@@ -1,0 +1,84 @@
+//go:build lispdebug
+
+package debugadapter
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Transport is the bidirectional message channel between the DAP client
+// and the server. Messages are framed with `Content-Length` headers, the
+// same convention used by LSP and DAP.
+type Transport struct {
+	r       *bufio.Reader
+	w       io.Writer
+	closer  io.Closer
+	writeMu sync.Mutex
+}
+
+// NewTransport wraps a reader/writer pair. closer (optional) is called by
+// Close to tear down the underlying connection.
+func NewTransport(r io.Reader, w io.Writer, closer io.Closer) *Transport {
+	return &Transport{r: bufio.NewReader(r), w: w, closer: closer}
+}
+
+// ReadMessage reads one DAP message and returns its raw JSON payload.
+func (t *Transport) ReadMessage() ([]byte, error) {
+	var contentLength int
+	for {
+		line, err := t.r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		if strings.HasPrefix(line, "Content-Length:") {
+			n, err := strconv.Atoi(strings.TrimSpace(line[len("Content-Length:"):]))
+			if err != nil {
+				return nil, fmt.Errorf("invalid Content-Length: %w", err)
+			}
+			contentLength = n
+		}
+	}
+	if contentLength <= 0 {
+		return nil, errors.New("missing or invalid Content-Length header")
+	}
+	buf := make([]byte, contentLength)
+	if _, err := io.ReadFull(t.r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// WriteMessage marshals v as JSON and writes it framed.
+func (t *Transport) WriteMessage(v interface{}) error {
+	payload, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(payload))
+	if _, err := t.w.Write([]byte(header)); err != nil {
+		return err
+	}
+	_, err = t.w.Write(payload)
+	return err
+}
+
+// Close releases any underlying connection.
+func (t *Transport) Close() error {
+	if t.closer == nil {
+		return nil
+	}
+	return t.closer.Close()
+}

--- a/mal.go
+++ b/mal.go
@@ -336,6 +336,19 @@ func EVAL(ctx context.Context, ast MalType, env EnvType) (res MalType, e error) 
 	isMacro := is_macro_call(ast, env)
 	functionName := extractFunctionName(ast, isMacro)
 
+	// Live execution stack (debug builds only). In release builds the
+	// helpers are no-ops and `runtime.Enabled` is the compile-time
+	// constant `false`, so the whole block is dead code.
+	var frame *runtime.Frame
+	if runtime.Enabled {
+		frame = runtime.MakeFrame(functionName, ast, env, lisperror.GetPosition(ast))
+		if runtime.PushFrame(ctx, frame) {
+			defer runtime.PopFrame(ctx)
+		} else {
+			frame = nil
+		}
+	}
+
 	// Add stack frame to any error that propagates out of this EVAL call
 	defer func() {
 		if e != nil {
@@ -358,6 +371,7 @@ func EVAL(ctx context.Context, ast MalType, env EnvType) (res MalType, e error) 
 		// the compile-time constant `false` (release build), the entire
 		// branch is dead code and the compiler removes it.
 		if runtime.Enabled {
+			runtime.UpdateFrame(frame, ast, env, lisperror.GetPosition(ast))
 			if DebugEvalEnabled {
 				installLegacyDebugHook()
 			}

--- a/mal_stack_test.go
+++ b/mal_stack_test.go
@@ -1,0 +1,115 @@
+//go:build lispdebug
+
+package lisp
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core"
+	"github.com/jig/lisp/runtime"
+	"github.com/jig/lisp/types"
+)
+
+// recordingStackHook captures the maximum observed stack depth and a
+// snapshot of frames each time OnEval fires.
+type recordingStackHook struct {
+	mu        sync.Mutex
+	maxDepth  int
+	snapshots [][]runtime.Frame
+}
+
+func (h *recordingStackHook) OnEval(ctx context.Context, _ runtime.EvalEvent) error {
+	t := runtime.ThreadFromContext(ctx)
+	if t == nil {
+		return nil
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if d := t.Depth(); d > h.maxDepth {
+		h.maxDepth = d
+	}
+	h.snapshots = append(h.snapshots, t.Snapshot())
+	return nil
+}
+
+func TestThreadGrowsAndShrinksWithEVAL(t *testing.T) {
+	prev := runtime.Hook
+	t.Cleanup(func() { runtime.Hook = prev })
+
+	h := &recordingStackHook{}
+	runtime.Hook = h
+
+	thread := runtime.NewThread()
+	ctx := runtime.WithThread(context.Background(), thread)
+
+	ns := env.NewEnv()
+	core.Load(ns)
+	core.LoadInput(ns)
+	if _, err := REPL(ctx, ns, core.HeaderBasic(), nil); err != nil {
+		t.Fatalf("preamble: %v", err)
+	}
+
+	src := "(let [a 1 b 2] (+ a b))"
+	ast, err := READ(src, types.NewCursorFile("stack-test"), ns)
+	if err != nil {
+		t.Fatalf("READ: %v", err)
+	}
+	if _, err := EVAL(ctx, ast, ns); err != nil {
+		t.Fatalf("EVAL: %v", err)
+	}
+
+	if h.maxDepth < 2 {
+		t.Fatalf("expected at least depth 2 (let + body), got %d", h.maxDepth)
+	}
+	if got := thread.Depth(); got != 0 {
+		t.Fatalf("expected stack to be empty after EVAL, got depth %d", got)
+	}
+}
+
+func TestFrameMutatesAcrossTCO(t *testing.T) {
+	prev := runtime.Hook
+	t.Cleanup(func() { runtime.Hook = prev })
+
+	h := &recordingStackHook{}
+	runtime.Hook = h
+
+	thread := runtime.NewThread()
+	ctx := runtime.WithThread(context.Background(), thread)
+
+	ns := env.NewEnv()
+	core.Load(ns)
+	core.LoadInput(ns)
+	if _, err := REPL(ctx, ns, core.HeaderBasic(), nil); err != nil {
+		t.Fatalf("preamble: %v", err)
+	}
+
+	// `do` triggers TCO: the inner forms reuse the same EVAL frame.
+	src := "(do 1 2 3 4 5)"
+	ast, err := READ(src, types.NewCursorFile("tco-test"), ns)
+	if err != nil {
+		t.Fatalf("READ: %v", err)
+	}
+	if _, err := EVAL(ctx, ast, ns); err != nil {
+		t.Fatalf("EVAL: %v", err)
+	}
+
+	// We expect at least one snapshot whose top frame's AST is not the
+	// initial (do ...) form — TCO mutated it.
+	var sawMutation bool
+	for _, snap := range h.snapshots {
+		if len(snap) == 0 {
+			continue
+		}
+		top := snap[len(snap)-1]
+		if _, ok := top.AST.(types.List); !ok {
+			sawMutation = true
+			break
+		}
+	}
+	if !sawMutation {
+		t.Fatal("expected TCO loop to mutate the top frame's AST to a non-list value")
+	}
+}

--- a/runtime/active_debug.go
+++ b/runtime/active_debug.go
@@ -5,6 +5,7 @@ package runtime
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/jig/lisp/printer"
 	"github.com/jig/lisp/types"
@@ -53,3 +54,184 @@ func (PrintEvalHook) OnEval(_ context.Context, ev EvalEvent) error {
 	}
 	return nil
 }
+
+// Frame is a single entry in the live execution stack.
+//
+// EVAL pushes a Frame on entry and mutates AST/Env/Cursor as the TCO loop
+// progresses. A Frame is popped when the EVAL call returns.
+type Frame struct {
+	FunctionName string
+	AST          types.MalType
+	Env          types.EnvType
+	Cursor       *types.Position
+}
+
+// Thread is the live call stack of a single Lisp evaluation goroutine.
+//
+// Operations are safe for concurrent use, but a Thread is conceptually
+// owned by one goroutine (the one running EVAL). External readers
+// (e.g. the DAP server) snapshot it under the mutex.
+type Thread struct {
+	mu     sync.Mutex
+	frames []*Frame
+}
+
+// NewThread returns an empty Thread.
+func NewThread() *Thread { return &Thread{} }
+
+// MakeFrame allocates a Frame. Helper used from EVAL so the release-build
+// stub can hide the Frame layout entirely.
+func MakeFrame(functionName string, ast types.MalType, env types.EnvType, cursor *types.Position) *Frame {
+	return &Frame{
+		FunctionName: functionName,
+		AST:          ast,
+		Env:          env,
+		Cursor:       cursor,
+	}
+}
+
+// UpdateFrame mutates an existing Frame in place. Used by the TCO loop in
+// EVAL to keep the top frame in sync with the form currently being
+// evaluated.
+func UpdateFrame(f *Frame, ast types.MalType, env types.EnvType, cursor *types.Position) {
+	if f == nil {
+		return
+	}
+	f.AST = ast
+	f.Env = env
+	f.Cursor = cursor
+}
+
+// PushFrame pushes a Frame onto the Thread carried by ctx, if any.
+// Reports whether a Thread was found.
+func PushFrame(ctx context.Context, f *Frame) bool {
+	t := ThreadFromContext(ctx)
+	if t == nil {
+		return false
+	}
+	t.Push(f)
+	return true
+}
+
+// PopFrame pops the top Frame from the Thread carried by ctx, if any.
+func PopFrame(ctx context.Context) {
+	if t := ThreadFromContext(ctx); t != nil {
+		t.Pop()
+	}
+}
+
+// Push appends a Frame to the stack.
+func (t *Thread) Push(f *Frame) {
+	t.mu.Lock()
+	t.frames = append(t.frames, f)
+	t.mu.Unlock()
+}
+
+// Pop removes the top frame. Returns nil if empty.
+func (t *Thread) Pop() *Frame {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	n := len(t.frames)
+	if n == 0 {
+		return nil
+	}
+	f := t.frames[n-1]
+	t.frames = t.frames[:n-1]
+	return f
+}
+
+// Depth returns the number of frames on the stack.
+func (t *Thread) Depth() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.frames)
+}
+
+// Top returns the deepest frame (or nil if empty). The pointer is the
+// live Frame; readers should not mutate its fields. Use Snapshot for a
+// stable copy.
+func (t *Thread) Top() *Frame {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	n := len(t.frames)
+	if n == 0 {
+		return nil
+	}
+	return t.frames[n-1]
+}
+
+// Snapshot returns a value copy of all frames, deepest last. The copy is
+// stable for the caller even if EVAL keeps mutating its frames.
+func (t *Thread) Snapshot() []Frame {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]Frame, len(t.frames))
+	for i, f := range t.frames {
+		out[i] = *f
+	}
+	return out
+}
+
+type ctxKey struct{}
+
+var threadKey ctxKey
+
+// WithThread returns a context carrying the given Thread. EVAL calls
+// invoked with this context push/pop frames on it.
+func WithThread(ctx context.Context, t *Thread) context.Context {
+	return context.WithValue(ctx, threadKey, t)
+}
+
+// ThreadFromContext returns the Thread carried by ctx, or nil if absent.
+func ThreadFromContext(ctx context.Context) *Thread {
+	if ctx == nil {
+		return nil
+	}
+	t, _ := ctx.Value(threadKey).(*Thread)
+	return t
+}
+
+// ModuleResolver maps Lisp module names (as carried in Position.Module)
+// to absolute filesystem paths. The DAP server consumes this to populate
+// `source.path` on stack frames and to match `setBreakpoints` requests
+// against incoming Cursors.
+type ModuleResolver struct {
+	mu    sync.RWMutex
+	paths map[string]string
+}
+
+// Register associates a module identifier with an absolute path.
+// Both arguments are stored verbatim; the caller is responsible for
+// resolving relative paths beforehand.
+func (r *ModuleResolver) Register(module, absPath string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.paths == nil {
+		r.paths = map[string]string{}
+	}
+	r.paths[module] = absPath
+}
+
+// Resolve returns the registered absolute path for module, or the
+// module name itself when no mapping exists. This makes the resolver
+// safe to consult unconditionally.
+func (r *ModuleResolver) Resolve(module string) string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if p, ok := r.paths[module]; ok {
+		return p
+	}
+	return module
+}
+
+// Lookup returns the registered absolute path for module and a boolean
+// reporting whether a mapping was found.
+func (r *ModuleResolver) Lookup(module string) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	p, ok := r.paths[module]
+	return p, ok
+}
+
+// Modules is the global module-to-path resolver.
+var Modules = &ModuleResolver{}

--- a/runtime/active_release.go
+++ b/runtime/active_release.go
@@ -18,3 +18,23 @@ const Enabled = false
 func Dispatch(_ context.Context, _ types.MalType, _ types.EnvType, _ *types.Position) error {
 	return nil
 }
+
+// Frame is a stub in release builds. The Frame contents only exist in
+// `lispdebug` builds; this empty struct keeps consumer code (mal.go,
+// debugadapter) compilable when wrapped in `if runtime.Enabled { ... }`.
+type Frame struct{}
+
+// MakeFrame returns nil in release builds. Dead code under
+// `if runtime.Enabled`.
+func MakeFrame(_ string, _ types.MalType, _ types.EnvType, _ *types.Position) *Frame {
+	return nil
+}
+
+// UpdateFrame is a no-op in release builds.
+func UpdateFrame(_ *Frame, _ types.MalType, _ types.EnvType, _ *types.Position) {}
+
+// PushFrame is a no-op in release builds.
+func PushFrame(_ context.Context, _ *Frame) bool { return false }
+
+// PopFrame is a no-op in release builds.
+func PopFrame(_ context.Context) {}


### PR DESCRIPTION
## Summary

Phase B of the Etapa 2 plan: a Debug Adapter Protocol server compiled
into `lispdebug` builds. Combined with PR1's EvalHook foundation, this
lets a VSCode (or any DAP client) drive a Lisp debug session: launch a
script, set breakpoints, inspect the call stack and locals, and step.

Three commits for incremental review:

1. **runtime: live stack + modules** (A2 + A3)
   - `runtime.Frame` / `runtime.Thread` propagated via ctx; EVAL pushes
     on entry, mutates each TCO iteration, pops on exit. Release stubs
     keep the `if runtime.Enabled` guard dead code.
   - `runtime.ModuleResolver` mapping `Position.Module` → absolute path
     for DAP `source.path` and breakpoint matching.

2. **debugadapter: DAP server**
   - `protocol.go` message types, `transport.go` Content-Length framing,
     `state.go` session state with pause/resume cond var, `hook.go`
     StepHook implementing `runtime.EvalHook`, `server.go` request
     dispatch + eval goroutine.
   - Implements: initialize, launch, setBreakpoints, configurationDone,
     threads, stackTrace, scopes, variables, continue, next, stepIn,
     stepOut, pause, disconnect, terminate.
   - Events: initialized, stopped, continued, output, exited,
     terminated.
   - Composite values (List/Vector/HashMap/Set) exposed via lazy
     `variablesReference` so the client can expand them on demand.

3. **command: --dap / --dap-listen**
   - `--dap` runs DAP on stdio (the path VSCode uses).
   - `--dap-listen HOST:PORT` runs DAP on a TCP listener (raspi remote
     case from CLAUDE.md).
   - Both gated by `lispdebug`; release returns an explicit error.
   - `ExecuteFile` now registers the script's absolute path with
     `runtime.Modules`.

## Build

```sh
go build -tags lispdebug ./cmd/lisp
./lisp --dap script.lisp           # stdio
./lisp --dap-listen :5678 script.lisp
```

In release builds (`go build ./cmd/lisp`) the flags fail with
"--dap requires a debug build: rebuild with -tags lispdebug" — same
shape as --debug.

## Out of scope (PR3, PR4, PR5)

- VSCode extension (PR3)
- LSP server + def cursors (PR4)
- VSCode LSP client + docs (PR5)

Conditional breakpoints, watch expressions, function breakpoints, and
multi-thread debugging stay deferred to Etapa 3.

## Test plan

- [x] `go build ./...` and `go build -tags lispdebug ./...`
- [x] `go vet ./...` and `go vet -tags lispdebug ./...`
- [x] `go test ./...` — all green
- [x] `go test -tags lispdebug ./...` — all green, including new
  `mal_stack_test.go` (TCO frame mutation) and
  `debugadapter/server_test.go` (initialize/launch handshake,
  stopOnEntry → continue)
- [x] `go test -race ./...` and
  `go test -race -tags lispdebug ./...` — only the pre-existing
  `lib/concurrent` race documented in PR #44 (out of scope)
- [x] Smoke release: `./lisp --dap /tmp/foo.lisp` →
  "--dap requires a debug build" and exits non-zero
- [x] `gofmt -l .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)