### PR TITLE
printer: honour fmt.Stringer in Pr_str

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -74,6 +74,13 @@ func Pr_str(obj types.MalType, print_readably bool) string {
 		return fmt.Sprintf("«function %v»", obj)
 	case error:
 		return "«go-error " + Pr_str(tobj.Error(), true) + "»"
+	case fmt.Stringer:
+		// Honour fmt.Stringer so Go values carrying a custom String()
+		// (e.g. *big.Int) render meaningfully instead of exposing their
+		// internal struct layout. This must come before the pointer
+		// dereference below, as many Stringer methods use pointer
+		// receivers and would otherwise be lost on indirection.
+		return tobj.String()
 	default:
 		if v := reflect.ValueOf(obj); v.Kind() == reflect.Pointer {
 			// if the value is a pointer, dereference it to print the value instead of the address

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -2,6 +2,8 @@ package printer_test
 
 import (
 	"errors"
+	"math/big"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -75,6 +77,27 @@ func TestPrStrPointer(t *testing.T) {
 	var p *int
 	if got := printer.Pr_str(p, true); got != "nil" {
 		t.Fatalf("nil *int = %q, want nil", got)
+	}
+}
+
+// pointerStringer is a helper whose String() has a pointer receiver, so
+// it would be lost if Pr_str dereferenced the value before checking for
+// fmt.Stringer.
+type pointerStringer struct{ n int }
+
+func (p *pointerStringer) String() string { return "stringer:" + strconv.Itoa(p.n) }
+
+// TestPrStrStringer covers the fmt.Stringer branch: Go values with a
+// custom String() must render via that method instead of exposing their
+// internal struct layout. *big.Int is the motivating real-world case
+// (its String() uses a pointer receiver, so it is only reachable before
+// the pointer dereference in the default branch).
+func TestPrStrStringer(t *testing.T) {
+	if got, want := printer.Pr_str(big.NewInt(1234567890), true), "1234567890"; got != want {
+		t.Fatalf("*big.Int = %q, want %q", got, want)
+	}
+	if got, want := printer.Pr_str(&pointerStringer{n: 7}, true), "stringer:7"; got != want {
+		t.Fatalf("*pointerStringer = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Render Go values that implement `fmt.Stringer` via their `String()` method instead of exposing their internal struct layout.

The check is placed before the pointer dereference in the default branch, because many `Stringer` implementations (e.g. `*big.Int`) use pointer receivers and would otherwise be lost on indirection.

## Tests

Add `TestPrStrStringer` covering both `*big.Int` and a pointer-receiver `Stringer` helper.