### PR TITLE
fix(printer): guard nil pointer in the fmt.Stringer branch

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -80,6 +80,14 @@ func Pr_str(obj types.MalType, print_readably bool) string {
 		// internal struct layout. This must come before the pointer
 		// dereference below, as many Stringer methods use pointer
 		// receivers and would otherwise be lost on indirection.
+		//
+		// Guard a nil pointer receiver first: the default branch below
+		// renders any nil pointer as "nil", but reaching String() here
+		// short-circuits that, and a String() that dereferences its
+		// receiver would panic. Keep the safe "nil" rendering.
+		if v := reflect.ValueOf(tobj); v.Kind() == reflect.Pointer && v.IsNil() {
+			return "nil"
+		}
 		return tobj.String()
 	default:
 		if v := reflect.ValueOf(obj); v.Kind() == reflect.Pointer {

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -101,6 +101,28 @@ func TestPrStrStringer(t *testing.T) {
 	}
 }
 
+// TestPrStrNilStringer guards the nil-pointer case of the fmt.Stringer
+// branch: a nil pointer whose String() dereferences its receiver
+// (pointerStringer) must render as "nil", not panic. Before the nil
+// guard the Stringer branch called String() on the nil pointer and
+// crashed, where the default branch had safely printed "nil".
+func TestPrStrNilStringer(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Pr_str panicked on a nil Stringer pointer: %v", r)
+		}
+	}()
+
+	var ps *pointerStringer
+	if got := printer.Pr_str(ps, true); got != "nil" {
+		t.Fatalf("nil *pointerStringer = %q, want %q", got, "nil")
+	}
+	var bi *big.Int
+	if got := printer.Pr_str(bi, true); got != "nil" {
+		t.Fatalf("nil *big.Int = %q, want %q", got, "nil")
+	}
+}
+
 // TestPrList covers Pr_list joining directly.
 func TestPrList(t *testing.T) {
 	got := printer.Pr_list([]types.MalType{1, 2, 3}, true, "<", ">", ",")


### PR DESCRIPTION
## What

Follow-up to #67. The new `case fmt.Stringer` in `Pr_str` runs **before** the `default` branch's `v.IsNil()` check. So a **nil pointer** whose `String()` dereferences its receiver now panics inside `Pr_str`, where the default branch previously rendered it safely as `"nil"`.

```
nil *big.Int        → "nil"    (big.Int.String() is nil-safe)
nil unsafe Stringer → PANIC    runtime error: invalid memory address or nil pointer dereference
```

`Pr_str` is called broadly (including `LispError.Error()` and all value printing), so this is a panic path an embedder can reach by registering a Go type with a nil-unsafe `String()`. It's not reachable from pure Lisp (the only internal `Stringer` is `*Position`, which is nil-safe), but it's the kind of "printing never panics" hole the robustness pass has been closing.

## Fix

Guard a nil pointer receiver before calling `String()`, keeping the safe `"nil"` rendering. Well-behaved Stringers (e.g. `*big.Int`) are unaffected — a non-nil value still renders via `String()`.

## Test

`TestPrStrNilStringer` covers a nil pointer whose `String()` dereferences its receiver (the `pointerStringer` helper from #67) plus a nil `*big.Int`. Verified it **panics without the guard** and passes with it.

`go test ./...`, `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)