### PR TITLE
feat(core): add into, and accept [k v] pairs/maps in conj

### DIFF
--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -978,10 +978,22 @@ func conj(a ...MalType) (MalType, error) {
 		new_slc := append(seq.Val, a[1:]...)
 		return Vector{Val: new_slc}, nil
 	case HashMap:
+		new_hm := copy_hash_map(seq)
+		// Entry form: each extra argument is a [k v] pair or a whole map —
+		// the shape `into` feeds via `(reduce conj m from)`. Detected from
+		// the first extra argument; otherwise fall back to the flat
+		// key/value form `(conj m k1 v1 …)`.
+		if len(a) > 1 && isMapEntry(a[1]) {
+			for _, entry := range a[1:] {
+				if err := conjMapEntry(new_hm, entry); err != nil {
+					return nil, err
+				}
+			}
+			return new_hm, nil
+		}
 		if len(a)%2 != 1 {
 			return nil, errors.New("conj called with on a hash map requires an odd number of arguments")
 		}
-		new_hm := copy_hash_map(seq)
 		for i := 1; i < len(a); i += 2 {
 			key := a[i]
 			if !Q[string](key) {
@@ -1002,6 +1014,41 @@ func conj(a ...MalType) (MalType, error) {
 	default:
 		return nil, errors.New("conj called on non-hash map and a non-list and a non-set and a non-vector")
 	}
+}
+
+// isMapEntry reports whether v is what conj accepts as a single map entry:
+// a two-element vector/list [k v], or a map to be merged in.
+func isMapEntry(v MalType) bool {
+	switch e := v.(type) {
+	case Vector:
+		return len(e.Val) == 2
+	case List:
+		return len(e.Val) == 2
+	case HashMap:
+		return true
+	}
+	return false
+}
+
+// conjMapEntry adds one entry — a [key value] pair or a whole map — to hm
+// in place. Keys must be strings or keywords, as elsewhere for maps.
+func conjMapEntry(hm HashMap, entry MalType) error {
+	if e, ok := entry.(HashMap); ok {
+		for k, v := range e.Val {
+			hm.Val[k] = v
+		}
+		return nil
+	}
+	slc, err := GetSlice(entry)
+	if err != nil || len(slc) != 2 {
+		return errors.New("conj: map entry must be a [key value] pair or a map")
+	}
+	key := slc[0]
+	if !Q[string](key) {
+		return errors.New("conj called with non-string key")
+	}
+	hm.Val[key.(string)] = slc[1]
+	return nil
 }
 
 func seq(seq MalType) (MalType, error) {

--- a/lib/coreextented/coreextended_test.go
+++ b/lib/coreextented/coreextended_test.go
@@ -85,3 +85,31 @@ func TestPrelude(t *testing.T) {
 		})
 	}
 }
+
+// TestInto covers `into` and the conj map-entry form it relies on. Map and
+// set element order is not stable when printed, so results are probed with
+// get/count rather than compared literally.
+func TestInto(t *testing.T) {
+	ns := newEnv(t)
+	cases := []struct{ src, want string }{
+		// into: result keeps the target's type
+		{"(into [] (list 1 2 3))", "[1 2 3]"},
+		{"(into [0] [1 2])", "[0 1 2]"},
+		{"(into (list) [1 2 3])", "(3 2 1)"}, // list conj prepends
+		{"(get (into {} [[:a 1] [:b 2]]) :b)", "2"},
+		{"(count (into {} [[:a 1] [:b 2]]))", "2"},
+		{"(count (into {:a 1} [{:b 2} {:c 3}]))", "3"}, // map entries merged
+		{"(count (into #{:x} [:a :b :a]))", "3"},       // keyword set, deduped
+		// conj map-entry form added for into, without breaking the flat form
+		{"(get (conj {:a 1} [:b 2]) :b)", "2"},
+		{"(count (conj {:a 1} {:b 2 :c 3}))", "3"},
+		{"(get (conj {:a 1} :b 2) :b)", "2"}, // flat form still works
+	}
+	for _, tc := range cases {
+		t.Run(tc.src, func(t *testing.T) {
+			if got := run(t, ns, tc.src); got != tc.want {
+				t.Errorf("%s = %s, want %s", tc.src, got, tc.want)
+			}
+		})
+	}
+}

--- a/lib/coreextented/header-coreextended.lisp
+++ b/lib/coreextented/header-coreextended.lisp
@@ -569,6 +569,13 @@
         (cons (first xs) (take-while pred (rest xs)))
         ())))
 
+;;; Collections
+
+  (defn into
+    "Pours every item of from into to using conj; the result keeps to's type."
+    [to from]
+    (reduce conj to from))
+
 ;;; Load File Once
   ;; This file is normally loaded with "load-file", so it needs a
   ;; different mechanism to neutralize multiple inclusions of


### PR DESCRIPTION
Adds Clojure-style `into` and the small `conj` change it needs.

### What
- **`into`** (`header-coreextended.lisp`, pure lisp): `(defn into [to from] (reduce conj to from))` — pours every item of `from` into `to`, keeping `to`'s type.
- **`conj` on maps** (`lib/core/core.go`) now also accepts a **map entry** — a `[k v]` pair (vector/list) or a whole map to merge — alongside the existing flat `(conj m k1 v1 …)` form. The form is picked from the first extra argument, so flat calls are unchanged.

```clojure
(into [] (list 1 2 3))        ;=> [1 2 3]
(into (list) [1 2 3])         ;=> (3 2 1)
(into {} [[:a 1] [:b 2]])     ;=> {:a 1 :b 2}
(into #{} [:a :b :a])         ;=> #{:a :b}
```

### Scope
Covers vectors, lists, maps and keyword/string sets. **Out of scope (Tier 2, deferred):** sets of arbitrary values (`Set` holds only strings/keywords, so `(into #{} [1 2 3])` still errors) and `into` directly over a lazy-seq (core `reduce`/`conj` don't know `*LazySeq` — `realize` first).

### Testing
`coreextended_test.go` covers `into` across target types, the map-entry conj form, map merging, and that the flat conj form still works. `go test ./...`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)