### PR TITLE
fix(eval): turn four interpreter panics on malformed input into errors

### DIFF
--- a/ROADMAP-robustness.md
+++ b/ROADMAP-robustness.md
@@ -15,10 +15,10 @@ Status summary (tick as you go):
 
 - [x] 1.1 CI: run tests with `-race` (done 2026-07-08)
 - [x] 1.2 Data race in `Future.Done` / `Future.Cancelled` (done 2026-07-08)
-- [ ] 2.1 Panic: `(try 1 (catch))` — catch with no binding
-- [ ] 2.2 Panic: `(try ())` — `first()` on empty list
-- [ ] 2.3 Panic: `(fn [&])` called — trailing `&` in binds
-- [ ] 2.4 Panic: `(quasiquote (unquote))` — and sibling `splice-unquote`
+- [x] 2.1 Panic: `(try 1 (catch))` — catch with no binding (done 2026-07-08)
+- [x] 2.2 Panic: `(try ())` — `first()` on empty list (done 2026-07-08)
+- [x] 2.3 Panic: `(fn [&])` called — trailing `&` in binds (done 2026-07-08)
+- [x] 2.4 Panic: `(quasiquote (unquote))` — and sibling `splice-unquote` (done 2026-07-08)
 - [ ] 2.5 `recur` outside `loop` silently returns the sentinel
 - [ ] 2.6 nil-context contract: `try` panics where the EVAL loop tolerates nil
 - [ ] 2.7 `malRecover` re-panics on non-error panic values
@@ -102,7 +102,15 @@ The neighbouring forms already do this right — `(defmacro)`, `(def)`,
 `(let [x] x)`, `(1 2 3)` all return clean positioned errors — so this
 is finishing a job, not introducing a new convention.
 
-### 2.1 `(try 1 (catch))` — catch with no binding
+**Done 2026-07-08** (branch `fix/interpreter-panics`): 2.1–2.4 fixed;
+`quasiquote`/`qq_loop` now return `(MalType, error)` instead of
+indexing blindly. Regression table
+[malformed_input_test.go](malformed_input_test.go) asserts *error, not
+panic* for every repro (plus a `(fn [3] …)` non-symbol-binding case
+found while fixing 2.3), and pins two happy-path forms. The `catch`
+arity message is unchanged (compat), just moved before the indexing.
+
+### ~~2.1 `(try 1 (catch))` — catch with no binding~~ (done 2026-07-08)
 
 ```
 $ echo '(try 1 (catch))' | lisp /dev/stdin
@@ -115,7 +123,7 @@ unchecked access in the `finally`→`catch` path a few lines below
 (~line 650). Note there *is* already a "catch must have 2 arguments at
 least" check — it just runs after the indexing.
 
-### 2.2 `(try ())` — `first()` on an empty list
+### ~~2.2 `(try ())` — `first()` on an empty list~~ (done 2026-07-08)
 
 ```
 $ echo '(try ())' | lisp /dev/stdin
@@ -126,7 +134,7 @@ panic: runtime error: index out of range [0] with length 0
 but not that it is non-empty before `list.(List).Val[0]`. One-line
 guard; fixes any caller.
 
-### 2.3 `(fn [&])` called — trailing `&` in the binds vector
+### ~~2.3 `(fn [&])` called — trailing `&` in the binds vector~~ (done 2026-07-08)
 
 ```
 $ echo '(def f (fn [&] 1)) (f)' | lisp /dev/stdin
@@ -139,7 +147,7 @@ line: the `.(types.Symbol)` assertion (a non-symbol after `&`, e.g.
 `(fn [& 3])`, panics too). Guard both; return the same kind of
 positioned error the function already produces for arity mismatches.
 
-### 2.4 `(quasiquote (unquote))` — and the `splice-unquote` sibling
+### ~~2.4 `(quasiquote (unquote))` — and the `splice-unquote` sibling~~ (done 2026-07-08)
 
 ```
 $ echo '(quasiquote (unquote))' | lisp /dev/stdin

