### PR TITLE
docs(embed): document the embedding contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,48 @@ func ExampleEVAL() {
 }
 ```
 
+### Embedding contract
+
+Guarantees an embedder can rely on. The interpreter is meant to run
+untrusted or hand-written Lisp (config files, a transmission format), so
+the boundaries matter.
+
+**Panics vs errors.** `READ`, `EVAL` and the `REPL*` helpers report
+problems by returning an `error` (a `lisperror.LispError` carrying a
+source position and a stack trace). Malformed input — bad syntax, wrong
+arity, ill-formed special forms — returns an error and must never panic
+the host process; if you can make a plain Lisp string panic `EVAL`,
+that is an interpreter bug, please report it. Two things are *not*
+covered by this: a builtin handed a Go value of the wrong dynamic type
+by your own code, and unbounded **non-tail** recursion, which can
+exhaust the Go stack (an unrecoverable fatal error, not a catchable
+panic — `loop`/`recur` and tail calls run in constant stack and are
+safe). The Lisp `(panic x)` builtin is a deliberate feature: it is
+caught by the builtin call boundary and surfaces as an `error`, so it
+does not crash the host either.
+
+**Context.** `EVAL` takes a `context.Context`. Pass one with a deadline
+(`context.WithTimeout`) to bound execution — `try` reserves 80% of the
+remaining time for the body and 20% for `catch`/`finally`, and a
+cancelled context stops evaluation with a timeout error. A `nil`
+context is accepted and simply disables cancellation and timeouts; use
+`context.TODO()` in tests, a real context in production.
+
+**Concurrency.** An `Env` is internally synchronised (an `RWMutex`), so
+concurrent reads and definitions are safe at the structure level. The
+recommended pattern is one shared base env holding the loaded libraries
+plus a per-goroutine child (`env.NewSubordinateEnv(base)`) for each
+`EVAL`, so top-level `def`s don't leak between evaluations. Share
+*mutable* state between goroutines through **atoms** (`atom`, `swap!`,
+`reset!` — thread-safe), not by `def`-ing into a shared env. `future`
+runs its body on its own goroutine; in `lispdebug` builds it detaches
+from the debug session (see the roadmap for multi-thread debugging).
+
+**Matching errors.** Since errors are decorated with a `file:line:`
+prefix and a stack trace, match them with `strings.Contains` (or
+`errors.Is` / `errors.As` against a `lisperror.LispError`), not string
+equality.
+
 ### Create new Go builtins
 
 You can create new Go builtins and register them in the environment.

--- a/ROADMAP-robustness.md
+++ b/ROADMAP-robustness.md
@@ -24,7 +24,7 @@ Status summary (tick as you go):
 - [x] 2.7 `malRecover` re-panics on non-error panic values (done 2026-07-08)
 - [x] 3.1 Fuzz tests for READ and EVAL (done 2026-07-08)
 - [ ] 4.1 Honest coverage numbers (`-coverpkg`) + targeted gap tests
-- [ ] 5.1 Document the embedding contract
+- [x] 5.1 Document the embedding contract (done 2026-07-08)
 - [ ] 5.2 `lib/coreextented` typo in the public import path
 - [ ] 5.3 Sweep of commented-out dead code
 - [ ] 5.4 Release notes for tags
@@ -289,7 +289,16 @@ Optional: add the `-coverpkg` run to CI with a soft threshold
 
 ## Phase 5 — maintainability and documentation (pick at leisure)
 
-### 5.1 Document the embedding contract
+### ~~5.1 Document the embedding contract~~ (done 2026-07-08)
+
+**Done 2026-07-08** (branch `docs/embedding-contract`): an "Embedding
+contract" section in the README plus a `# Embedding contract` block in
+the root-package godoc, covering panics-vs-errors (incl. the non-tail
+recursion and `(panic …)` caveats), nil context, the shared-base +
+per-goroutine-child + atoms concurrency pattern, and `strings.Contains`
+error matching. The concurrency claim was checked with a throwaway
+`-race` test (50 concurrent EVALs over a shared base env mutating one
+atom → 50, clean).
 
 The README explains *how* to embed but not the *guarantees*. One
 "Embedding contract" section (README or root-package godoc) stating:

--- a/mal.go
+++ b/mal.go
@@ -25,6 +25,27 @@
 // Functions and file directories keep the same structure as original MAL, this is way
 // main functions [READ], [EVAL] and [PRINT] keep its all caps (non Go standard) names.
 //
+// # Embedding contract
+//
+// The interpreter is meant to run untrusted or hand-written Lisp, so a
+// few boundaries are guaranteed:
+//
+//   - [READ] and [EVAL] report problems as an error (a
+//     lisperror.LispError with position and stack trace). Malformed
+//     Lisp input returns an error and never panics the host; a panic
+//     escaping [EVAL] on a plain Lisp string is a bug. Exceptions:
+//     unbounded non-tail recursion can exhaust the Go stack (tail calls
+//     and loop/recur run in constant stack), and a builtin handed a
+//     wrong-typed Go value by embedder code may still panic.
+//   - [EVAL] accepts a nil context (cancellation and try timeouts are
+//     then disabled); pass a context.WithTimeout deadline to bound
+//     execution.
+//   - An env is internally synchronised; share a base env across
+//     goroutines, give each [EVAL] its own child env, and use atoms for
+//     mutable state shared between goroutines.
+//
+// See the README "Embedding contract" section for the full version.
+//
 // [kanaka/mal]: https://github.com/kanaka/mal
 package lisp
 


### PR DESCRIPTION
## What

Documents the *guarantees* an embedder can rely on — the README so far explained *how* to embed but not the contract. Consolidates the design decisions made across the phase-1/2/3 robustness work into one place.

Two surfaces:
- **README** — a new "Embedding contract" section under *Embed jig/lisp in Go code*.
- **root-package godoc** — a `# Embedding contract` block (renders on pkg.go.dev).

## Content

- **Panics vs errors** — malformed Lisp input returns a `lisperror.LispError`, never panics the host; a panic escaping `EVAL` on a plain Lisp string is a bug. Caveats stated honestly: unbounded **non-tail** recursion can exhaust the Go stack (tail calls and `loop`/`recur` are constant-stack), and the `(panic …)` builtin is a deliberate feature that surfaces as an error.
- **Context** — `nil` is accepted (disables cancellation/`try` timeouts); pass `context.WithTimeout` to bound execution.
- **Concurrency** — shared base env + per-goroutine child env + **atoms** for mutable shared state. Verified with a throwaway `-race` test: 50 concurrent `EVAL`s over a shared base env mutating one atom → 50, clean.
- **Matching errors** — `strings.Contains` / `errors.Is`, not equality, because errors carry a `file:line:` prefix and stack trace.

No code changes; docs only. `go vet` / `go build` clean, godoc renders correctly.

Closes item 5.1 of `ROADMAP-robustness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)