### PR TITLE
feat(lazy): add lazy sequence namespace

### DIFF
--- a/cmd/lisp/main.go
+++ b/cmd/lisp/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jig/lisp/lib/concurrent/nsconcurrent"
 	"github.com/jig/lisp/lib/core/nscore"
 	"github.com/jig/lisp/lib/coreextented/nscoreextended"
+	"github.com/jig/lisp/lib/lazy/nslazy"
 	"github.com/jig/lisp/lib/require/nsrequire"
 	"github.com/jig/lisp/lib/system/nssystem"
 	"github.com/jig/lisp/types"
@@ -27,6 +28,7 @@ func main() {
 		{"command line args", nscore.LoadCmdLineArgs(command.PreParseArgs(os.Args))},
 		{"concurrent", nsconcurrent.Load},
 		{"core mal extended", nscoreextended.Load},
+		{"lazy", nslazy.Load},
 		{"require", nsrequire.Load("lisp")},
 		{"assert", nsassert.Load},
 		{"system", nssystem.Load},

--- a/lib/lazy/README.md
+++ b/lib/lazy/README.md
@@ -1,0 +1,96 @@
+# lib/lazy — lazy sequences for jig/lisp
+
+Lazy sequences produce their elements **on demand** and memoise them, so they
+can be infinite and traversed more than once cheaply. This makes idioms like
+"the first 5 primes", "iterate until stable" or "take from an endless stream"
+natural, without computing more than you consume.
+
+The namespace is **self-contained**: producers and transformers return an
+opaque `lazy-seq`; consumers walk it; `realize` forces a finite one into a
+vector so the rest of core can work on the result. Any list or vector is
+accepted wherever a `lazy-seq` is, so eager data flows in freely.
+
+## Loading
+
+`cmd/lisp` loads it by default. To embed it:
+
+```go
+import "github.com/jig/lisp/lib/lazy/nslazy"
+
+nslazy.Load(ns) // registers the builtins; implemented entirely in Go
+```
+
+## Example
+
+```clojure
+;; the first 5 numbers > 3 from squaring the naturals, computed lazily
+(realize
+  (lazy-take 5
+    (lazy-filter (fn [x] (> x 3))
+      (lazy-map (fn [x] (* x x)) (lazy-range)))))
+;; => [4 9 16 25 36]
+
+;; powers of two, on demand
+(realize (lazy-take 6 (lazy-iterate (fn [x] (* x 2)) 1)))
+;; => [1 2 4 8 16 32]
+```
+
+`(lazy-range)` with no arguments is **infinite** — nothing runs until a
+consumer pulls elements, and only as many as asked for are ever computed.
+
+## Operations
+
+### Producers (return a lazy-seq)
+
+| Form | Meaning |
+|------|---------|
+| `(lazy-range)` | 0, 1, 2, … (infinite) |
+| `(lazy-range end)` | 0 … end-1 |
+| `(lazy-range start end)` | start … end-1 |
+| `(lazy-range start end step)` | start, start+step, … |
+| `(lazy-iterate f x)` | x, (f x), (f (f x)), … (infinite) |
+| `(lazy-repeat x)` | x, x, x, … (infinite) |
+| `(lazy-repeat n x)` | n copies of x |
+| `(lazy-cycle coll)` | coll's elements, forever |
+
+### Transformers (lazy-seq → lazy-seq)
+
+| Form | Meaning |
+|------|---------|
+| `(lazy-map f coll)` | (f x) for each x |
+| `(lazy-filter pred coll)` | items where `(pred x)` is truthy |
+| `(lazy-remove pred coll)` | items where `(pred x)` is falsy |
+| `(lazy-take n coll)` | first n items |
+| `(lazy-drop n coll)` | all but the first n |
+| `(lazy-take-while pred coll)` | leading run while `(pred x)` is truthy |
+| `(lazy-drop-while pred coll)` | the rest after that leading run |
+
+### Consumers and bridge
+
+| Form | Meaning |
+|------|---------|
+| `(lazy-first coll)` | first element, or `nil` if empty |
+| `(lazy-rest coll)` | a lazy-seq of everything after the first |
+| `(lazy-nth coll n)` | the nth element (forces up to n) |
+| `(lazy-reduce f init coll)` | left fold, forcing coll |
+| `(realize coll)` | forces a **finite** lazy-seq into a vector |
+| `(lazy-seq coll)` | views a list/vector as a lazy-seq |
+| `(lazy-seq? x)` | whether x is a lazy-seq |
+
+## Notes and limits
+
+- **This namespace is a separate vocabulary.** `lazy-*` operations know about
+  lazy sequences; the core `first`/`rest`/`map`/`take` do not. Cross back with
+  `realize` (lazy → vector) and `lazy-seq` (vector/list → lazy). A future
+  change could make the core seq functions lazy-aware; it would only *add*
+  interop, not change anything here.
+- **`realize` must be given a finite sequence.** On an infinite one it never
+  returns — `lazy-take` (or `lazy-take-while`) first. It does honour context
+  cancellation, so a cancelled evaluation stops it.
+- **Memoised.** Each element is computed at most once, even across repeated
+  traversals of the same lazy-seq.
+- **Errors are lazy too.** If a mapping/predicate function throws, the error
+  surfaces when that element is forced (by a consumer), not when the pipeline
+  is built.
+- A lazy-seq prints as `«lazy-seq»`; it is never forced just to be printed, so
+  printing an infinite sequence is safe.

--- a/lib/lazy/lazy.go
+++ b/lib/lazy/lazy.go
@@ -1,0 +1,516 @@
+// Package lazy adds lazy sequences to jig/lisp. A lazy sequence produces its
+// elements on demand and memoises them, so it can be infinite (lazy-range,
+// lazy-iterate, lazy-repeat, lazy-cycle) and re-traversed cheaply.
+//
+// The namespace is self-contained: producers and transformers return an
+// opaque lazy-seq, and consumers (lazy-first, lazy-rest, lazy-nth,
+// lazy-reduce) walk it. realize forces a finite lazy-seq into a vector so the
+// rest of core can work on the result. Any list or vector is accepted
+// wherever a lazy-seq is, so eager data flows in freely.
+package lazy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/jig/lisp/lib/call"
+	. "github.com/jig/lisp/types"
+)
+
+// LazySeq is a memoised thunk: forcing it yields either "empty" or a head
+// plus the (lazy) tail. The thunk runs at most once; its result is cached and
+// the closure released.
+type LazySeq struct {
+	mu     sync.Mutex
+	thunk  func(ctx context.Context) (head MalType, tail *LazySeq, empty bool, err error)
+	forced bool
+	head   MalType
+	tail   *LazySeq
+	empty  bool
+	err    error
+}
+
+func (l *LazySeq) LispPrint(_ func(MalType, bool) string) string { return "«lazy-seq»" }
+
+func (l *LazySeq) force(ctx context.Context) (MalType, *LazySeq, bool, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.forced {
+		l.head, l.tail, l.empty, l.err = l.thunk(ctx)
+		l.forced = true
+		l.thunk = nil
+	}
+	return l.head, l.tail, l.empty, l.err
+}
+
+func lazy(thunk func(ctx context.Context) (MalType, *LazySeq, bool, error)) *LazySeq {
+	return &LazySeq{thunk: thunk}
+}
+
+func emptySeq() *LazySeq { return &LazySeq{forced: true, empty: true} }
+
+// toSeq views any lisp sequence (a lazy-seq, list, vector or nil) as a lazy-seq.
+func toSeq(v MalType) (*LazySeq, error) {
+	switch t := v.(type) {
+	case *LazySeq:
+		return t, nil
+	case nil:
+		return emptySeq(), nil
+	default:
+		slc, err := GetSlice(v)
+		if err != nil {
+			return nil, fmt.Errorf("lazy: not a sequence: %T", v)
+		}
+		return fromSlice(slc), nil
+	}
+}
+
+func fromSlice(slc []MalType) *LazySeq {
+	if len(slc) == 0 {
+		return emptySeq()
+	}
+	return lazy(func(ctx context.Context) (MalType, *LazySeq, bool, error) {
+		return slc[0], fromSlice(slc[1:]), false, nil
+	})
+}
+
+func truthy(v MalType) bool { return v != nil && v != false }
+
+func truthyApply(ctx context.Context, pred, x MalType) (bool, error) {
+	r, err := Apply(ctx, pred, []MalType{x})
+	if err != nil {
+		return false, err
+	}
+	return truthy(r), nil
+}
+
+// Load registers the lazy builtins in env.
+func Load(env EnvType) {
+	// producers
+	call.CallOverrideFN(env, "lazy-range", lazyRange, 0, 3)
+	call.CallOverrideFN(env, "lazy-iterate", lazyIterate)
+	call.CallOverrideFN(env, "lazy-repeat", lazyRepeat, 1, 2)
+	call.CallOverrideFN(env, "lazy-cycle", lazyCycle)
+	// transformers
+	call.CallOverrideFN(env, "lazy-map", lazyMap)
+	call.CallOverrideFN(env, "lazy-filter", lazyFilter)
+	call.CallOverrideFN(env, "lazy-remove", lazyRemove)
+	call.CallOverrideFN(env, "lazy-take", lazyTake)
+	call.CallOverrideFN(env, "lazy-drop", lazyDrop)
+	call.CallOverrideFN(env, "lazy-take-while", lazyTakeWhile)
+	call.CallOverrideFN(env, "lazy-drop-while", lazyDropWhile)
+	// consumers / bridge
+	call.CallOverrideFN(env, "lazy-seq", lazySeqCoerce)
+	call.CallOverrideFN(env, "lazy-seq?", func(v MalType) (bool, error) { return Q[*LazySeq](v), nil })
+	call.CallOverrideFN(env, "lazy-first", lazyFirst)
+	call.CallOverrideFN(env, "lazy-rest", lazyRest)
+	call.CallOverrideFN(env, "lazy-nth", lazyNth)
+	call.CallOverrideFN(env, "lazy-reduce", lazyReduce)
+	call.CallOverrideFN(env, "realize", realize)
+
+	call.Doc(env, "lazy-range", "[] [end] [start end] [start end step]", "Lazy sequence of numbers; with no args it is infinite from 0.")
+	call.Doc(env, "lazy-iterate", "[f x]", "Infinite lazy sequence x, (f x), (f (f x)), …")
+	call.Doc(env, "lazy-repeat", "[x] [n x]", "Lazy sequence of x, infinite or of length n.")
+	call.Doc(env, "lazy-cycle", "[coll]", "Infinite lazy repetition of coll's elements.")
+	call.Doc(env, "lazy-map", "[f coll]", "Lazy sequence of (f x) for each x in coll.")
+	call.Doc(env, "lazy-filter", "[pred coll]", "Lazy sequence of the items in coll for which (pred x) is truthy.")
+	call.Doc(env, "lazy-remove", "[pred coll]", "Lazy sequence of the items in coll for which (pred x) is falsy.")
+	call.Doc(env, "lazy-take", "[n coll]", "Lazy sequence of the first n items of coll.")
+	call.Doc(env, "lazy-drop", "[n coll]", "Lazy sequence of coll without its first n items.")
+	call.Doc(env, "lazy-take-while", "[pred coll]", "Lazy prefix of coll while (pred x) is truthy.")
+	call.Doc(env, "lazy-drop-while", "[pred coll]", "Lazy sequence of coll after the (pred x)-truthy prefix.")
+	call.Doc(env, "lazy-seq", "[coll]", "Views a list or vector as a lazy-seq.")
+	call.Doc(env, "lazy-seq?", "[x]", "Whether x is a lazy-seq.")
+	call.Doc(env, "lazy-first", "[coll]", "First element of coll, or nil if empty.")
+	call.Doc(env, "lazy-rest", "[coll]", "Lazy sequence of coll without its first element.")
+	call.Doc(env, "lazy-nth", "[coll n]", "The nth element of coll (forces up to n).")
+	call.Doc(env, "lazy-reduce", "[f init coll]", "Reduces coll with f starting from init (forces coll).")
+	call.Doc(env, "realize", "[coll]", "Forces a finite lazy-seq into a vector.")
+}
+
+// --- producers ---
+
+func rangeSeq(cur, end, step int, bounded bool) *LazySeq {
+	return lazy(func(ctx context.Context) (MalType, *LazySeq, bool, error) {
+		if bounded && ((step > 0 && cur >= end) || (step < 0 && cur <= end)) {
+			return nil, nil, true, nil
+		}
+		return cur, rangeSeq(cur+step, end, step, bounded), false, nil
+	})
+}
+
+func lazyRange(args ...int) (MalType, error) {
+	switch len(args) {
+	case 0:
+		return rangeSeq(0, 0, 1, false), nil
+	case 1:
+		return rangeSeq(0, args[0], 1, true), nil
+	case 2:
+		return rangeSeq(args[0], args[1], 1, true), nil
+	case 3:
+		if args[2] == 0 {
+			return nil, errors.New("lazy-range: step cannot be 0")
+		}
+		return rangeSeq(args[0], args[1], args[2], true), nil
+	default:
+		return nil, errors.New("lazy-range: too many arguments")
+	}
+}
+
+func lazyIterate(f, x MalType) (MalType, error) {
+	var mk func(x MalType) *LazySeq
+	mk = func(x MalType) *LazySeq {
+		return lazy(func(ctx context.Context) (MalType, *LazySeq, bool, error) {
+			tail := lazy(func(ctx context.Context) (MalType, *LazySeq, bool, error) {
+				nxt, err := Apply(ctx, f, []MalType{x})
+				if err != nil {
+					return nil, nil, false, err
+				}
+				return mk(nxt).force(ctx)
+			})
+			return x, tail, false, nil
+		})
+	}
+	return mk(x), nil
+}
+
+func lazyRepeat(params ...MalType) (MalType, error) {
+	var mk func(n int, unbounded bool) *LazySeq
+	mk = func(n int, unbounded bool) *LazySeq {
+		if !unbounded && n <= 0 {
+			return emptySeq()
+		}
+		return lazy(func(ctx context.Context) (MalType, *LazySeq, bool, error) {
+			return params[len(params)-1], mk(n-1, unbounded), false, nil
+		})
+	}
+	switch len(params) {
+	case 1:
+		return mk(0, true), nil
+	case 2:
+		n, ok := params[0].(int)
+		if !ok {
+			return nil, errors.New("lazy-repeat: count must be an integer")
+		}
+		return mk(n, false), nil
+	default:
+		return nil, errors.New("lazy-repeat: expects (x) or (n x)")
+	}
+}
+
+func lazyCycle(coll MalType) (MalType, error) {
+	orig, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	var mk func(cur *LazySeq) *LazySeq
+	mk = func(cur *LazySeq) *LazySeq {
+		return lazy(func(ctx context.Context) (MalType, *LazySeq, bool, error) {
+			h, t, empty, err := cur.force(ctx)
+			if err != nil {
+				return nil, nil, false, err
+			}
+			if empty {
+				// wrap around; an empty source yields an empty cycle
+				h, t, empty, err = orig.force(ctx)
+				if err != nil {
+					return nil, nil, false, err
+				}
+				if empty {
+					return nil, nil, true, nil
+				}
+			}
+			return h, mk(t), false, nil
+		})
+	}
+	return mk(orig), nil
+}
+
+// --- transformers ---
+
+func lazyMap(f, coll MalType) (MalType, error) {
+	src, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	var mk func(src *LazySeq) *LazySeq
+	mk = func(src *LazySeq) *LazySeq {
+		return lazy(func(ctx context.Context) (MalType, *LazySeq, bool, error) {
+			h, t, empty, err := src.force(ctx)
+			if err != nil {
+				return nil, nil, false, err
+			}
+			if empty {
+				return nil, nil, true, nil
+			}
+			mapped, err := Apply(ctx, f, []MalType{h})
+			if err != nil {
+				return nil, nil, false, err
+			}
+			return mapped, mk(t), false, nil
+		})
+	}
+	return mk(src), nil
+}
+
+func filterSeq(pred MalType, src *LazySeq, keep bool) *LazySeq {
+	return lazy(func(ctx context.Context) (MalType, *LazySeq, bool, error) {
+		cur := src
+		for {
+			if err := ctx.Err(); err != nil {
+				return nil, nil, false, err
+			}
+			h, t, empty, err := cur.force(ctx)
+			if err != nil {
+				return nil, nil, false, err
+			}
+			if empty {
+				return nil, nil, true, nil
+			}
+			ok, err := truthyApply(ctx, pred, h)
+			if err != nil {
+				return nil, nil, false, err
+			}
+			if ok == keep {
+				return h, filterSeq(pred, t, keep), false, nil
+			}
+			cur = t
+		}
+	})
+}
+
+func lazyFilter(pred, coll MalType) (MalType, error) {
+	src, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	return filterSeq(pred, src, true), nil
+}
+
+func lazyRemove(pred, coll MalType) (MalType, error) {
+	src, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	return filterSeq(pred, src, false), nil
+}
+
+func takeSeq(n int, src *LazySeq) *LazySeq {
+	if n <= 0 {
+		return emptySeq()
+	}
+	return lazy(func(ctx context.Context) (MalType, *LazySeq, bool, error) {
+		h, t, empty, err := src.force(ctx)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		if empty {
+			return nil, nil, true, nil
+		}
+		return h, takeSeq(n-1, t), false, nil
+	})
+}
+
+func lazyTake(n int, coll MalType) (MalType, error) {
+	src, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	return takeSeq(n, src), nil
+}
+
+func lazyDrop(n int, coll MalType) (MalType, error) {
+	src, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	return lazy(func(ctx context.Context) (MalType, *LazySeq, bool, error) {
+		cur := src
+		for range n {
+			_, t, empty, err := cur.force(ctx)
+			if err != nil {
+				return nil, nil, false, err
+			}
+			if empty {
+				return nil, nil, true, nil
+			}
+			cur = t
+		}
+		return cur.force(ctx)
+	}), nil
+}
+
+func lazyTakeWhile(pred, coll MalType) (MalType, error) {
+	src, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	var mk func(src *LazySeq) *LazySeq
+	mk = func(src *LazySeq) *LazySeq {
+		return lazy(func(ctx context.Context) (MalType, *LazySeq, bool, error) {
+			h, t, empty, err := src.force(ctx)
+			if err != nil {
+				return nil, nil, false, err
+			}
+			if empty {
+				return nil, nil, true, nil
+			}
+			ok, err := truthyApply(ctx, pred, h)
+			if err != nil {
+				return nil, nil, false, err
+			}
+			if !ok {
+				return nil, nil, true, nil
+			}
+			return h, mk(t), false, nil
+		})
+	}
+	return mk(src), nil
+}
+
+func lazyDropWhile(pred, coll MalType) (MalType, error) {
+	src, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	return lazy(func(ctx context.Context) (MalType, *LazySeq, bool, error) {
+		cur := src
+		for {
+			if err := ctx.Err(); err != nil {
+				return nil, nil, false, err
+			}
+			h, t, empty, err := cur.force(ctx)
+			if err != nil {
+				return nil, nil, false, err
+			}
+			if empty {
+				return nil, nil, true, nil
+			}
+			ok, err := truthyApply(ctx, pred, h)
+			if err != nil {
+				return nil, nil, false, err
+			}
+			if !ok {
+				return h, t, false, nil
+			}
+			cur = t
+		}
+	}), nil
+}
+
+// --- consumers / bridge ---
+
+func lazySeqCoerce(coll MalType) (MalType, error) {
+	s, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func lazyFirst(ctx context.Context, coll MalType) (MalType, error) {
+	s, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	h, _, empty, err := s.force(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if empty {
+		return nil, nil
+	}
+	return h, nil
+}
+
+func lazyRest(ctx context.Context, coll MalType) (MalType, error) {
+	s, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	_, t, empty, err := s.force(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if empty {
+		return emptySeq(), nil
+	}
+	return t, nil
+}
+
+func lazyNth(ctx context.Context, coll MalType, idx int) (MalType, error) {
+	if idx < 0 {
+		return nil, errors.New("lazy-nth: negative index")
+	}
+	cur, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	for range idx {
+		_, t, empty, err := cur.force(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if empty {
+			return nil, errors.New("lazy-nth: index out of range")
+		}
+		cur = t
+	}
+	h, _, empty, err := cur.force(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if empty {
+		return nil, errors.New("lazy-nth: index out of range")
+	}
+	return h, nil
+}
+
+func lazyReduce(ctx context.Context, f, init, coll MalType) (MalType, error) {
+	cur, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	acc := init
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		h, t, empty, err := cur.force(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if empty {
+			return acc, nil
+		}
+		acc, err = Apply(ctx, f, []MalType{acc, h})
+		if err != nil {
+			return nil, err
+		}
+		cur = t
+	}
+}
+
+func realize(ctx context.Context, coll MalType) (MalType, error) {
+	cur, err := toSeq(coll)
+	if err != nil {
+		return nil, err
+	}
+	out := []MalType{}
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		h, t, empty, err := cur.force(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if empty {
+			return Vector{Val: out}, nil
+		}
+		out = append(out, h)
+		cur = t
+	}
+}

--- a/lib/lazy/lazy_test.go
+++ b/lib/lazy/lazy_test.go
@@ -1,0 +1,157 @@
+package lazy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/concurrent"
+	"github.com/jig/lisp/lib/core"
+	"github.com/jig/lisp/types"
+)
+
+// testEnv builds an interpreter with core, the basic header, the concurrent
+// namespace (for atom/swap! used in the laziness tests) and the lazy
+// namespace loaded.
+func testEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	core.Load(ns)
+	if _, err := lisp.REPL(context.Background(), ns, core.HeaderBasic(), types.NewCursorFile("preamble")); err != nil {
+		t.Fatalf("HeaderBasic: %v", err)
+	}
+	concurrent.Load(ns)
+	Load(ns)
+	return ns
+}
+
+func evalErr(ns types.EnvType, src string) (types.MalType, error) {
+	ast, err := lisp.READ(src, types.NewCursorFile("test"), ns)
+	if err != nil {
+		return nil, err
+	}
+	return lisp.EVAL(context.Background(), ast, ns)
+}
+
+func eval(t *testing.T, ns types.EnvType, src string) types.MalType {
+	t.Helper()
+	res, err := evalErr(ns, src)
+	if err != nil {
+		t.Fatalf("eval %q: %v", src, err)
+	}
+	return res
+}
+
+// asInts realises a Vector result into a Go []int for easy comparison.
+func asInts(t *testing.T, v types.MalType) []int {
+	t.Helper()
+	vec, ok := v.(types.Vector)
+	if !ok {
+		t.Fatalf("expected Vector, got %T", v)
+	}
+	out := make([]int, len(vec.Val))
+	for i, e := range vec.Val {
+		n, ok := e.(int)
+		if !ok {
+			t.Fatalf("element %d is %T, want int", i, e)
+		}
+		out[i] = n
+	}
+	return out
+}
+
+func eq(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestProducersAndTransformers(t *testing.T) {
+	ns := testEnv(t)
+	cases := []struct {
+		name string
+		src  string
+		want []int
+	}{
+		{"range bounded", `(realize (lazy-range 0 4))`, []int{0, 1, 2, 3}},
+		{"range start-end-step", `(realize (lazy-range 1 10 3))`, []int{1, 4, 7}},
+		{"range infinite + take", `(realize (lazy-take 4 (lazy-range)))`, []int{0, 1, 2, 3}},
+		{"map over infinite", `(realize (lazy-take 3 (lazy-map (fn [x] (* x x)) (lazy-range))))`, []int{0, 1, 4}},
+		{"filter over infinite", `(realize (lazy-take 3 (lazy-filter (fn [x] (> x 5)) (lazy-range))))`, []int{6, 7, 8}},
+		{"remove", `(realize (lazy-remove (fn [x] (> x 2)) [1 2 3 4 1]))`, []int{1, 2, 1}},
+		{"drop", `(realize (lazy-drop 2 (lazy-range 0 5)))`, []int{2, 3, 4}},
+		{"take-while", `(realize (lazy-take-while (fn [x] (< x 3)) (lazy-range)))`, []int{0, 1, 2}},
+		{"drop-while", `(realize (lazy-drop-while (fn [x] (< x 3)) [0 1 2 3 4 1]))`, []int{3, 4, 1}},
+		{"iterate", `(realize (lazy-take 5 (lazy-iterate (fn [x] (* x 2)) 1)))`, []int{1, 2, 4, 8, 16}},
+		{"repeat n", `(realize (lazy-repeat 3 7))`, []int{7, 7, 7}},
+		{"repeat infinite + take", `(realize (lazy-take 2 (lazy-repeat 9)))`, []int{9, 9}},
+		{"cycle", `(realize (lazy-take 7 (lazy-cycle [1 2 3])))`, []int{1, 2, 3, 1, 2, 3, 1}},
+		{"eager vector as source", `(realize (lazy-map (fn [x] (+ x 1)) [10 20 30]))`, []int{11, 21, 31}},
+		{"eager list as source", `(realize (lazy-filter (fn [x] (> x 1)) (list 1 2 3)))`, []int{2, 3}},
+		{"pipeline", `(realize (lazy-take 3 (lazy-filter (fn [x] (> x 3)) (lazy-map (fn [x] (+ x 1)) (lazy-range)))))`, []int{4, 5, 6}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := asInts(t, eval(t, ns, tc.src))
+			if !eq(got, tc.want) {
+				t.Errorf("%s = %v, want %v", tc.src, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConsumers(t *testing.T) {
+	ns := testEnv(t)
+
+	if got := eval(t, ns, `(lazy-first (lazy-range 5 9))`); got != 5 {
+		t.Errorf("lazy-first = %v, want 5", got)
+	}
+	if got := eval(t, ns, `(lazy-first [])`); got != nil {
+		t.Errorf("lazy-first of empty = %v, want nil", got)
+	}
+	if got := eval(t, ns, `(lazy-nth (lazy-range) 1000)`); got != 1000 {
+		t.Errorf("lazy-nth = %v, want 1000", got)
+	}
+	if got := eval(t, ns, `(lazy-reduce + 0 (lazy-take 100 (lazy-range 1 1000000)))`); got != 5050 {
+		t.Errorf("lazy-reduce = %v, want 5050", got)
+	}
+	if got := eval(t, ns, `(lazy-seq? (lazy-rest (lazy-range)))`); got != true {
+		t.Errorf("lazy-rest should be a lazy-seq, got %v", got)
+	}
+	if _, err := evalErr(ns, `(lazy-nth (lazy-range 0 3) 10)`); err == nil {
+		t.Error("lazy-nth out of range should error")
+	}
+}
+
+// TestMemoisation checks that a lazy sequence forces each element at most
+// once even across repeated traversals.
+func TestMemoisation(t *testing.T) {
+	ns := testEnv(t)
+	eval(t, ns, `(def calls (atom 0))`)
+	eval(t, ns, `(def s (lazy-map (fn [x] (do (swap! calls (fn [n] (+ n 1))) x)) [1 2 3]))`)
+	eval(t, ns, `(realize s)`)
+	eval(t, ns, `(realize s)`) // second traversal must not re-run the map fn
+	if got := eval(t, ns, `(deref calls)`); got != 3 {
+		t.Errorf("map fn call count = %v, want 3 (memoised)", got)
+	}
+}
+
+// TestErrorPropagation checks that a throw inside a lazy computation surfaces
+// when the element is forced.
+func TestErrorPropagation(t *testing.T) {
+	ns := testEnv(t)
+	if _, err := evalErr(ns, `(realize (lazy-map (fn [x] (throw "boom")) [1 2 3]))`); err == nil {
+		t.Fatal("expected the thrown error to propagate through realize")
+	}
+	// the error must only fire once the offending element is forced
+	if _, err := evalErr(ns, `(lazy-first (lazy-map (fn [x] (throw "boom")) [1 2 3]))`); err == nil {
+		t.Fatal("expected lazy-first to force and propagate the error")
+	}
+}

--- a/lib/lazy/nslazy/nslazy.go
+++ b/lib/lazy/nslazy/nslazy.go
@@ -1,0 +1,14 @@
+// Package nslazy loads the lazy-sequence namespace into a jig/lisp
+// environment. The namespace is implemented entirely in Go, so loading it is
+// just a matter of registering the builtins.
+package nslazy
+
+import (
+	"github.com/jig/lisp/lib/lazy"
+	"github.com/jig/lisp/types"
+)
+
+func Load(env types.EnvType) error {
+	lazy.Load(env)
+	return nil
+}


### PR DESCRIPTION
Adds `lib/lazy`, a **self-contained lazy-sequence** library. A lazy-seq is a memoised thunk (thread-safe), so sequences can be infinite and traversed more than once; nothing is computed until a consumer pulls elements, and only as many as asked for.

### API
- **Producers:** `lazy-range` (infinite with no args), `lazy-iterate`, `lazy-repeat`, `lazy-cycle`
- **Transformers:** `lazy-map`, `lazy-filter`, `lazy-remove`, `lazy-take`, `lazy-drop`, `lazy-take-while`, `lazy-drop-while`
- **Consumers / bridge:** `lazy-first`, `lazy-rest`, `lazy-nth`, `lazy-reduce`, `realize` (force a finite seq into a vector), `lazy-seq`, `lazy-seq?`

Any list or vector is accepted wherever a lazy-seq is, so eager data flows in; `realize` bridges back to core.

### Notes
- Element **and** error evaluation are lazy: a throwing map/predicate surfaces only when the element is forced. Realisation threads and honours the evaluation context (a cancelled eval stops `realize`).
- It is a **separate vocabulary** — core `first`/`map`/`take` don't know about lazy-seqs; cross back with `realize`/`lazy-seq`. Making core seq fns lazy-aware later would only *add* interop.
- `lib/lazy/nslazy` wires it into `cmd/lisp`.

### Testing
`lib/lazy/lazy_test.go` covers producers/transformers/consumers, memoisation across repeated traversals, and lazy error propagation. `go test ./...`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)