### PR TITLE
feat(eval): add loop and recur special forms

### DIFF
--- a/loop_recur_test.go
+++ b/loop_recur_test.go
@@ -1,0 +1,75 @@
+package lisp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core"
+	"github.com/jig/lisp/types"
+)
+
+func loopEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	core.Load(ns)
+	core.LoadInput(ns)
+	if _, err := REPL(context.Background(), ns, core.HeaderBasic(), nil); err != nil {
+		t.Fatalf("HeaderBasic: %v", err)
+	}
+	return ns
+}
+
+// run evaluates src and returns its printed form (REPL returns the printed
+// representation).
+func run(t *testing.T, ns types.EnvType, src string) string {
+	t.Helper()
+	res, err := REPL(context.Background(), ns, src, types.NewCursorFile("test"))
+	if err != nil {
+		t.Fatalf("eval %q: %v", src, err)
+	}
+	return res.(string)
+}
+
+func TestLoopRecur(t *testing.T) {
+	ns := loopEnv(t)
+	cases := []struct{ src, want string }{
+		{"(loop [i 0 acc []] (if (< i 5) (recur (+ i 1) (conj acc i)) acc))", "[0 1 2 3 4]"},
+		{"(loop [n 5 acc 1] (if (= n 0) acc (recur (- n 1) (* acc n))))", "120"}, // factorial
+		{"(loop [x 41] (+ x 1))", "42"},                                                  // no recur: returns the body
+		{"(loop [i 0] (let [j (+ i 1)] (if (< j 5) (recur j) j)))", "5"},                 // recur in tail of let
+		{"(loop [i 0] (do 1 (if (< i 3) (recur (+ i 1)) i)))", "3"},                      // recur in tail of do
+		{"(do (defn cnt [n] (loop [i 0] (if (< i n) (recur (+ i 1)) i))) (cnt 7))", "7"}, // loop inside fn
+	}
+	for _, tc := range cases {
+		t.Run(tc.src, func(t *testing.T) {
+			if got := run(t, ns, tc.src); got != tc.want {
+				t.Errorf("%s = %s, want %s", tc.src, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoopRecurConstantStack forces many iterations; without constant-stack
+// recur this would overflow.
+func TestLoopRecurConstantStack(t *testing.T) {
+	ns := loopEnv(t)
+	if got := run(t, ns, "(loop [i 0] (if (< i 1000000) (recur (+ i 1)) :done))"); got != ":done" {
+		t.Errorf("got %s, want :done", got)
+	}
+}
+
+func TestLoopRecurErrors(t *testing.T) {
+	ns := loopEnv(t)
+	cases := map[string]string{
+		"arity mismatch": "(loop [i 0 j 0] (recur 1))",
+		"non-tail recur": "(loop [i 0] (+ 1 (recur (+ i 1))))",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := REPL(context.Background(), ns, src, types.NewCursorFile("test")); err == nil {
+				t.Errorf("expected an error for %q, got none", src)
+			}
+		})
+	}
+}

--- a/lsp/analyse.go
+++ b/lsp/analyse.go
@@ -109,6 +109,7 @@ var specialForms = map[string]bool{
 	"quasiquoteexpand": true, "defmacro": true, "macroexpand": true,
 	"try": true, "catch": true, "finally": true, "do": true, "if": true,
 	"fn": true, "unquote": true, "splice-unquote": true, "context": true,
+	"loop": true, "recur": true,
 }
 
 // tail returns vals[n:], or an empty slice when n is past the end.

--- a/mal.go
+++ b/mal.go
@@ -393,6 +393,16 @@ func do(ctx context.Context, ast MalType, from, to int, env EnvType) (MalType, e
 	return lst[len(lst)-1], nil
 }
 
+// recurValue is the sentinel `recur` produces: the evaluated rebind values,
+// caught by the nearest enclosing `loop`. Using a distinct value (rather than
+// an error) means a `recur` left in non-tail position reaches a real consumer
+// (e.g. arithmetic) and fails there, instead of silently jumping.
+type recurValue struct {
+	args []MalType
+}
+
+func (recurValue) LispPrint(_ func(MalType, bool) string) string { return "«recur»" }
+
 // EVAL evaluates an Abstract Syntaxt Tree (AST) and returns a result (a reduced AST).
 // It requires a context that might cancel execution, and requires an environment that might
 // be modified.
@@ -533,6 +543,57 @@ func EVAL(ctx context.Context, ast MalType, env EnvType) (res MalType, e error) 
 				return nil, e
 			}
 			env = let_env
+		case "loop":
+			// Like `let`, but a recursion point: `recur` in tail position
+			// rebinds these symbols and jumps back here, in constant stack.
+			arr1, e := GetSlice(a1)
+			if e != nil {
+				return nil, e
+			}
+			if len(arr1)%2 != 0 {
+				return nil, lisperror.NewLispError(errors.New("loop: odd elements on binding vector"), a1)
+			}
+			loop_env := NewSubordinateEnv(env)
+			syms := make([]Symbol, 0, len(arr1)/2)
+			for i := 0; i < len(arr1); i += 2 {
+				if !Q[Symbol](arr1[i]) {
+					return nil, lisperror.NewLispError(errors.New("loop: non-symbol bind value"), a1)
+				}
+				val, e := EVAL(ctx, arr1[i+1], loop_env)
+				if e != nil {
+					return nil, e
+				}
+				loop_env.Set(arr1[i].(Symbol), val)
+				syms = append(syms, arr1[i].(Symbol))
+			}
+			astRef := ast.(List)
+			for {
+				res, e := do(ctx, astRef, 2, 0, loop_env)
+				if e != nil {
+					return nil, e
+				}
+				rv, ok := res.(recurValue)
+				if !ok {
+					return res, nil
+				}
+				if len(rv.args) != len(syms) {
+					return nil, lisperror.NewLispError(fmt.Errorf("recur: got %d arguments but loop has %d bindings", len(rv.args), len(syms)), ast)
+				}
+				for i, sym := range syms {
+					loop_env.Set(sym, rv.args[i])
+				}
+			}
+		case "recur":
+			args := ast.(List).Val[1:]
+			vals := make([]MalType, len(args))
+			for i, arg := range args {
+				v, e := EVAL(ctx, arg, env)
+				if e != nil {
+					return nil, e
+				}
+				vals[i] = v
+			}
+			return recurValue{args: vals}, nil
 		case "quote": // '
 			return a1, nil
 		case "quasiquoteexpand":


### PR DESCRIPTION
Adds Clojure-style **`loop`/`recur`** for local iteration.

- `loop` is like `let` but a recursion point; `recur` in tail position rebinds the loop's symbols and jumps back, in **constant stack**, via loop's own catch loop.
- `recur` produces a distinct sentinel value (not an error), so a recur left in **non-tail position** reaches a real consumer and fails there instead of silently jumping. `loop` checks recur's **arity** against its bindings.

```clojure
(loop [n 5 acc 1] (if (= n 0) acc (recur (- n 1) (* acc n))))  ;=> 120
```

### Notes
- The interpreter already had TCO, so named tail-recursive functions were already stack-safe. `loop`/`recur` add a local iteration construct with accumulators without a named helper.
- `recur` targets the nearest enclosing **`loop`** (not `fn`) — a named self-call (already TCO'd) or a `loop` inside the fn covers that case.
- `loop`/`recur` are registered as special forms in the LSP analyser so they aren't flagged as unknown symbols.

### Testing
`loop_recur_test.go`: accumulation, factorial, constant stack over 1e6 iterations, recur through `let`/`do` tails, `loop` inside a `fn`, and the arity / non-tail error cases. `go test ./...`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)