### PR TITLE
fix(concurrent): make Future.Done/Cancelled atomic to fix data race

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,19 @@ jobs:
     # without this second pass its tests never run in CI.
     - run: go test -tags lispdebug ./...
 
+  # The race detector catches data races the plain test job cannot see
+  # (concurrent atoms/futures). Ubuntu-only: it is ~10x slower, and a
+  # data race is a logic bug, not an OS-specific one.
+  race:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - uses: actions/setup-go@v6
+      with:
+        go-version: 1.25.x
+    - run: go test -race ./...
+    - run: go test -race -tags lispdebug ./...
+
   quality:
     runs-on: ubuntu-latest
     steps:

--- a/ROADMAP-robustness.md
+++ b/ROADMAP-robustness.md
@@ -13,8 +13,8 @@ ROADMAP.md.
 
 Status summary (tick as you go):
 
-- [ ] 1.1 CI: run tests with `-race`
-- [ ] 1.2 Data race in `Future.Done` / `Future.Cancelled`
+- [x] 1.1 CI: run tests with `-race` (done 2026-07-08)
+- [x] 1.2 Data race in `Future.Done` / `Future.Cancelled` (done 2026-07-08)
 - [ ] 2.1 Panic: `(try 1 (catch))` — catch with no binding
 - [ ] 2.2 Panic: `(try ())` — `first()` on empty list
 - [ ] 2.3 Panic: `(fn [&])` called — trailing `&` in binds
@@ -36,7 +36,16 @@ independent and can be picked at leisure.
 
 ## Phase 1 — CI and the confirmed race (surgical, do first)
 
