### PR TITLE
test(fuzz): add FuzzReadStr and FuzzEval to guard against panics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,20 @@ jobs:
     - run: go test -race ./...
     - run: go test -race -tags lispdebug ./...
 
+  # Smoke-fuzz READ and EVAL: a short run per push that would have caught
+  # the phase-2 panics. It mainly re-runs the committed seed corpus plus a
+  # little exploration; long fuzzing sessions stay manual/local. A crasher
+  # is written under testdata/fuzz/ and committed so it becomes a seed.
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+    - uses: actions/setup-go@v6
+      with:
+        go-version: 1.25.x
+    - run: go test -run='^$' -fuzz='^FuzzReadStr$' -fuzztime=30s ./reader/
+    - run: go test -run='^$' -fuzz='^FuzzEval$' -fuzztime=30s .
+
   quality:
     runs-on: ubuntu-latest
     steps:

--- a/ROADMAP-robustness.md
+++ b/ROADMAP-robustness.md
@@ -22,7 +22,7 @@ Status summary (tick as you go):
 - [x] 2.5 `recur` outside `loop` silently returns the sentinel (done 2026-07-08)
 - [x] 2.6 nil-context contract: `try` panics where the EVAL loop tolerates nil (done 2026-07-08)
 - [x] 2.7 `malRecover` re-panics on non-error panic values (done 2026-07-08)
-- [ ] 3.1 Fuzz tests for READ and EVAL
+- [x] 3.1 Fuzz tests for READ and EVAL (done 2026-07-08)
 - [ ] 4.1 Honest coverage numbers (`-coverpkg`) + targeted gap tests
 - [ ] 5.1 Document the embedding contract
 - [ ] 5.2 `lib/coreextented` typo in the public import path
@@ -218,7 +218,19 @@ trivial.*
 
 ## Phase 3 — fuzzing (surgical; validates phase 2)
 
-### 3.1 Fuzz tests for READ and EVAL
+**Done 2026-07-08** (branch `feature/fuzzing`): `FuzzReadStr`
+([reader/fuzz_test.go](reader/fuzz_test.go)) and `FuzzEval`
+([fuzz_test.go](fuzz_test.go)), seeded with valid forms + every phase-2
+repro. `FuzzEval` is `package lisp_test` (external) because `nscore`
+imports `lisp`; it reads then evaluates under a 100ms timeout in a
+fresh child of a core-loaded env so top-level defs don't leak. Both ran
+**70s locally with no crasher**. CI gained a `fuzz` job (30s each).
+Known limit documented in the test: deep non-tail Lisp recursion can
+still exhaust the Go stack (unrecoverable) — byte-level fuzzing is very
+unlikely to synthesise it, and a recursion-depth limit is a separate
+item, not covered here.
+
+### ~~3.1 Fuzz tests for READ and EVAL~~ (done 2026-07-08)
 
 Native Go fuzzing would have found every panic in phase 2 unattended.
 Two targets:

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,67 @@
+package lisp_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core/nscore"
+)
+
+// evalFuzzSeeds mirrors the reader seeds but as whole programs worth
+// evaluating: happy-path forms plus the phase-2 malformed inputs, which
+// must now return an error rather than panic.
+var evalFuzzSeeds = []string{
+	"(+ 1 2)",
+	"(let [a 1 b 2] (+ a b))",
+	"(loop [i 0] (if (< i 3) (recur (+ i 1)) i))",
+	"(try 1 (catch e e))",
+	"(try (throw \"boom\") (catch e e))",
+	"(map (fn [x] (* x x)) (list 1 2 3))",
+	"(reduce + 0 [1 2 3 4])",
+	"`(1 ~(+ 1 1) ~@(list 3 4))",
+	"(def f (fn [& xs] (count xs))) (f 1 2 3)",
+	// phase-2 shapes: error, not panic
+	"(try ())",
+	"(try 1 (catch))",
+	"(quasiquote (unquote))",
+	"(def g (fn [&] 1)) (g)",
+	"(recur 1 2)",
+	"((fn [] (recur 1)))",
+}
+
+// FuzzEval asserts EVAL never panics on any well-read input. Each input
+// is read, then evaluated under a short timeout in a fresh child of a
+// core-loaded env, so top-level defs don't leak between iterations and
+// infinite loops are cut off by the context.
+//
+// Note: like any interpreter for a Turing-complete language, deep
+// non-tail Lisp recursion can still exhaust the Go stack (an
+// unrecoverable fatal error, not a catchable panic). Byte-level fuzzing
+// from these seeds is very unlikely to synthesise such programs; a
+// recursion-depth limit is tracked separately, not here.
+func FuzzEval(f *testing.F) {
+	base := env.NewEnv()
+	if err := nscore.Load(base); err != nil {
+		f.Fatalf("load core: %v", err)
+	}
+	for _, s := range evalFuzzSeeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, src string) {
+		ast, err := lisp.READ(src, nil, base)
+		if err != nil {
+			return // a read error is a valid outcome
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("EVAL panicked on %q: %v", src, r)
+			}
+		}()
+		_, _ = lisp.EVAL(ctx, ast, env.NewSubordinateEnv(base))
+	})
+}

