### PR TITLE
feat(cli): tools.cli-style command-line option parsing library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,9 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   pairs / maps
 - `require` with `:as` / `:refer` / `:refer :all`, a module search path
   and `LISPPATH`
+- `cli` library — command-line option parsing modelled on
+  clojure/tools.cli (`cli/parse-opts`), plus the `subs`, `starts-with?`
+  and `ends-with?` string builtins it builds on
 - LSP/DAP improvements (signature help, hover docs, macro-aware
   stepping) under the `lispdebug` build tag
 - Clojure-style docstrings on `defn`, and `call.Doc` for documenting Go

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Changes respect to [kanaka/mal](https://github.com/kanaka/mal):
 - Clojure-style docstrings: `(defn name "docstring" [params] body…)` attaches a docstring to the function, readable with `(doc name)` and surfaced by the LSP. Backwards compatible — a leading string is a docstring only when a parameter vector follows it
 - Go builtins can be documented from the code that registers them with `call.Doc(env, name, arglist, doc)`; the docs travel with the value in the environment, so the LSP and `(doc name)` describe exactly the builtins an interpreter loads — including an embedder's own. Native-function `meta` stays `nil` (kanaka/mal compatible): documentation lives in dedicated fields, not metadata
 - `partial` function added (see [./tests/stepN_defn.mal.go](./tests/stepN_defn.mal) for an example of `partial` usage, or go to Clojure documentation)
+- `subs`, `starts-with?` and `ends-with?` string functions (Clojure-style; `subs` counts in Unicode code points)
+- `cli` library for command-line option parsing, modelled on [clojure/tools.cli](https://github.com/clojure/tools.cli) — `(cli/parse-opts *ARGV* specs)`. See [./lib/cli/README.md](./lib/cli/README.md)
 
 ## Embed jig/lisp in Go code
 

--- a/cmd/lisp/main.go
+++ b/cmd/lisp/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jig/lisp/command"
 	"github.com/jig/lisp/env"
 	"github.com/jig/lisp/lib/assert/nsassert"
+	"github.com/jig/lisp/lib/cli/nscli"
 	"github.com/jig/lisp/lib/concurrent/nsconcurrent"
 	"github.com/jig/lisp/lib/core/nscore"
 	"github.com/jig/lisp/lib/coreextended/nscoreextended"
@@ -36,6 +37,7 @@ func main() {
 		{"lazy", nslazy.Load},
 		{"require", nsrequire.Load("lisp")},
 		{"sql", nssql.Load},
+		{"cli", nscli.Load},
 	} {
 		if err := library.load(ns); err != nil {
 			log.Fatalf("Library Load Error: %v\n", err)

--- a/lib/cli/README.md
+++ b/lib/cli/README.md
@@ -1,0 +1,72 @@
+# lib/cli — command-line option parsing for jig/lisp
+
+A small option parser modelled on
+[clojure/tools.cli](https://github.com/clojure/tools.cli), written in
+**pure Lisp**. It turns a raw argument sequence (typically `*ARGV*`) into
+a map of parsed options, leftover positional arguments, a generated help
+string, and any errors.
+
+## Loading
+
+`cmd/lisp` loads it by default, so scripts can use `cli/parse-opts`
+directly. To embed it:
+
+```go
+import "github.com/jig/lisp/lib/cli/nscli"
+
+nscli.Load(ns) // evaluates the pure-Lisp header into the environment
+```
+
+It depends on core and the extended core (`reduce`, `filter`, `map`,
+`keyword`, `subs`, `starts-with?`, …), so load those first.
+
+## Usage
+
+```lisp
+(def specs
+  [["-p" "--port PORT" "Port to listen on"
+    :default 8080
+    :parse-fn read-string
+    :validate [(fn [n] (and (< 0 n) (< n 65536))) "must be 0..65535"]]
+   ["-v" "--verbose" "Verbose output"]
+   ["-h" "--help"    "Show help"]])
+
+(def parsed (cli/parse-opts *ARGV* specs))
+
+(get parsed :options)    ; => {:port 8080 :verbose true}
+(get parsed :arguments)  ; => ["file.txt"]   (positionals)
+(get parsed :errors)     ; => nil, or ["--port: must be 0..65535" …]
+(get parsed :summary)    ; => a help string, one line per option
+```
+
+Read result fields with `get` (the `(:key m)` shorthand is not
+supported).
+
+## Option specs
+
+Each spec is a vector `[short long desc & kv-opts]`:
+
+| element | meaning |
+|---------|---------|
+| `short` | short flag, e.g. `"-p"` (or `nil`) |
+| `long`  | `"--port PORT"` (takes an argument) or `"--verbose"` (boolean flag) |
+| `desc`  | one-line description, used by the summary |
+
+Optional key/value options:
+
+| key | meaning |
+|-----|---------|
+| `:default val`        | value placed in `:options` when the flag is absent |
+| `:parse-fn fn`        | applied to the raw string, e.g. `read-string` for a number |
+| `:validate [pred msg]`| `pred` is called on the parsed value; `msg` is reported on failure (and the value is rejected) |
+| `:id keyword`         | override the derived id (default: the long flag without `--`) |
+
+## Subset (vs tools.cli)
+
+Implemented: short/long flags, boolean flags, `:default`, `:parse-fn`,
+`:validate`, `:id`, the `--` end-of-options separator, positional
+arguments, and a generated summary.
+
+Not yet implemented: the `--opt=val` joined form (use `--opt val`),
+short grouping (`-abc`), `:update-fn` / `:multi` (repeated flags), and
+in-order / sub-command parsing.

--- a/lib/cli/cli.go
+++ b/lib/cli/cli.go
@@ -1,0 +1,12 @@
+// Package cli provides command-line option parsing for jig/lisp,
+// modelled on clojure/tools.cli. It is pure Lisp: the namespace is a
+// header evaluated into the environment (see nscli.Load), exposing
+// cli/parse-opts and cli/summarize.
+package cli
+
+import _ "embed"
+
+//go:embed header-cli.lisp
+var headerCli string
+
+func HeaderCli() string { return headerCli }

--- a/lib/cli/cli_test.go
+++ b/lib/cli/cli_test.go
@@ -1,0 +1,90 @@
+package cli_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/cli/nscli"
+	"github.com/jig/lisp/lib/concurrent/nsconcurrent"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/coreextended/nscoreextended"
+	"github.com/jig/lisp/types"
+)
+
+func newEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	for _, load := range []func(types.EnvType) error{
+		nscore.Load,
+		nscore.LoadInput,
+		nsconcurrent.Load,
+		nscoreextended.Load, // reduce, filter, map, keyword, … used by the header
+		nscli.Load,          // the namespace under test
+	} {
+		if err := load(ns); err != nil {
+			t.Fatalf("load: %v", err)
+		}
+	}
+	return ns
+}
+
+func run(t *testing.T, ns types.EnvType, src string) string {
+	t.Helper()
+	res, err := lisp.REPL(context.Background(), ns, src, types.NewCursorFile("test"))
+	if err != nil {
+		t.Fatalf("eval %q: %v", src, err)
+	}
+	s, ok := res.(string)
+	if !ok {
+		t.Fatalf("REPL returned %T for %q, want printed string", res, src)
+	}
+	return s
+}
+
+func TestParseOpts(t *testing.T) {
+	ns := newEnv(t)
+
+	// A representative spec set: an option with a parse-fn + validate, a
+	// boolean flag, and a help flag. Defined once in the env.
+	run(t, ns, `(def specs
+		[["-p" "--port PORT" "Port number" :default 80 :parse-fn read-string
+		  :validate [(fn [n] (and (< 0 n) (< n 65536))) "must be 0..65535"]]
+		 ["-v" "--verbose" "Verbosity"]
+		 ["-h" "--help" "Show help"]])`)
+
+	cases := []struct{ name, src, want string }{
+		// Map fields are read with get to avoid map key-order flakiness.
+		{"long-with-arg", `(get (get (cli/parse-opts ["--port" "8080"] specs) :options) :port)`, "8080"},
+		{"default-applied", `(get (get (cli/parse-opts [] specs) :options) :port)`, "80"},
+		{"short-boolean-flag", `(get (get (cli/parse-opts ["-v"] specs) :options) :verbose)`, "true"},
+		{"positional-args", `(get (cli/parse-opts ["-v" "a" "b"] specs) :arguments)`, `["a" "b"]`},
+		{"double-dash-separator", `(get (cli/parse-opts ["--" "--port" "x"] specs) :arguments)`, `["--port" "x"]`},
+		{"no-errors-when-ok", `(get (cli/parse-opts ["--port" "80"] specs) :errors)`, "nil"},
+		{"unknown-option", `(get (cli/parse-opts ["--nope"] specs) :errors)`, `["Unknown option: --nope"]`},
+		{"validate-failure", `(get (cli/parse-opts ["--port" "99999"] specs) :errors)`, `["--port: must be 0..65535"]`},
+		{"missing-argument", `(get (cli/parse-opts ["--port"] specs) :errors)`, `["Missing argument for --port"]`},
+		// *ARGV* is a List, not a Vector: parse-opts must accept both.
+		{"accepts-a-list", `(get (get (cli/parse-opts (list "--port" "22") specs) :options) :port)`, "22"},
+		// A failed validation must not leave a bad value in :options
+		// (the default stays).
+		{"invalid-keeps-default", `(get (get (cli/parse-opts ["--port" "0"] specs) :options) :port)`, "80"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := run(t, ns, tc.src); got != tc.want {
+				t.Fatalf("%s = %q, want %q", tc.src, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	ns := newEnv(t)
+	got := run(t, ns, `(cli/summarize [["-v" "--verbose" "Be loud"]])`)
+	want := `"  -v --verbose  Be loud\n"`
+	if got != want {
+		t.Fatalf("summarize = %q, want %q", got, want)
+	}
+}

--- a/lib/cli/header-cli.lisp
+++ b/lib/cli/header-cli.lisp
@@ -1,0 +1,128 @@
+;; cli — command-line option parsing for jig/lisp, modelled on
+;; clojure/tools.cli (a pragmatic subset). Pure Lisp.
+;;
+;; (cli/parse-opts args specs) parses a sequence of argument strings
+;; (typically *ARGV*) against a vector of option specs and returns a map
+;;   {:options   {…}      ; parsed option values, keyed by :id
+;;    :arguments [...]     ; leftover positional arguments
+;;    :summary   "…"       ; a help string built from the specs
+;;    :errors    nil|[…]}  ; error messages, or nil when all is well
+;; Read fields with get, e.g. (get result :options).
+;;
+;; A spec is a vector [short long desc & kv-opts]:
+;;   short   short flag string, e.g. "-p" (or nil)
+;;   long    long flag string, e.g. "--port PORT" (with an argument name)
+;;           or "--verbose" (no argument name → boolean flag)
+;;   desc    one-line description
+;; kv-opts (optional):
+;;   :default val         value when the option is absent
+;;   :parse-fn fn          applied to the raw string, e.g. read-string
+;;   :validate [pred msg]  pred is called on the parsed value; msg on fail
+;;   :id keyword           override the derived id (default: long w/o "--")
+;;
+;; Subset limitations (vs tools.cli): only the separate "--opt val" form
+;; (no "--opt=val"), no short grouping ("-abc"), no :update-fn/:multi,
+;; no in-order/sub-command parsing.
+(do
+  (defn cli/-compile-spec [spec]
+    (let [short (nth spec 0)
+          long  (nth spec 1)
+          desc  (nth spec 2)
+          kvs   (apply hash-map (drop 3 spec))
+          parts (split long " ")
+          flag  (nth parts 0)
+          takes (= (count parts) 2)]
+      (hash-map
+        :short       short
+        :long        flag
+        :arg-name    (if takes (nth parts 1) nil)
+        :desc        desc
+        :takes-arg   takes
+        :id          (if (contains? kvs :id) (get kvs :id) (keyword (subs flag 2)))
+        :has-default (contains? kvs :default)
+        :default     (get kvs :default)
+        :parse-fn    (get kvs :parse-fn)
+        :validate    (get kvs :validate))))
+
+  (defn cli/-find-spec [compiled tok]
+    (first (filter
+             (fn [s] (or (= (get s :long) tok) (= (get s :short) tok)))
+             compiled)))
+
+  ;; Apply parse-fn then validate. Returns [ok? value-or-message].
+  (defn cli/-coerce [spec raw]
+    (let [pf  (get spec :parse-fn)
+          val (if pf (pf raw) raw)
+          v   (get spec :validate)]
+      (if v
+        (if ((nth v 0) val)
+          [true val]
+          [false (str (get spec :long) ": " (nth v 1))])
+        [true val])))
+
+  (defn cli/-defaults [compiled]
+    (reduce
+      (fn [m s] (if (get s :has-default) (assoc m (get s :id) (get s :default)) m))
+      {}
+      compiled))
+
+  (defn cli/-option-token? [tok]
+    (and (starts-with? tok "-") (not (= tok "-")) (not (= tok "--"))))
+
+  (defn cli/summarize
+    "Builds a help string from a vector of option specs, one line per option."
+    [specs]
+    (reduce
+      (fn [acc s]
+        (str acc
+             "  " (if (get s :short) (get s :short) "  ")
+             " " (get s :long)
+             (if (get s :arg-name) (str " " (get s :arg-name)) "")
+             "  " (get s :desc) "\n"))
+      ""
+      (map cli/-compile-spec specs)))
+
+  (defn cli/parse-opts
+    ¬Parses args (typically *ARGV*) against a vector of option specs.
+Returns a map:
+  :options   parsed values keyed by :id
+  :arguments leftover positional arguments
+  :summary   generated help text
+  :errors    a vector of messages, or nil when all is well¬
+    [args specs]
+    (let [compiled (map cli/-compile-spec specs)]
+      (loop [toks    args
+             opts    (cli/-defaults compiled)
+             posargs []
+             errs    []
+             no-opts false]
+        (if (empty? toks)
+          (hash-map
+            :options   opts
+            :arguments posargs
+            :summary   (cli/summarize specs)
+            :errors    (if (empty? errs) nil errs))
+          (let [tok  (first toks)
+                more (rest toks)]
+            (cond
+              no-opts
+                (recur more opts (conj posargs tok) errs true)
+              (= tok "--")
+                (recur more opts posargs errs true)
+              (cli/-option-token? tok)
+                (let [spec (cli/-find-spec compiled tok)]
+                  (cond
+                    (nil? spec)
+                      (recur more opts posargs (conj errs (str "Unknown option: " tok)) no-opts)
+                    (get spec :takes-arg)
+                      (if (empty? more)
+                        (recur more opts posargs (conj errs (str "Missing argument for " tok)) no-opts)
+                        (let [res (cli/-coerce spec (first more))]
+                          (if (nth res 0)
+                            (recur (rest more) (assoc opts (get spec :id) (nth res 1)) posargs errs no-opts)
+                            (recur (rest more) opts posargs (conj errs (nth res 1)) no-opts))))
+                    :else
+                      (recur more (assoc opts (get spec :id) true) posargs errs no-opts)))
+              :else
+                (recur more opts (conj posargs tok) errs no-opts)))))))
+)

--- a/lib/cli/nscli/nscli.go
+++ b/lib/cli/nscli/nscli.go
@@ -1,0 +1,28 @@
+// Package nscli loads the cli command-line-parsing namespace into a
+// jig/lisp environment.
+package nscli
+
+import (
+	"context"
+	_ "embed"
+	"reflect"
+	"strings"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/lib/cli"
+	"github.com/jig/lisp/types"
+)
+
+type Here struct{}
+
+var (
+	__package_fullpath__ = strings.Split(reflect.TypeFor[Here]().PkgPath(), "/")
+	_package_            = "$" + __package_fullpath__[len(__package_fullpath__)-1]
+)
+
+func Load(env types.EnvType) error {
+	if _, err := lisp.REPL(context.Background(), env, cli.HeaderCli(), types.NewCursorFile(_package_)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -69,6 +69,9 @@ func Load(env EnvType) {
 	call.Call(env, mErge)
 	call.Call(env, rename_keys)
 	call.Call(env, split)
+	call.Call(env, subs, 2, 3)
+	call.CallOverrideFN(env, "starts-with?", func(s, prefix string) (bool, error) { return strings.HasPrefix(s, prefix), nil })
+	call.CallOverrideFN(env, "ends-with?", func(s, suffix string) (bool, error) { return strings.HasSuffix(s, suffix), nil })
 	call.Call(env, mAp)
 	call.Call(env, throw)
 	call.CallOverrideFN(env, "symbol", func(a string) (Symbol, error) { return Symbol{Val: a}, nil })
@@ -1154,6 +1157,32 @@ func deref(ctx context.Context, ref Dereferable) (MalType, error) {
 
 func uUid() (string, error) {
 	return uuid.New().String(), nil
+}
+
+// subs returns the substring of s from start (inclusive) to end
+// (exclusive), counted in Unicode code points (runes) like Clojure's
+// subs. With two arguments it runs to the end of the string.
+func subs(args ...MalType) (MalType, error) {
+	s, ok := args[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("subs requires a string (it was %T)", args[0])
+	}
+	runes := []rune(s)
+	start, ok := args[1].(int)
+	if !ok {
+		return nil, fmt.Errorf("subs start must be an int (it was %T)", args[1])
+	}
+	end := len(runes)
+	if len(args) == 3 {
+		end, ok = args[2].(int)
+		if !ok {
+			return nil, fmt.Errorf("subs end must be an int (it was %T)", args[2])
+		}
+	}
+	if start < 0 || start > end || end > len(runes) {
+		return nil, fmt.Errorf("subs index out of range (start=%d end=%d len=%d)", start, end, len(runes))
+	}
+	return string(runes[start:end]), nil
 }
 
 func split(str, sep string) (Vector, error) {

--- a/tests/stepH_strings.mal
+++ b/tests/stepH_strings.mal
@@ -20,3 +20,25 @@
 ;; compatible with first
 (first (split "abc-abc" "-"))
 ;=>"abc"
+
+;; Testing "subs" function (counted in Unicode code points)
+(subs "hello" 1 3)
+;=>"el"
+(subs "hello" 2)
+;=>"llo"
+(subs "héllo" 1 3)
+;=>"él"
+(subs "hello" 0 0)
+;=>""
+(subs "hello" 5)
+;=>""
+
+;; Testing "starts-with?" and "ends-with?"
+(starts-with? "--foo" "--")
+;=>true
+(starts-with? "-f" "--")
+;=>false
+(ends-with? "file.txt" ".txt")
+;=>true
+(ends-with? "file.txt" ".md")
+;=>false


### PR DESCRIPTION
## What

A new **pure-Lisp** library for parsing command-line options in scripts, modelled on [clojure/tools.cli](https://github.com/clojure/tools.cli). It fills a real gap: today script arguments reach the interpreter as `*ARGV*` (a raw list) with nothing to interpret them.

```lisp
(def specs
  [["-p" "--port PORT" "Port" :default 8080 :parse-fn read-string
    :validate [(fn [n] (and (< 0 n) (< n 65536))) "must be 0..65535"]]
   ["-v" "--verbose" "Verbose"]])

(cli/parse-opts *ARGV* specs)
;; => {:options {:port 8080 :verbose true}
;;     :arguments ["file.txt"]
;;     :summary   "  -p --port PORT  Port\n  -v --verbose  Verbose\n"
;;     :errors    nil}
```

## Design

Per the discussion: **pure Lisp**, **subset** of tools.cli, namespace **`cli`**.

- Two commits: first adds the `subs` / `starts-with?` / `ends-with?` core string builtins the parser needs (Clojure-style; `subs` is Unicode-code-point based and errors on out-of-range instead of panicking); second adds the library.
- Packaged like the other pure-Lisp namespaces (`header-cli.lisp` + `nscli.Load`), loaded by `cmd/lisp` by default, so scripts get `cli/parse-opts` and `cli/summarize` with docstrings.
- Supported: short/long flags, boolean flags, `:default`, `:parse-fn`, `:validate`, `:id`, `--` separator, positional args, generated summary. A failed `:validate` records an error and keeps the default rather than a bad value.
- **Subset (v1):** no `--opt=val`, no short grouping (`-abc`), no `:update-fn`/`:multi`, no sub-commands — documented in `lib/cli/README.md`.

## Tests

- `lib/cli/cli_test.go` — 12 cases: parsing, defaults, short/long, `--` separator, unknown option, validate failure, missing argument, accepting a `List` (`*ARGV*`), invalid-keeps-default; plus `cli/summarize`.
- `tests/stepH_strings.mal` — the new string builtins (incl. a Unicode `subs` case).
- Verified end-to-end through the built binary with real `*ARGV*`.

`go test ./...`, `-tags lispdebug`, `go vet` and `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)