### PR TITLE
fix(require): don't deadlock when a required module requires another

### DIFF
--- a/lib/require/require.go
+++ b/lib/require/require.go
@@ -77,7 +77,7 @@ func load(rootEnv types.EnvType, cfg Config) error {
 	// Each loaded module is evaluated once in its own environment
 	// subordinate to rootEnv; the cache lives in this closure so
 	// distinct root environments (e.g. tests) do not share modules.
-	loader := &moduleLoader{root: rootEnv, cache: map[string]types.EnvType{}}
+	loader := &moduleLoader{root: rootEnv, cache: map[string]types.EnvType{}, loading: map[string]bool{}}
 	rootEnv.Set(types.Symbol{Val: "require"}, types.Func{Fn: loader.require})
 
 	call.Doc(rootEnv, "require", `[module & [:as alias] [:refer [names]|:all]]`,
@@ -90,9 +90,10 @@ func load(rootEnv types.EnvType, cfg Config) error {
 // moduleLoader evaluates modules once and exposes their top-level
 // definitions in the root environment under qualified names.
 type moduleLoader struct {
-	mu    sync.Mutex
-	root  types.EnvType
-	cache map[string]types.EnvType // abs path → module env
+	mu      sync.Mutex
+	root    types.EnvType
+	cache   map[string]types.EnvType // abs path → module env
+	loading map[string]bool          // abs paths currently being evaluated
 }
 
 // require implements `(require "module" [:as "alias"] [:refer ["name" …]])`.
@@ -160,12 +161,45 @@ func (l *moduleLoader) require(ctx context.Context, args []types.MalType) (types
 }
 
 // loadModule evaluates the module file once and caches its environment.
+//
+// The mutex guards only the cache and the in-progress set — never the
+// evaluation itself. A module may `require` others, which re-enters
+// loadModule, so holding the lock across EVAL would deadlock (sync.Mutex
+// is not reentrant). The in-progress set turns a circular require into a
+// clear error instead of unbounded recursion.
 func (l *moduleLoader) loadModule(ctx context.Context, absPath string) (types.EnvType, error) {
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	if moduleEnv, ok := l.cache[absPath]; ok {
+		l.mu.Unlock()
 		return moduleEnv, nil
 	}
+	if l.loading[absPath] {
+		l.mu.Unlock()
+		return nil, fmt.Errorf("require: circular dependency loading %q", absPath)
+	}
+	l.loading[absPath] = true
+	l.mu.Unlock()
+
+	moduleEnv, err := l.evalModule(ctx, absPath)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.loading, absPath)
+	if err != nil {
+		return nil, err
+	}
+	if existing, ok := l.cache[absPath]; ok {
+		// Another require finished this module while we evaluated it.
+		return existing, nil
+	}
+	l.cache[absPath] = moduleEnv
+	return moduleEnv, nil
+}
+
+// evalModule reads and evaluates a module file into a fresh subordinate
+// environment, without touching the loader's shared state (so it holds no
+// lock and nested requires can proceed).
+func (l *moduleLoader) evalModule(ctx context.Context, absPath string) (types.EnvType, error) {
 	content, err := os.ReadFile(absPath)
 	if err != nil {
 		return nil, fmt.Errorf("require: %w", err)
@@ -187,7 +221,6 @@ func (l *moduleLoader) loadModule(ctx context.Context, absPath string) (types.En
 	if _, err := lisp.EVAL(ctx, ast, moduleEnv); err != nil {
 		return nil, err
 	}
-	l.cache[absPath] = moduleEnv
 	return moduleEnv, nil
 }
 

--- a/lib/require/require_test.go
+++ b/lib/require/require_test.go
@@ -156,6 +156,45 @@ func TestRequire_ReferAll(t *testing.T) {
 	}
 }
 
+func TestRequire_Nested(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "base.lisp"),
+		[]byte("(def answer 42)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// mid requires base, then uses its definition: requiring a module that
+	// itself requires another must not deadlock.
+	if err := os.WriteFile(filepath.Join(dir, "mid.lisp"),
+		[]byte("(require \"base\" :refer :all)\n(defn doubled [] (* answer 2))\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ns := testEnv(t, dir)
+	mustRepl(t, ns, `(require "mid" :refer :all)`)
+	if out := mustRepl(t, ns, `(doubled)`); out != "84" {
+		t.Errorf("expected 84, got %v", out)
+	}
+}
+
+func TestRequire_CircularErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.lisp"),
+		[]byte("(require \"b\" :refer :all)\n(def x 1)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.lisp"),
+		[]byte("(require \"a\" :refer :all)\n(def y 2)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ns := testEnv(t, dir)
+	// A circular require must be reported, not hang.
+	if _, err := repl(t, ns, `(require "a" :refer :all)`); err == nil ||
+		!strings.Contains(err.Error(), "circular dependency") {
+		t.Errorf("expected a circular dependency error, got %v", err)
+	}
+}
+
 func TestRequire_LoadsOnlyOnce(t *testing.T) {
 	dir := t.TempDir()
 	// The module bumps a root-env counter on every EVALUATION (eval runs


### PR DESCRIPTION
### Bug
Requiring a module that itself calls `require` **hung the interpreter**. `loadModule` held the loader mutex across the module's `EVAL`; a nested `require` re-enters `loadModule` and tries to re-lock the same (non-reentrant) `sync.Mutex` → deadlock.

### Fix
Hold the mutex only around the cache and a new *in-progress* set — never during evaluation (moved into `evalModule`, which touches no shared state). A module that is required while already being loaded is now reported as a **circular dependency** instead of recursing without bound. Load-once is preserved: the cache is checked before evaluating and again before caching.

### Testing
- `TestRequire_Nested`: a module that requires another loads and runs (would previously hang).
- `TestRequire_CircularErrors`: a circular require errors clearly rather than hanging.
- Existing `TestRequire_LoadsOnlyOnce` still passes; the package passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)