-### 1.1 CI: run tests with `-race`
+**Done 2026-07-08** (branch `fix/future-data-race`): `Future.Done` and
+`Future.Cancelled` are now `atomic.Bool`; `Cancel` uses a
+`CompareAndSwap` to make its check-then-act atomic. CI gained a
+ubuntu-only `race` job (plain + `lispdebug`). Regression test
+`TestFutureConcurrentStateNoRace` in
+[lib/concurrent/future_race_test.go](lib/concurrent/future_race_test.go)
+reproduces the original race (4 reports under `-race` on the old code)
+and passes on the new. `go test -race ./...` is clean.
+
+### ~~1.1 CI: run tests with `-race`~~ (done 2026-07-08)
 
 `.github/workflows/test.yml` runs `go test ./...` without `-race`, so
 the data race in 1.2 was never seen by CI (a local
@@ -46,7 +55,7 @@ matter. The `lispdebug` pass should get it too.
 
 *Effort: trivial. Do together with 1.2 so the new job is born green.*
 
-### 1.2 Data race in `Future.Done` / `Future.Cancelled`
+### ~~1.2 Data race in `Future.Done` / `Future.Cancelled`~~ (done 2026-07-08)
 
 `Future.Done` and `Future.Cancelled` are plain bools
 ([lib/concurrent/concurrent.go](lib/concurrent/concurrent.go)):

--- a/lib/concurrent/concurrent.go
+++ b/lib/concurrent/concurrent.go
@@ -5,10 +5,11 @@ import (
 
 	_ "embed"
 	"errors"
-	"github.com/jig/lisp/runtime"
 	"sync"
+	"sync/atomic"
 
 	"github.com/jig/lisp/lib/call"
+	"github.com/jig/lisp/runtime"
 	. "github.com/jig/lisp/types"
 )
 
@@ -25,8 +26,8 @@ func Load(env EnvType) {
 	call.CallOverrideFN(env, "reset!", reset_BANG)
 	call.Call(env, future_call)
 	call.Call(env, future_cancel)
-	call.CallOverrideFN(env, "future-cancelled?", func(f *Future) (bool, error) { return f.Cancelled, nil })
-	call.CallOverrideFN(env, "future-done?", func(f *Future) (bool, error) { return f.Done, nil })
+	call.CallOverrideFN(env, "future-cancelled?", func(f *Future) (bool, error) { return f.Cancelled.Load(), nil })
+	call.CallOverrideFN(env, "future-done?", func(f *Future) (bool, error) { return f.Done.Load(), nil })
 	call.CallOverrideFN(env, "future?", func(f MalType) (bool, error) { return Q[*Future](f), nil })
 	call.Call(env, new_future_call)
 
@@ -114,8 +115,11 @@ type Future struct {
 	ValChan    chan MalType
 	ErrChan    chan error
 	CancelFunc context.CancelFunc
-	Done       bool
-	Cancelled  bool
+	// Done and Cancelled are read from other goroutines (future-done? /
+	// future-cancelled?) while the future's goroutine and Cancel write
+	// them, so they are atomic. Read with .Load(), not as bare bools.
+	Done      atomic.Bool
+	Cancelled atomic.Bool
 
 	Fn     MalFunc
 	Meta   MalType
@@ -135,7 +139,7 @@ func NewFuture(ctx context.Context, fn MalFunc) *Future {
 		Fn:         fn,
 	}
 	go func() {
-		defer func() { f.Done = true }()
+		defer func() { f.Done.Store(true) }()
 		// The future's goroutine must not share the spawner's debug
 		// thread: see runtime.DetachThread. No-op in release builds.
 		res, err := Apply(runtime.DetachThread(ctx), fn, nil)
@@ -150,12 +154,14 @@ func NewFuture(ctx context.Context, fn MalFunc) *Future {
 }
 
 func (f *Future) Cancel() bool {
-	if !f.Done {
-		f.Cancelled = true
-		f.Done = true
+	// CompareAndSwap makes the check-then-act atomic: whoever flips Done
+	// false→true owns the cancellation. If the goroutine already
+	// finished (Done true), the swap fails and we leave Cancelled false.
+	if f.Done.CompareAndSwap(false, true) {
+		f.Cancelled.Store(true)
 		f.CancelFunc()
 	}
-	return f.Cancelled
+	return f.Cancelled.Load()
 }
 
 func (f *Future) Deref(ctx context.Context) (MalType, error) {

--- a/lib/concurrent/future_race_test.go
+++ b/lib/concurrent/future_race_test.go
@@ -1,0 +1,53 @@
+package concurrent
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/types"
+)
+
+// TestFutureConcurrentStateNoRace exercises the Done/Cancelled flags the
+// way the interpreter does: the future's goroutine writes them while
+// other goroutines poll future-done?/future-cancelled? and one calls
+// Cancel. Before Done/Cancelled were atomic this tripped the race
+// detector (see ROADMAP-robustness.md 1.2); run with `-race`.
+func TestFutureConcurrentStateNoRace(t *testing.T) {
+	base := env.NewEnv()
+	newFn := func() types.MalFunc {
+		return types.MalFunc{
+			Eval: func(_ context.Context, _ types.MalType, _ types.EnvType) (types.MalType, error) {
+				time.Sleep(time.Millisecond)
+				return nil, nil
+			},
+			Exp:    types.List{},
+			Env:    base,
+			Params: types.List{},
+			GenEnv: env.NewSubordinateEnvWithBinds,
+		}
+	}
+
+	for range 200 {
+		f := NewFuture(context.Background(), newFn())
+
+		var wg sync.WaitGroup
+		for range 4 {
+			wg.Go(func() {
+				for range 100 {
+					_ = f.Done.Load()
+					_ = f.Cancelled.Load()
+				}
+			})
+		}
+		wg.Go(func() {
+			f.Cancel()
+		})
+
+		// Always drains the goroutine (value or cancellation error).
+		_, _ = f.Deref(context.Background())
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
## What

`Future.Done` and `Future.Cancelled` were plain bools written by the future's goroutine (and by `Cancel`) while `future-done?` / `future-cancelled?` read them from other goroutines — a data race the race detector flags today. They are now `atomic.Bool`, and `Cancel` uses `CompareAndSwap` so its check-then-act is atomic (whoever flips `Done` false→true owns the cancellation).

## Why it went unseen

The test matrix ran `go test ./...` **without** `-race`. This PR adds a ubuntu-only `race` job (plain + `lispdebug`).

## Verification

- `TestFutureConcurrentStateNoRace` reproduces the race — **4 reports under `-race` on the old code**, passes on the new.
- `go test -race ./...` and `go test -race -tags lispdebug ./...` → both clean.

## Notes

`Future.Done`/`Cancelled` are exported fields; they change type `bool` → `atomic.Bool`. No code in the repo reads them as bare bools (only `concurrent.go`), and the Lisp-level API (`future-done?`, `future-cancelled?`, `future?`) is unchanged. External embedders reading `f.Done` directly would need `f.Done.Load()`.

Closes items 1.1 and 1.2 of `ROADMAP-robustness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)