--- a/reader/fuzz_test.go
+++ b/reader/fuzz_test.go
@@ -1,0 +1,67 @@
+package reader_test
+
+import (
+	"testing"
+
+	"github.com/jig/lisp/reader"
+)
+
+// fuzzSeeds are shared shapes for the reader and eval fuzzers: valid
+// forms exercising every syntactic construct, plus the malformed inputs
+// that used to panic (ROADMAP-robustness.md phase 2). The corpus grows
+// from here as the fuzzer discovers new inputs under testdata/fuzz/.
+var fuzzSeeds = []string{
+	// valid
+	"(+ 1 2)",
+	"(def x 1)",
+	"(let [a 1 b 2] (+ a b))",
+	"[1 2 3]",
+	"{:a 1 :b 2}",
+	"#{1 2 3}",
+	"(fn [x & xs] xs)",
+	"(try 1 (catch e e) (finally 2))",
+	"(quasiquote (unquote 5))",
+	"`(1 ~x ~@ys)",
+	"(loop [i 0] (if (< i 3) (recur (+ i 1)) i))",
+	";; a comment\n(+ 1 1)",
+	"\"a string\\n\"",
+	"'quoted",
+	"@deref",
+	"1.5",
+	"-42",
+	":keyword",
+	"nil true false",
+	// malformed shapes fixed in phase 2 — must read or error, never panic
+	"(try ())",
+	"(try 1 (catch))",
+	"(try 1 (catch) (finally 2))",
+	"(quasiquote (unquote))",
+	"(quasiquote ((splice-unquote)))",
+	"(fn [&])",
+	"(fn [& 3])",
+	"(fn [3])",
+	"(recur 1 2)",
+	")",
+	"(((((",
+	"{:a}",
+	"[",
+	"\"unterminated",
+	"",
+}
+
+// FuzzReadStr asserts the reader never panics: any input must yield an
+// AST or an error. Read_str is called without an environment, so no Go
+// constructors are involved — pure syntax.
+func FuzzReadStr(f *testing.F) {
+	for _, s := range fuzzSeeds {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, src string) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Read_str panicked on %q: %v", src, r)
+			}
+		}()
+		_, _ = reader.Read_str(src, nil, nil)
+	})
+}


### PR DESCRIPTION
## What

Native Go fuzzers for the two entry points that the phase-2 panics slipped through, so that class of bug is caught automatically from now on.

- **`FuzzReadStr`** (`reader/`): `Read_str` on arbitrary input must yield an AST or an error, never panic.
- **`FuzzEval`** (`package lisp_test`, external — `nscore` imports `lisp`, so it can't be an internal test): READ then EVAL under a 100ms timeout in a fresh child of a core-loaded env, so top-level `def`s don't leak between iterations and infinite loops are cut off by the context.

Both are seeded with valid forms exercising every syntactic construct plus every phase-2 repro (`(try ())`, `(try 1 (catch))`, `(quasiquote (unquote))`, `(fn [&])`, `(recur 1 2)`, …).

## Results

Ran **70s locally each, no crasher**. No `testdata/fuzz/` is committed because there are no crashers (the interesting corpus lives in Go's build cache). CI gains a short `fuzz` job (30s per target) — mainly re-running the seed corpus plus a little exploration.

## Known limit (documented in `FuzzEval`)

Like any interpreter for a Turing-complete language, deep **non-tail** Lisp recursion can exhaust the Go stack — an unrecoverable fatal error, not a catchable panic. Byte-level fuzzing from these seeds is very unlikely to synthesise such a program; a configurable recursion-depth limit is a separate concern, not this PR.

Closes item 3.1 of `ROADMAP-robustness.md` — **phase 3 complete**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)