### PR TITLE
fix(dap): step-over treating TCO continuations as new calls

### DIFF
--- a/debugadapter/hook.go
+++ b/debugadapter/hook.go
@@ -27,8 +27,10 @@ func (h *StepHook) OnEval(ctx context.Context, ev runtime.EvalEvent) error {
 
 	t := runtime.ThreadFromContext(ctx)
 	depth := 0
+	var top *runtime.Frame
 	if t != nil {
 		depth = t.Depth()
+		top = t.Top()
 	}
 
 	// Breakpoint check first: a breakpoint always wins over step mode.
@@ -37,12 +39,24 @@ func (h *StepHook) OnEval(ctx context.Context, ev runtime.EvalEvent) error {
 		return nil
 	}
 
+	// EVAL's TCO loop calls OnEval repeatedly on the *same* frame for
+	// constructs like do/let/if/fn-body. A "step" should only react to a
+	// genuinely new call (push) or return to a different frame (pop), so
+	// we ignore re-entries on the frame we were on at step time.
+	sameFrame := top != nil && top == s.stepFrame
+
 	switch s.mode {
 	case modeStopOnEntry:
 		s.pauseAndWait("entry", "")
 	case modeStepIn:
+		if sameFrame {
+			break
+		}
 		s.pauseAndWait("step", "")
 	case modeStepOver:
+		if sameFrame {
+			break
+		}
 		if depth <= s.targetDepth {
 			s.pauseAndWait("step", "")
 		}

--- a/debugadapter/server_test.go
+++ b/debugadapter/server_test.go
@@ -142,6 +142,64 @@ func TestServer_InitializeLaunchHandshake(t *testing.T) {
 	sendRequest(t, client, 4, "disconnect", nil)
 }
 
+func TestServer_StepOverSkipsTCOContinuation(t *testing.T) {
+	client, server, closer := pair()
+
+	ns := newTestEnv(t)
+	called := make(chan struct{}, 1)
+	eval := func(ctx context.Context, env types.EnvType) error {
+		_, err := evalSimple(ctx, env, "(do 1 2 3 4)")
+		called <- struct{}{}
+		return err
+	}
+
+	srv := NewServer(server, eval, ns)
+	stop := runServer(t, srv, closer)
+	defer stop()
+
+	sendRequest(t, client, 1, "initialize", nil)
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["event"] == "initialized"
+	})
+	sendRequest(t, client, 2, "launch", map[string]interface{}{"stopOnEntry": true})
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "launch" && m["type"] == "response"
+	})
+	sendRequest(t, client, 3, "configurationDone", nil)
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "configurationDone" && m["type"] == "response"
+	})
+
+	// First stop: entry pause on the outer (do …) form.
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["event"] == "stopped"
+	})
+
+	// Step over should walk past every TCO continuation of the outer
+	// `do` and land at the next *new* call. Since `(do 1 2 3 4)` has
+	// only literal subforms (no nested calls), it should run to
+	// completion without another stop.
+	sendRequest(t, client, 4, "next", map[string]interface{}{"threadId": 1})
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "next" && m["type"] == "response"
+	})
+
+	// Expect terminated without an intervening stopped.
+	got := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["event"] == "stopped" || m["event"] == "terminated"
+	})
+	if got["event"] != "terminated" {
+		t.Fatalf("expected terminated next, got another stopped: %v", got)
+	}
+
+	select {
+	case <-called:
+	case <-time.After(3 * time.Second):
+		t.Fatal("eval did not finish")
+	}
+	sendRequest(t, client, 5, "disconnect", nil)
+}
+
 func TestServer_StopOnEntryAndContinue(t *testing.T) {
 	client, server, closer := pair()
 

--- a/debugadapter/state.go
+++ b/debugadapter/state.go
@@ -48,7 +48,11 @@ type state struct {
 	cond *sync.Cond
 
 	mode        mode
-	targetDepth int // for stepOver (entered at this depth) / stepOut
+	targetDepth int            // for stepOver (entered at this depth) / stepOut
+	stepFrame   *runtime.Frame // top frame at the moment the step request arrived;
+	//                            EVAL's TCO loop re-enters OnEval on the same frame,
+	//                            so we use this to distinguish a "new call" from a
+	//                            "next iteration of the same call".
 
 	breakpoints map[string]map[int]bool // abs path → line → set
 
@@ -137,10 +141,13 @@ func (s *state) pauseAndWait(reason, description string) {
 }
 
 // resume wakes the EVAL goroutine after switching to the given mode.
+// stepFrame snapshots the top frame so the hook can ignore TCO loop
+// re-entries on the same frame and only react to a real new call.
 // Caller must hold s.mu.
 func (s *state) resume(m mode, depth int) {
 	s.mode = m
 	s.targetDepth = depth
+	s.stepFrame = s.thread.Top()
 	s.cond.Signal()
 	go s.server.sendEvent("continued", ContinuedEventBody{
 		ThreadID:            1,

--- a/tools/vscode-lisp/package.json
+++ b/tools/vscode-lisp/package.json
@@ -18,7 +18,8 @@
   ],
   "main": "./out/extension.js",
   "activationEvents": [
-    "onDebug",
+    "onDebugResolve:lisp",
+    "onDebugDynamicConfigurations:lisp",
     "onLanguage:lisp"
   ],
   "contributes": {


### PR DESCRIPTION
## Summary

Two bugs hit while smoke-testing the debugger from VSCode:

### 1) F10 acted like F11 (step-over entered every subform)

EVAL's TCO loop reuses the same Frame for `do`/`let`/`if`/fn-body and
re-enters the hook on the same `Top()` pointer. The PR2 step
controller paused whenever `depth <= targetDepth`, so it fired on
every TCO iteration — turning step-over into step-in.

Fix: snapshot the top frame at step time. Re-entries on that same
frame are TCO continuations and are skipped.

```
step-over: pause if Top() != stepFrame AND depth <= target
step-in:   pause if Top() != stepFrame
step-out:  pause if depth < target            (unaffected)
```

New regression test `TestServer_StepOverSkipsTCOContinuation` runs
`(do 1 2 3 4)` with stopOnEntry, sends one `next`, and asserts the
program terminates without pausing again.

### 2) VSCode reported "Configured debug type 'lisp' is not supported"

`tools/vscode-lisp/package.json` had `activationEvents: ["onDebug",
"onLanguage:lisp"]`. `onDebug` activates *after* VSCode validates the
launch.json, which is too late. Switched to `onDebugResolve:lisp` and
`onDebugDynamicConfigurations:lisp` so the extension is up before
launch validation runs.

Re-package and re-install:

```sh
cd tools/vscode-lisp
npm run compile
npx @vscode/vsce package
code --install-extension vscode-lisp-0.1.0.vsix --force
```

## Test plan

- [x] `go build ./...` and `go build -tags lispdebug ./...`
- [x] `go test -tags lispdebug ./...` — all green, including new regression
- [x] `go vet ./...` and `go vet -tags lispdebug ./...`
- [x] `gofmt -l .` clean
- [ ] Manual: F5 in VSCode resolves debug type, breakpoint pauses,
      F10 steps over the form, F11 steps in. (Reviewer to verify.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)