--- a/env/env.go
+++ b/env/env.go
@@ -60,14 +60,25 @@ func _newSubordinateEnvWithBinds(outer *Env, binds_mt types.MalType, exprs_mt ty
 		i := 0
 		for ; i < len(binds); i++ {
 			if types.Q[types.Symbol](binds[i]) && binds[i].(types.Symbol).Val == "&" {
-				env.data[binds[i+1].(types.Symbol).Val] = types.List{Val: exprs[i:]}
+				if i+1 >= len(binds) {
+					return nil, lisperror.NewLispError(errors.New("missing symbol after '&' in binding list"), nil)
+				}
+				rest, ok := binds[i+1].(types.Symbol)
+				if !ok {
+					return nil, lisperror.NewLispError(fmt.Errorf("expected symbol after '&' in binding list, got %T", binds[i+1]), nil)
+				}
+				env.data[rest.Val] = types.List{Val: exprs[i:]}
 				varargs = true
 				break
 			} else {
 				if i == len(exprs) {
 					return nil, lisperror.NewLispError(fmt.Errorf("too few arguments passed (%d binds, %d arguments passed)", len(binds), len(exprs)), nil)
 				}
-				env.data[binds[i].(types.Symbol).Val] = exprs[i]
+				sym, ok := binds[i].(types.Symbol)
+				if !ok {
+					return nil, lisperror.NewLispError(fmt.Errorf("binding list expected symbol, got %T", binds[i]), nil)
+				}
+				env.data[sym.Val] = exprs[i]
 			}
 		}
 		if !varargs && len(exprs) != i {

--- a/mal.go
+++ b/mal.go
@@ -161,37 +161,50 @@ func starts_with(xs []MalType, sym string) bool {
 	return false
 }
 
-func qq_loop(xs []MalType) MalType {
+func qq_loop(xs []MalType) (MalType, error) {
 	acc := NewList(nil)
 	for i := len(xs) - 1; 0 <= i; i -= 1 {
 		elt := xs[i]
 		switch e := elt.(type) {
 		case List:
 			if starts_with(e.Val, "splice-unquote") {
+				if len(e.Val) < 2 {
+					return nil, lisperror.NewLispError(errors.New("splice-unquote requires exactly 1 argument"), elt)
+				}
 				acc = NewList(lisperror.GetPosition(elt), Symbol{Val: "concat"}, e.Val[1], acc)
 				continue
 			}
 		default:
 		}
-		acc = NewList(lisperror.GetPosition(elt), Symbol{Val: "cons"}, quasiquote(elt), acc)
+		q, err := quasiquote(elt)
+		if err != nil {
+			return nil, err
+		}
+		acc = NewList(lisperror.GetPosition(elt), Symbol{Val: "cons"}, q, acc)
 	}
-	return acc
+	return acc, nil
 }
 
-func quasiquote(ast MalType) MalType {
+func quasiquote(ast MalType) (MalType, error) {
 	switch a := ast.(type) {
 	case Vector:
-		return NewList(a.Cursor, Symbol{Val: "vec"}, qq_loop(a.Val))
+		inner, err := qq_loop(a.Val)
+		if err != nil {
+			return nil, err
+		}
+		return NewList(a.Cursor, Symbol{Val: "vec"}, inner), nil
 	case HashMap, Symbol:
-		return NewList(lisperror.GetPosition(ast), Symbol{Val: "quote"}, ast)
+		return NewList(lisperror.GetPosition(ast), Symbol{Val: "quote"}, ast), nil
 	case List:
 		if starts_with(a.Val, "unquote") {
-			return a.Val[1]
-		} else {
-			return qq_loop(a.Val)
+			if len(a.Val) < 2 {
+				return nil, lisperror.NewLispError(errors.New("unquote requires exactly 1 argument"), ast)
+			}
+			return a.Val[1], nil
 		}
+		return qq_loop(a.Val)
 	default:
-		return ast
+		return ast, nil
 	}
 }
 
@@ -597,9 +610,13 @@ func EVAL(ctx context.Context, ast MalType, env EnvType) (res MalType, e error) 
 		case "quote": // '
 			return a1, nil
 		case "quasiquoteexpand":
-			return quasiquote(a1), nil
+			return quasiquote(a1)
 		case "quasiquote": // `
-			ast = quasiquote(a1)
+			var e error
+			ast, e = quasiquote(a1)
+			if e != nil {
+				return nil, e
+			}
 		case "defmacro":
 			fn, e := EVAL(ctx, a2, env)
 			if e != nil {
@@ -636,17 +653,20 @@ func EVAL(ctx context.Context, ast MalType, env EnvType) (res MalType, e error) 
 
 			switch first(last) {
 			case "catch":
+				if len(last.(List).Val) < 3 {
+					return nil, lisperror.NewLispError(errors.New("catch must have 2 arguments at least"), last)
+				}
 				finallyDo = nil
 				catchBind = last.(List).Val[1]
 				catchDo = List{Val: last.(List).Val[2:], Cursor: last.(List).Cursor}
 				tryDo = List{Val: lst[1 : len(lst)-1], Cursor: ast.(List).Cursor}
-				if len(catchDo.(List).Val) == 0 {
-					return nil, lisperror.NewLispError(errors.New("catch must have 2 arguments at least"), ast)
-				}
 			case "finally":
 				finallyDo = List{Val: last.(List).Val[1:], Cursor: last.(List).Cursor}
 				switch first(prelast) {
 				case "catch":
+					if len(prelast.(List).Val) < 3 {
+						return nil, lisperror.NewLispError(errors.New("catch must have 2 arguments at least"), prelast)
+					}
 					catchBind = prelast.(List).Val[1]
 					catchDo = List{Val: prelast.(List).Val[2:], Cursor: prelast.(List).Cursor}
 					tryDo = List{Val: lst[1 : len(lst)-2], Cursor: ast.(List).Cursor}
@@ -775,8 +795,11 @@ func EVAL(ctx context.Context, ast MalType, env EnvType) (res MalType, e error) 
 }
 
 func first(list MalType) string {
-	if list != nil && Q[List](list) && Q[Symbol](list.(List).Val[0]) {
-		return list.(List).Val[0].(Symbol).Val
+	if list != nil && Q[List](list) {
+		l := list.(List).Val
+		if len(l) > 0 && Q[Symbol](l[0]) {
+			return l[0].(Symbol).Val
+		}
 	}
 	return ""
 }

--- a/malformed_input_test.go
+++ b/malformed_input_test.go
@@ -1,0 +1,68 @@
+package lisp
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/jig/lisp/env"
+	. "github.com/jig/lisp/types"
+)
+
+// TestMalformedInputNoPanic guards the interpreter against panicking on
+// malformed but well-read Lisp input — for an embeddable interpreter a
+// bad config file must surface a LispError, never crash the host Go
+// process. Each case previously panicked with an index-out-of-range
+// (see ROADMAP-robustness.md phase 2). A few valid forms are included to
+// pin that the guards did not break the happy path.
+func TestMalformedInputNoPanic(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		wantErr bool
+	}{
+		// 2.1 — catch clause with no binding / body.
+		{"try-catch-no-binding", "(try 1 (catch))", true},
+		{"try-catch-finally-no-binding", "(try 1 (catch) (finally 2))", true},
+		// 2.2 — first() on an empty list; must not panic, evaluates to ().
+		{"try-empty-list", "(try ())", false},
+		// 2.3 — binding vector edge cases.
+		{"fn-trailing-amp", "(do (def f (fn [&] 1)) (f))", true},
+		{"fn-nonsymbol-after-amp", "(do (def g (fn [& 3] 1)) (g 1))", true},
+		{"fn-nonsymbol-binding", "(do (def h (fn [3] 1)) (h 1))", true},
+		// 2.4 — bare unquote / splice-unquote inside quasiquote.
+		{"quasiquote-bare-unquote", "(quasiquote (unquote))", true},
+		{"quasiquote-bare-splice", "(quasiquote ((splice-unquote)))", true},
+		// Happy path — the guards must leave these working.
+		{"try-catch-ok", "(try 1 (catch e e))", false},
+		{"quasiquote-unquote-ok", "(quasiquote (unquote 5))", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewEnv()
+			ast, err := READ(tc.src, nil, e)
+			if err != nil {
+				t.Fatalf("READ(%q): %v", tc.src, err)
+			}
+			_, err = evalNoPanic(t, ast, e)
+			switch {
+			case tc.wantErr && err == nil:
+				t.Fatalf("EVAL(%q): expected an error, got nil", tc.src)
+			case !tc.wantErr && err != nil:
+				t.Fatalf("EVAL(%q): unexpected error: %v", tc.src, err)
+			}
+		})
+	}
+}
+
+// evalNoPanic runs EVAL and turns a panic into a test failure rather
+// than a process crash, so a regression reports cleanly.
+func evalNoPanic(t *testing.T, ast MalType, e EnvType) (res MalType, err error) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("EVAL panicked instead of returning an error: %v", r)
+		}
+	}()
+	return EVAL(context.Background(), ast, e)
+}


### PR DESCRIPTION
## What

Four pieces of malformed—but well-read—Lisp input crashed the host Go process with an index-out-of-range panic. For an embeddable interpreter (config files, transmission format) a bad input must surface a `LispError`, never `panic`.

| Input | Was |
|---|---|
| `(try 1 (catch))` | panic: index out of range [1] |
| `(try ())` | panic: index out of range [0] |
| `(def f (fn [&] 1)) (f)` | panic: index out of range [1] |
| `(quasiquote (unquote))` | panic: index out of range [1] |

## Fix

- `quasiquote` / `qq_loop` now return `(MalType, error)` and reject a bare `unquote` / `splice-unquote` instead of indexing blindly.
- The `catch` arity check moved **before** the indexing in both the `catch` and `finally`→`catch` paths — **message unchanged** (`catch must have 2 arguments at least`) for compatibility with error-string matching.
- `env._newSubordinateEnvWithBinds` rejects a dangling `&` and non-symbol bindings (`(fn [3] …)`, `(fn [& 3] …)`) with positioned errors.

## Tests

`malformed_input_test.go` — a table asserting *error, not panic* for every repro (plus the `(fn [3] …)` non-symbol case found while fixing 2.3), and two happy-path forms pinned so the guards don't break normal quasiquote/try.

`go test ./...`, `go test -tags lispdebug ./...` and `go vet ./...` all clean.

Closes items 2.1–2.4 of `ROADMAP-robustness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)