### PR TITLE
chore: remove commented-out dead code

### DIFF
--- a/ROADMAP-robustness.md
+++ b/ROADMAP-robustness.md
@@ -26,7 +26,7 @@ Status summary (tick as you go):
 - [x] 4.1 Honest coverage numbers (`-coverpkg`) + targeted gap tests (done 2026-07-08)
 - [x] 5.1 Document the embedding contract (done 2026-07-08)
 - [x] 5.2 `lib/coreextented` typo in the public import path (done 2026-07-09)
-- [ ] 5.3 Sweep of commented-out dead code
+- [x] 5.3 Sweep of commented-out dead code (done 2026-07-09)
 - [ ] 5.4 Release notes for tags
 
 Suggested order: phase 1 first (one real bug + the CI line that would
@@ -349,7 +349,16 @@ Related memory note: stdlib functions live in
 directory carries the typo. Decide, then either do 2/3 or strike this
 item as "documented, won't fix".
 
-### 5.3 Sweep of commented-out dead code
+### ~~5.3 Sweep of commented-out dead code~~ (done 2026-07-09)
+
+**Done 2026-07-09** (branch `chore/remove-dead-code`): removed the dead
+commented-out lines in [env/env.go](env/env.go) (four), [mal.go](mal.go)
+(the duplicated `strings.Cut` line) and a stale `// type Here` /
+`// var (…)` block in
+[lib/system/nssystem/nssystem.go](lib/system/nssystem/nssystem.go).
+Pure deletion, 12 lines, tests unchanged. Left as agreed: the intentional
+`do-not-use-GetNT-here` markers, and EVAL's big switch (the `a1`/`a2`
+extraction and mal/TCO structure) — churn there is all risk, no payoff.
 
 Leftover commented code confuses later readers into thinking there is
 a pending decision: [env/env.go](env/env.go) lines ~74, ~78, ~191,

--- a/env/env.go
+++ b/env/env.go
@@ -82,11 +82,9 @@ func _newSubordinateEnvWithBinds(outer *Env, binds_mt types.MalType, exprs_mt ty
 			}
 		}
 		if !varargs && len(exprs) != i {
-			// return nil, fmt.Errorf("too many arguments passed (%d binds, %d arguments passed)", len(binds), len(exprs))
 			return nil, lisperror.NewLispError(fmt.Errorf("too many arguments passed (%d binds, %d arguments passed)", len(binds), len(exprs)), nil)
 		}
 	}
-	//return &et, nil
 	return env, nil
 }
 
@@ -199,14 +197,12 @@ func (e *Env) GetNT(key types.Symbol) (types.MalType, error) {
 		// do-not-use-GetNT-here
 		return e.outer.Get(key)
 	} else {
-		// return nil, errors.New("'" + key.Val + "' not found")
 		return nil, lisperror.NewLispError(fmt.Errorf("symbol '%w' not found", errors.New(key.Val)), key)
 	}
 }
 
 func (e *Env) RemoveNT(key types.Symbol) error {
 	if _, ok := e.data[key.Val]; !ok {
-		// return errors.New("types.symbol not found")
 		return lisperror.NewLispError(fmt.Errorf("symbol '%w' not found", errors.New(key.Val)), key)
 	}
 	delete(e.data, key.Val)

--- a/lib/system/nssystem/nssystem.go
+++ b/lib/system/nssystem/nssystem.go
@@ -5,13 +5,6 @@ import (
 	"github.com/jig/lisp/types"
 )
 
-// type Here struct{}
-
-// var (
-// 	__package_fullpath__ = strings.Split(reflect.TypeFor[Here]().PkgPath(), "/")
-// 	_package_            = "$" + __package_fullpath__[len(__package_fullpath__)-1]
-// )
-
 func Load(env types.EnvType) error {
 	system.Load(env)
 	return nil

--- a/mal.go
+++ b/mal.go
@@ -131,7 +131,6 @@ func READWithPreamble(str string, cursor *Position, ns EnvType) (MalType, error)
 	i := 0
 	for ; ; i++ {
 		var line string
-		// line, str, _ = strings.Cut(str, "\n")
 		line, str, _ = strings.Cut(str, "\n")
 		line = strings.Trim(line, " \t\r\n")
 		if len(line) == 0 {


### PR DESCRIPTION
## What

Pure deletion of leftover commented-out code that reads as a pending decision (roadmap item 5.3):

- **`env/env.go`** — four dead `// return …` / `//return &et, nil` lines that duplicate the live code right below them.
- **`mal.go`** — the duplicated `// line, str, _ = strings.Cut(...)` line above its live copy.
- **`lib/system/nssystem/nssystem.go`** — a stale `// type Here struct{}` + `// var (…)` block from an old package-path approach.

12 lines removed, no behaviour change. **Kept on purpose:** the intentional `do-not-use-GetNT-here` markers (they warn against the non-locking variant), and EVAL's big switch (the `a1`/`a2` extraction / mal-TCO structure — churn there is all risk, no payoff).

`go test ./...`, `go vet` and `gofmt` clean.

Closes item 5.3 of `ROADMAP-robustness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)