### PR TITLE
feat(coreextended): add common numeric and sequence prelude functions

### DIFF
--- a/lib/coreextented/coreextended_test.go
+++ b/lib/coreextented/coreextended_test.go
@@ -1,0 +1,87 @@
+package coreextented_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/concurrent/nsconcurrent"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/coreextented/nscoreextended"
+	"github.com/jig/lisp/types"
+)
+
+func newEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	for _, load := range []func(types.EnvType) error{
+		nscore.Load,         // core builtins + basic header (defn, cond, …)
+		nscore.LoadInput,    // load-file (used by the header's load-file-once)
+		nsconcurrent.Load,   // atom/swap! (used by the header's gensym/memoize)
+		nscoreextended.Load, // the header under test
+	} {
+		if err := load(ns); err != nil {
+			t.Fatalf("load: %v", err)
+		}
+	}
+	return ns
+}
+
+// run evaluates src and returns its printed form (REPL returns the printed
+// representation, which is convenient for asserting on results).
+func run(t *testing.T, ns types.EnvType, src string) string {
+	t.Helper()
+	res, err := lisp.REPL(context.Background(), ns, src, types.NewCursorFile("test"))
+	if err != nil {
+		t.Fatalf("eval %q: %v", src, err)
+	}
+	s, ok := res.(string)
+	if !ok {
+		t.Fatalf("REPL returned %T, want printed string", res)
+	}
+	return s
+}
+
+func TestPrelude(t *testing.T) {
+	ns := newEnv(t)
+	cases := []struct{ src, want string }{
+		// quot / rem / mod, including the negative cases where they diverge
+		{"(quot 17 5)", "3"},
+		{"(quot -17 5)", "-3"},
+		{"(rem 17 5)", "2"},
+		{"(rem -17 5)", "-2"},
+		{"(mod 17 5)", "2"},
+		{"(mod -17 5)", "3"},
+		{"(mod 17 -5)", "-3"},
+		{"(mod 6 3)", "0"},
+		// abs / min / max
+		{"(abs -4)", "4"},
+		{"(abs 4)", "4"},
+		{"(min 3 1 2)", "1"},
+		{"(max 3 1 2)", "3"},
+		{"(min 5)", "5"},
+		// predicates
+		{"(pos? 1)", "true"},
+		{"(pos? 0)", "false"},
+		{"(neg? -1)", "true"},
+		{"(even? 4)", "true"},
+		{"(even? 0)", "true"},
+		{"(odd? 3)", "true"},
+		{"(odd? -3)", "true"},
+		{"(even? -4)", "true"},
+		// sequence filters
+		{"(filter even? [1 2 3 4])", "(2 4)"},
+		{"(filter even? (list 1 2 3 4))", "(2 4)"},
+		{"(remove even? [1 2 3 4])", "(1 3)"},
+		{"(take-while (fn [x] (< x 3)) [1 2 3 1])", "(1 2)"},
+		{"(take-while (fn [x] (< x 3)) [])", "()"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.src, func(t *testing.T) {
+			if got := run(t, ns, tc.src); got != tc.want {
+				t.Errorf("%s = %s, want %s", tc.src, got, tc.want)
+			}
+		})
+	}
+}

--- a/lib/coreextented/header-coreextended.lisp
+++ b/lib/coreextented/header-coreextended.lisp
@@ -484,6 +484,91 @@
                                   (if ~condvar (and ~@(rest xs)) ~condvar)))))
       {:doc "Evaluates its arguments in order, returning the first falsey one, or the last (true with none)."}))
 
+;;; Arithmetic
+  ;; Integer division helpers, absolute value and min/max. Integer `/`
+  ;; already truncates toward zero, so quot is just a named alias.
+
+  (defn quot
+    "Integer quotient of a divided by b, truncated toward zero."
+    [a b]
+    (/ a b))
+
+  (defn rem
+    "Remainder of (quot a b); the sign follows the dividend a."
+    [a b]
+    (- a (* b (/ a b))))
+
+  (defn mod
+    "Modulo of a by b; the sign follows the divisor b."
+    [a b]
+    (let [r (rem a b)]
+      (if (= r 0)
+        0
+        (if (if (< r 0) (< b 0) (> b 0)) ; r and b share sign?
+          r
+          (+ r b)))))
+
+  (defn abs
+    "Absolute value of n."
+    [n]
+    (if (< n 0) (- 0 n) n))
+
+  (defn min
+    "Smallest of one or more numbers."
+    [a & more]
+    (reduce (fn [m x] (if (< x m) x m)) a more))
+
+  (defn max
+    "Largest of one or more numbers."
+    [a & more]
+    (reduce (fn [m x] (if (> x m) x m)) a more))
+
+;;; Numeric Predicates
+
+  (defn pos?
+    "Whether n is greater than 0."
+    [n]
+    (> n 0))
+
+  (defn neg?
+    "Whether n is less than 0."
+    [n]
+    (< n 0))
+
+  (defn even?
+    "Whether n is even."
+    [n]
+    (= 0 (mod n 2)))
+
+  (defn odd?
+    "Whether n is odd."
+    [n]
+    (not (even? n)))
+
+;;; Sequence Filters
+  ;; Eager filtering; the lazy counterparts live in lib/lazy.
+
+  (defn filter
+    "List of the items in xs for which (pred x) is truthy."
+    [pred xs]
+    (cond (empty? xs)       ()
+          (pred (first xs)) (cons (first xs) (filter pred (rest xs)))
+          true              (filter pred (rest xs))))
+
+  (defn remove
+    "List of the items in xs for which (pred x) is falsy."
+    [pred xs]
+    (filter (fn [x] (not (pred x))) xs))
+
+  (defn take-while
+    "Leading items of xs while (pred x) is truthy."
+    [pred xs]
+    (if (empty? xs)
+      ()
+      (if (pred (first xs))
+        (cons (first xs) (take-while pred (rest xs)))
+        ())))
+
 ;;; Load File Once
   ;; This file is normally loaded with "load-file", so it needs a
   ;; different mechanism to neutralize multiple inclusions of


### PR DESCRIPTION
Fills gaps in jig/lisp's standard vocabulary, all in **pure lisp** in `header-coreextended.lisp`:

- **arithmetic:** `quot`, `rem`, `mod`, `abs`, `min`, `max`
- **numeric predicates:** `pos?`, `neg?`, `even?`, `odd?`
- **eager sequence filters:** `filter`, `remove`, `take-while`

### Notes
- Integer `/` already truncates toward zero, so `quot` aliases it. `rem`'s sign follows the dividend and `mod`'s follows the divisor — they diverge only for negatives (`(rem -17 5)` → -2, `(mod -17 5)` → 3, `(mod 17 -5)` → -3), all covered by tests.
- `filter`/`remove`/`take-while` return lists (matching `map`) and are written recursively in the style of the existing `every?`/`some`.
- The eager filters complement the lazy versions in `lib/lazy` (separate branch).

### Testing
New `lib/coreextented/coreextended_test.go` covers all of the above, including the negative-operand cases where `quot`/`rem`/`mod` differ. `go test ./...`, `go vet` and `gofmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)