### PR TITLE
docs(builtins): document 8 undocumented Go builtins + guard against gaps

### DIFF
--- a/cmd/lisp/docs_test.go
+++ b/cmd/lisp/docs_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/types"
+)
+
+// TestAllBuiltinsDocumented is the project-wide guard that no Go builtin
+// the binary loads ships without doc metadata (an arglist and a doc
+// string), so the LSP, (doc …) and the doc generator describe every
+// builtin. It loads exactly the namespaces main loads (via the shared
+// libraries list), so a new builtin registered without a call.Doc or a
+// docs.go entry fails here.
+//
+// Lisp-defined functions (MalFunc from the .lisp headers) are exempt —
+// their docs come from optional docstrings, not this metadata.
+func TestAllBuiltinsDocumented(t *testing.T) {
+	ns := env.NewEnv()
+	for _, lib := range libraries(nil) {
+		if err := lib.load(ns); err != nil {
+			t.Fatalf("load %q: %v", lib.name, err)
+		}
+	}
+
+	var missing []string
+	for _, name := range ns.(*env.Env).LocalSymbols() {
+		v, err := ns.Get(types.Symbol{Val: name})
+		if err != nil {
+			continue
+		}
+		if fn, ok := v.(types.Func); ok && (fn.Doc == "" || fn.Arglist == "") {
+			missing = append(missing, name)
+		}
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("Go builtins missing doc/arglist metadata (%d): %v\n"+
+			"Add a call.Doc(env, name, arglist, doc) at registration, or a "+
+			"coreDocs entry for core builtins.", len(missing), missing)
+	}
+}

--- a/cmd/lisp/main.go
+++ b/cmd/lisp/main.go
@@ -18,16 +18,19 @@ import (
 	"github.com/jig/lisp/types"
 )
 
