### PR TITLE
docs: add RELEASING.md documenting the release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ It requires Go 1.25.
 
 > **Upgrading?** See [CHANGELOG.md](./CHANGELOG.md) for behaviour changes
 > that may need action — notably the error-message format changed since
-> v0.2.24.
+> v0.2.24. Maintainers: see [RELEASING.md](./RELEASING.md) for how a tag
+> is cut.
 
 ## Install
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,66 @@
+# Releasing jig/lisp
+
+How a tagged release is cut. The goal of this document (roadmap item
+5.4) is that every future tag ships with notes — the historical tags up
+to `v0.2.24` have none.
+
+## Branch model
+
+- **`develop`** — integration branch; every PR merges here.
+- **`main`** — release branch; only fast-forwarded/merged from `develop`
+  at release time. `origin/HEAD` points here.
+- **Tags** `vMAJOR.MINOR.PATCH` live on `main`.
+
+Pre-1.0, so a **minor** bump may carry breaking changes (e.g. the
+`coreextented` → `coreextended` rename and the error-format change land
+in 0.3). Anything users must act on goes in `CHANGELOG.md` under
+**Changed** with a migration note.
+
+## Cutting a release
+
+1. **Make sure `develop` is green** — the `test`, `race`, `fuzz` and
+   `quality` CI jobs all pass.
+
+2. **Finalise the changelog.** In `CHANGELOG.md`, rename the
+   `## Unreleased (since vX)` heading to `## vNEW — YYYY-MM-DD` and open
+   a fresh empty `## Unreleased` above it. This section becomes the
+   release notes, so keep the **Changed / breaking** items at the top.
+
+3. **Merge `develop` into `main`.**
+
+   ```bash
+   git checkout main && git merge --ff-only develop   # or a merge commit
+   git push origin main
+   ```
+
+4. **Tag `main` with an annotated tag** (historical tags are lightweight;
+   prefer annotated from now on so `git describe` and the release carry a
+   message):
+
+   ```bash
+   git tag -a vNEW -m "jig/lisp vNEW"
+   git push origin vNEW
+   ```
+
+5. **Publish the GitHub release** with the changelog section as the body:
+
+   ```bash
+   # notes taken from the just-finalised CHANGELOG section
+   gh release create vNEW --title "vNEW" --notes-file <(sed -n '/## vNEW/,/## v/p' CHANGELOG.md)
+   # or let GitHub auto-generate from merged PRs and edit afterwards:
+   # gh release create vNEW --generate-notes
+   ```
+
+6. **Verify** the module is installable at the new tag:
+
+   ```bash
+   go install github.com/jig/lisp/cmd/lisp@vNEW
+   ```
+
+## Backfilling older tags (optional)
+
+The tags up to `v0.2.24` predate the changelog and have no GitHub
+release. Backfilling is optional; if wanted, `gh release create <tag>
+--generate-notes` produces reasonable notes from the merged PRs between
+tags. Start with the next release rather than spending effort on old
+ones.

--- a/ROADMAP-robustness.md
+++ b/ROADMAP-robustness.md
@@ -27,7 +27,7 @@ Status summary (tick as you go):
 - [x] 5.1 Document the embedding contract (done 2026-07-08)
 - [x] 5.2 `lib/coreextented` typo in the public import path (done 2026-07-09)
 - [ ] 5.3 Sweep of commented-out dead code
-- [ ] 5.4 Release notes for tags
+- [x] 5.4 Release notes for tags (done 2026-07-09)
 
 Suggested order: phase 1 first (one real bug + the CI line that would
 have caught it), then phase 2 (all four panics share the same fix
@@ -359,7 +359,16 @@ switch in mal.go (~lines 491–504) collapses to two `if len > n`
 lookups. **Deliberately out of scope: restructuring EVAL's big switch
 — it is the mal/TCO style and churn there is all risk, no payoff.**
 
-### 5.4 Release notes for tags
+### ~~5.4 Release notes for tags~~ (done 2026-07-09)
+
+**Done 2026-07-09** (branch `docs/release-process`): added
+[RELEASING.md](RELEASING.md) documenting the develop→main→tag flow and a
+6-step release procedure (finalise CHANGELOG `Unreleased` → merge to
+main → annotated tag → `gh release create` with the changelog section →
+verify `go install @tag`). No GitHub release is cut here — that is an
+outward-facing action for the maintainer to run at the 0.3 bump. Now
+that `CHANGELOG.md` exists, the notes come from it rather than raw merge
+commits. Backfilling historical tags stays optional.
 
 Tags reach v0.2.24 with no changelog anywhere. Lightest viable
 process: `gh release create` per tag with auto-generated notes from


### PR DESCRIPTION
## What

Roadmap item 5.4: the tags up to `v0.2.24` have no release notes anywhere. Rather than cut releases (an outward-facing action for the maintainer), this **documents the process** so every future tag ships with notes.

`RELEASING.md` covers:
- **Branch model** — `develop` (integration) → `main` (release) → `vX.Y.Z` tags, and the pre-1.0 note that a *minor* can carry breaking changes.
- **6-step release procedure** — finalise the `CHANGELOG.md` `Unreleased` section → merge `develop` into `main` → cut an **annotated** tag (historical ones are lightweight) → `gh release create` with the changelog section as the body → verify `go install @tag`.
- **Optional backfill** of historical tags via `--generate-notes`.

Linked from the README. Docs only — no code, no releases created.

Closes item 5.4 of `ROADMAP-robustness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)