### PR TITLE
docs(cli): correct the dependency list in lib/cli/README.md

### DIFF
--- a/lib/cli/README.md
+++ b/lib/cli/README.md
@@ -17,8 +17,15 @@ import "github.com/jig/lisp/lib/cli/nscli"
 nscli.Load(ns) // evaluates the pure-Lisp header into the environment
 ```
 
-It depends on core and the extended core (`reduce`, `filter`, `map`,
-`keyword`, `subs`, `starts-with?`, …), so load those first.
+Its primitives come almost entirely from **core** — `subs`,
+`starts-with?`, `ends-with?`, `split`, `keyword`, `map`, `assoc`,
+`get`, `conj`, `nth`, `hash-map`, `str`, … are Go builtins there, and
+`defn`/`cond` come from core's basic header. The only functions it
+needs from the **extended core** are `reduce` and `filter`.
+
+So the minimal load sequence is `nscore.Load`, `nsconcurrent.Load`
+(the extended core needs `atom`), `nscoreextended.Load`, then
+`nscli.Load`. `cmd/lisp` already loads all of these.
 
 ## Usage
 


### PR DESCRIPTION
## What

You flagged that `lib/cli/README.md` implied `starts-with?` / `subs` etc. come from **coreextended**. They don't — I added them to **core** (`core.go`) in the same series, alongside the existing core builtins the parser uses.

Verified the provenance of every function the header calls:

- **core** (Go builtins): `subs`, `starts-with?`, `ends-with?`, `split`, `keyword`, `map`, `assoc`, `get`, `conj`, `nth`, `hash-map`, `str`, `apply`, `count`, `drop`, `first`, `rest`, …
- **core basic header**: `defn`, `cond`
- **coreextended** — *only* `reduce` and `filter`

Also corrected the **load order**: the minimal sequence is `nscore.Load` → `nsconcurrent.Load` (coreextended needs `atom`) → `nscoreextended.Load` → `nscli.Load`. Checked empirically that coreextended needs `nsconcurrent` but **not** `nscore.LoadInput`, so the README no longer lists LoadInput as required.

Docs only.

## Note (not changed here)

The commented-out `starts-with?` in `header-coreextended.lisp` (lines ~178) is unrelated: it's an abandoned pure-mal attempt at implementing `=`, and its `starts-with?` operates on **sequences** (list-prefix), not strings. It's dead and harmless — happy to delete it in a separate cleanup if you want, but I left the legacy header untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)