-func main() {
-	ns := env.NewEnv()
+type library struct {
+	name string
+	load func(ns types.EnvType) error
+}
 
-	for _, library := range []struct {
-		name string
-		load func(ns types.EnvType) error
-	}{
+// libraries lists every namespace loaded into the interpreter, in order.
+// It is the single source of truth shared by main and the docs-coverage
+// test (docs_test.go), so the test checks exactly what the binary ships.
+func libraries(scriptArgs []string) []library {
+	return []library{
 		{"core mal", nscore.Load},
 		{"core mal with input", nscore.LoadInput},
-		{"command line args", nscore.LoadCmdLineArgs(command.PreParseArgs(os.Args))},
+		{"command line args", nscore.LoadCmdLineArgs(scriptArgs)},
 		{"concurrent", nsconcurrent.Load},
 		{"core mal extended", nscoreextended.Load},
 		{"assert", nsassert.Load},
@@ -38,7 +41,13 @@ func main() {
 		{"require", nsrequire.Load("lisp")},
 		{"sql", nssql.Load},
 		{"cli", nscli.Load},
-	} {
+	}
+}
+
+func main() {
+	ns := env.NewEnv()
+
+	for _, library := range libraries(command.PreParseArgs(os.Args)) {
 		if err := library.load(ns); err != nil {
 			log.Fatalf("Library Load Error: %v\n", err)
 		}

--- a/lib/concurrent/concurrent.go
+++ b/lib/concurrent/concurrent.go
@@ -43,6 +43,11 @@ func Load(env EnvType) {
 	call.Doc(env, "future-cancelled?", "[future]", "Whether the future was cancelled.")
 	call.Doc(env, "future-done?", "[future]", "Whether the future has finished.")
 	call.Doc(env, "future?", "[x]", "Whether x is a future.")
+	// new-atom / new-future-call are constructors registered for the
+	// reader; atoms and futures cannot be deserialized, so they only
+	// ever error. Documented so the LSP describes them honestly.
+	call.Doc(env, "new-atom", "[atom]", "Constructor placeholder — atoms cannot be deserialized.")
+	call.Doc(env, "new-future-call", "[fn]", "Constructor placeholder — futures cannot be deserialized.")
 }
 
 func future_call(ctx context.Context, f MalFunc) (*Future, error) {

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -80,6 +80,9 @@ var coreDocs = []struct{ name, arglist, doc string }{
 	{"str", "[& args]", "Concatenates the printed representations of its arguments."},
 	{"pr-str", "[& args]", "Like str but with readable (quoted) representations."},
 	{"split", "[string cutset]", "Splits string on any character of cutset, returning a vector."},
+	{"subs", "[s start end]", "Substring of s from start to end (end optional), counted in Unicode code points."},
+	{"starts-with?", "[s prefix]", "Whether string s starts with prefix."},
+	{"ends-with?", "[s suffix]", "Whether string s ends with suffix."},
 	{"read-string", "[string]", "Reads the first lisp form from string."},
 	{"keyword", "[name]", "Creates a keyword from a string."},
 	{"symbol", "[name]", "Creates a symbol from a string."},
@@ -140,7 +143,9 @@ var coreDocs = []struct{ name, arglist, doc string }{
 
 	// Errors & debugging
 	{"error-string", "[err]", "The message of an error as a string."},
+	{"new-error", "[value & [cursor]]", "Creates a lisp error wrapping value, optionally at a source position."},
 	{"go-error", "[format & args]", "Creates a Go error from a format string and arguments."},
+	{"new-go-error", "[message]", "Creates a Go error with the given message."},
 	{"unwrap-error", "[err]", "The error wrapped inside err (Go's errors.Unwrap)."},
 	{"panic", "[value]", "Raises value as a Go panic."},
 	{"spew", "[x]", "Dumps x to stderr in Go syntax for debugging; returns nil."},

--- a/lib/core/docs_test.go
+++ b/lib/core/docs_test.go
@@ -1,11 +1,36 @@
 package core
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/jig/lisp/env"
 	. "github.com/jig/lisp/types"
 )
+
+// TestCoreBuiltinsAllDocumented is the reverse of TestCoreDocsAreHonest:
+// it asserts every Go builtin registered by core Load/LoadInput carries
+// doc metadata, so a new builtin added without a docs.go entry (or a
+// call.Doc) is caught instead of silently reaching the LSP undocumented.
+func TestCoreBuiltinsAllDocumented(t *testing.T) {
+	ns := env.NewEnv()
+	Load(ns)
+	LoadInput(ns)
+	var missing []string
+	for _, name := range ns.(*env.Env).LocalSymbols() {
+		v, err := ns.Get(Symbol{Val: name})
+		if err != nil {
+			continue
+		}
+		if fn, ok := v.(Func); ok && (fn.Doc == "" || fn.Arglist == "") {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("core Go builtins missing doc/arglist (add a coreDocs entry): %v", missing)
+	}
+}
 
 // TestCoreDocsAreHonest asserts every documented core builtin is really
 // registered by Load as a Go function, so the doc table cannot drift

--- a/lib/core/nscore/nscore.go
+++ b/lib/core/nscore/nscore.go
@@ -6,9 +6,17 @@ import (
 	"strings"
 
 	"github.com/jig/lisp"
+	"github.com/jig/lisp/lib/call"
 	"github.com/jig/lisp/lib/core"
 	. "github.com/jig/lisp/types"
 )
+
+// evalDoc documents the eval builtin, registered directly (not via
+// call.Call) in Load and LoadInput; call.Doc must run after each Set so
+// the doc rides on the current Func value.
+func docEval(env EnvType) {
+	call.Doc(env, "eval", "[form]", "Evaluates a lisp form (AST) and returns its result.")
+}
 
 type Here struct{}
 
@@ -22,6 +30,7 @@ func Load(env EnvType) error {
 	env.Set(Symbol{Val: "eval"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
 		return lisp.EVAL(ctx, a[0], env)
 	}})
+	docEval(env)
 
 	if _, err := lisp.REPL(context.Background(), env, core.HeaderBasic(), NewCursorFile(_package_)); err != nil {
 		return err
@@ -34,6 +43,7 @@ func LoadInput(env EnvType) error {
 	env.Set(Symbol{Val: "eval"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
 		return lisp.EVAL(ctx, a[0], env)
 	}})
+	docEval(env)
 
 	if _, err := lisp.REPL(context.Background(), env, core.HeaderLoadFile(), NewCursorFile(_package_)); err != nil {
 		return err

--- a/lsp/server_test.go
+++ b/lsp/server_test.go
@@ -817,9 +817,10 @@ func TestServer_SignatureHelpBuiltin(t *testing.T) {
 
 	uri := "file:///sigb.lisp"
 	// not: (fn [a] …) → named param; cond: (fn [& xs] …) → variadic,
-	// the & is dropped so the label reads (cond xs); new-go-error is an
-	// internal Go builtin left undocumented → no signature.
-	didOpen(t, client, uri, "(not x)\n(cond a b)\n(new-go-error v)\n")
+	// the & is dropped so the label reads (cond xs); new-go-error is a
+	// documented Go builtin → signature from its arglist; an unknown
+	// symbol yields no signature.
+	didOpen(t, client, uri, "(not x)\n(cond a b)\n(new-go-error v)\n(zzz-unknown v)\n")
 
 	// (not |x) → signature from the env MalFunc with the real param name
 	send(t, client, 2, "textDocument/signatureHelp", TextDocumentPositionParams{
@@ -846,14 +847,25 @@ func TestServer_SignatureHelpBuiltin(t *testing.T) {
 		t.Errorf("expected label (cond xs), got %q", label)
 	}
 
-	// undocumented Go builtin (new-go-error) has no signature → null
+	// documented Go builtin (new-go-error) → signature from its arglist
 	send(t, client, 4, "textDocument/signatureHelp", TextDocumentPositionParams{
 		TextDocument: TextDocumentIdentifier{URI: uri},
 		Position:     Position{Line: 2, Character: 14},
 	})
 	resp = readUntil(t, client, response(4))
+	res = resp["result"].(map[string]interface{})
+	if label := res["signatures"].([]interface{})[0].(map[string]interface{})["label"].(string); label != "(new-go-error message)" {
+		t.Errorf("expected label (new-go-error message), got %q", label)
+	}
+
+	// unknown symbol → no signature → null
+	send(t, client, 5, "textDocument/signatureHelp", TextDocumentPositionParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 3, Character: 13},
+	})
+	resp = readUntil(t, client, response(5))
 	if resp["result"] != nil {
-		t.Errorf("expected null for undocumented Go builtin, got %v", resp["result"])
+		t.Errorf("expected null for an unknown symbol, got %v", resp["result"])
 	}
 }
 


### PR DESCRIPTION
## What

You spotted `starts-with?` had no doc in the LSP. It wasn't just that one — the LSP and `(doc …)` read builtin docs from the live env (`types.Func.Doc`/`Arglist`, attached via `call.Doc` / the `coreDocs` table), and **8 Go builtins shipped without it**:

| builtin | namespace | fix |
|---|---|---|
| `subs`, `starts-with?`, `ends-with?` | core | added `coreDocs` entries (these were mine, from the cli series) |
| `eval` | nscore | documented where it's registered (`Load`/`LoadInput`) |
| `new-error`, `new-go-error` | core | added `coreDocs` entries |
| `new-atom`, `new-future-call` | concurrent | documented honestly (placeholders — atoms/futures cannot be deserialized) |

## Guard so it can't happen again

The existing `TestCoreDocsAreHonest` only checks **doc → builtin** (every documented name is a real builtin). Nothing checked the reverse, so an undocumented builtin slipped through silently. Added:

- **`TestCoreBuiltinsAllDocumented`** (core) — every registered core `Func` must carry doc/arglist.
- **`TestAllBuiltinsDocumented`** (cmd/lisp) — a project-wide guard that loads the same namespaces as the binary and fails on any undocumented builtin. `main` now shares its library list via a `libraries()` function, so the test checks exactly what ships.

## Also

- `TestServer_SignatureHelpBuiltin` used `new-go-error` as its "undocumented builtin → null" case. Now that it's documented, the test asserts its signature and uses an **unknown symbol** for the null path.

Verified: `(doc starts-with?)` / `(doc eval)` / … now return their strings; `go test ./...`, `-tags lispdebug`, `-race`, `vet`, `gofmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)