### PR TITLE
docs(changelog): document the error-format change since v0.2.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,105 @@
+# Changelog
+
+Notable changes to `jig/lisp`. Format loosely follows
+[Keep a Changelog](https://keepachangelog.com/). The project is
+pre-1.0, so minor tags can carry behaviour changes; the ones that may
+need action when upgrading are called out under **Changed** with a
+migration note.
+
+## Unreleased (since v0.2.24)
+
+### ⚠️ Changed — error message formatting
+
+Two related changes affect the **text** of error messages (what
+`LispError.Error()` returns, and what the CLI/logs print). They do not
+change any Go API signature, and — importantly — they do **not** change
+the value a `catch` binds (see "What is *not* affected" below). If your
+code matches on, parses, or displays the *text* of errors, read this.
+
+Both changes are, in isolation, fixes: v0.2.24 leaked Go's internal
+struct/reflection formatting into user-facing error text (including
+malformed `%!s(...)` verbs). The new output is the intended
+Lisp-readable form. But the text differs, so treat it as a breaking
+change to the error *format*.
+
+#### 1. Thrown non-error values render as Lisp data
+
+When a non-error value is raised — `(throw {:a 1})`, `(throw 42)`,
+`(throw "boom")`, or a Go builtin failing with a non-`error` payload —
+`Error()` now renders it with the Lisp printer (`printer.Pr_str`)
+instead of Go's `fmt.Sprint`.
+
+| Expression        | v0.2.24 error text                    | develop error text |
+|-------------------|---------------------------------------|--------------------|
+| `(throw "boom")`  | `boom`                                | `"boom"` (quoted)  |
+| `(throw 42)`      | `%!s(int=42)`                         | `42`               |
+| `(throw {:a 1})`  | `{map[ʞa:%!s(int=1)] <nil> -e:1}`     | `{:a 1}`           |
+| `(+ 1 "x")`       | `reflect: Call using string as type int` | `"reflect: Call using string as type int"` (quoted) |
+
+Note the two practical gotchas: thrown **strings are now quoted**
+(`"boom"`, not `boom`), and internal Go error messages that reach this
+path also gain quotes.
+
+(Introduced in the Stage-1 cleanup, commit `6a31817`.)
+
+#### 2. Library / macro-expanded errors carry a `file:line:` prefix
+
+Errors originating inside loaded Lisp library code (the `nscore`
+headers) or inside macro-expanded code now carry a source-position
+prefix they previously lacked, because expanded forms now get source
+positions (commit `63c6647`).
+
+| Expression       | v0.2.24 error text                                | develop error text |
+|------------------|---------------------------------------------------|--------------------|
+| `(reduce + [1])` | `too few arguments passed (…) (around do)`        | `$nscore:29: too few arguments passed (…) (around do)` |
+
+Errors that already had a position (e.g. `-e:1: nth: index out of
+range`) are unchanged.
+
+### What is *not* affected
+
+- **`try`/`catch`.** The value bound in a `catch` clause is the
+  original thrown value, not its formatted text — identical in both
+  versions. `(try (throw {:a 1}) (catch e (get e :a)))` returns `1` in
+  both. If you handle errors by catching and inspecting the value, you
+  need to change nothing.
+- **Go API signatures.** `READ`, `EVAL`, `PRINT`, the `REPL*` helpers,
+  `env.*`, `nscore.Load`, `lisperror.*` etc. keep their signatures.
+  Upgrading does not break compilation.
+- **Printing of normal values.** `prn`, `str`, `json-encode` and the
+  rest render values exactly as before.
+
+### Migration
+
+- **Go embedders matching on error text:** match with
+  `strings.Contains` on a stable substring, never string equality, and
+  expect the new `file:line:` prefix on some messages. Better: type-
+  assert to `lisperror.LispError` and use `ErrorValue()` (the original
+  `MalType`) for thrown values, or `errors.Is` / `errors.As` for Go
+  errors — none of which depend on the rendered text.
+- **Thrown strings:** if you raise a string and later match its text,
+  account for the surrounding quotes (`"boom"`). Prefer raising a value
+  you can inspect in `catch` (a map/keyword) over matching a message.
+- **Lisp code using `try`/`catch`:** inspect the caught **value**, not
+  a formatted string, and you are unaffected.
+- **Tests asserting exact error strings (Go or Lisp `assert-throws`):**
+  update expected strings to the new format, or relax them to substring
+  matches.
+
+See the "Embedding contract" section of the [README](./README.md#embedding-contract)
+for the general error-matching guidance.
+
+### Other notable additions since v0.2.24
+
+Non-breaking, for context (see `git log v0.2.24..` for the full list):
+
+- `loop`/`recur` special forms; `into`, and `conj` accepting `[k v]`
+  pairs / maps
+- `require` with `:as` / `:refer` / `:refer :all`, a module search path
+  and `LISPPATH`
+- LSP/DAP improvements (signature help, hover docs, macro-aware
+  stepping) under the `lispdebug` build tag
+- Clojure-style docstrings on `defn`, and `call.Doc` for documenting Go
+  builtins
+- Robustness pass: malformed input now returns errors instead of
+  panicking, a fixed `Future` data race, and READ/EVAL fuzzers

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This implementation is focused on _embeddability_ in Go projects. See [lisp main
 
 It requires Go 1.25.
 
+> **Upgrading?** See [CHANGELOG.md](./CHANGELOG.md) for behaviour changes
+> that may need action — notably the error-message format changed since
+> v0.2.24.
+
 ## Install
 
 ### Install the interpreter and REPL


### PR DESCRIPTION
## Why

Clients on v0.2.24 reported a behaviour incompatibility with `develop` they couldn't pin down. I traced it by diffing the two binaries over a battery of expressions and running the format-pinning tests against a v0.2.24 worktree.

**It is not an API break** — every exported signature is unchanged, so embedder code keeps compiling. It's a change to error-message **text**, in two parts:

1. **Thrown non-error values** (`(throw {:a 1})`, `(throw 42)`, `(throw "boom")`, or a builtin failing with a non-`error` payload) now render with the Lisp printer instead of Go's `fmt.Sprint`. v0.2.24 leaked Go struct/reflection formatting — including malformed `%!s(...)` verbs — so the new output is a fix, but strings are now **quoted** (`"boom"`). Commit `6a31817`.
2. **Library / macro-expanded errors** now carry a `file:line:` prefix they previously lacked (e.g. `$nscore:29:`). Commit `63c6647`.

## Key point that limits the blast radius

The value bound by a `catch` clause is the **original thrown value**, identical in both versions — only the rendered `.Error()` text differs. Code that catches and inspects the value needs no change; only code that matches/parses/displays the error **text** is affected.

## What this PR adds

- **`CHANGELOG.md`** — before/after tables for both changes, an explicit "what is *not* affected" section, and migration steps (prefer `ErrorValue()` / `errors.Is` and substring matching over exact error-text matching).
- README link to it for anyone upgrading.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)