### PR TITLE
feat(integrity): add library to attest and verify lisp source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,9 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
 - `cli` library — command-line option parsing modelled on
   clojure/tools.cli (`cli/parse-opts`), plus the `subs`, `starts-with?`
   and `ends-with?` string builtins it builds on
+- `integrity` library — attest and verify lisp source: `fmt` (canonical
+  formatting, as `lisp --fmt`), `sha2-256`, and deterministic Ed25519
+  signatures (`ed25519-generate`, `ed25519-sign`, `ed25519-verify`)
 - LSP/DAP improvements (signature help, hover docs, macro-aware
   stepping) under the `lispdebug` build tag
 - Clojure-style docstrings on `defn`, and `call.Doc` for documenting Go

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Changes respect to [kanaka/mal](https://github.com/kanaka/mal):
 - `partial` function added (see [./tests/stepN_defn.mal.go](./tests/stepN_defn.mal) for an example of `partial` usage, or go to Clojure documentation)
 - `subs`, `starts-with?` and `ends-with?` string functions (Clojure-style; `subs` counts in Unicode code points)
 - `cli` library for command-line option parsing, modelled on [clojure/tools.cli](https://github.com/clojure/tools.cli) — `(cli/parse-opts *ARGV* specs)`. See [./lib/cli/README.md](./lib/cli/README.md)
+- `integrity` library to attest and verify lisp source: `fmt` (canonical formatting, as `lisp --fmt`), `sha2-256`, and deterministic Ed25519 signatures (`ed25519-generate`, `ed25519-sign`, `ed25519-verify`). See [./lib/integrity/README.md](./lib/integrity/README.md)
 
 ## Embed jig/lisp in Go code
 

--- a/cmd/lisp/main.go
+++ b/cmd/lisp/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jig/lisp/lib/concurrent/nsconcurrent"
 	"github.com/jig/lisp/lib/core/nscore"
 	"github.com/jig/lisp/lib/coreextended/nscoreextended"
+	"github.com/jig/lisp/lib/integrity/nsintegrity"
 	"github.com/jig/lisp/lib/lazy/nslazy"
 	"github.com/jig/lisp/lib/require/nsrequire"
 	"github.com/jig/lisp/lib/sql/nssql"
@@ -41,6 +42,7 @@ func libraries(scriptArgs []string) []library {
 		{"require", nsrequire.Load("lisp")},
 		{"sql", nssql.Load},
 		{"cli", nscli.Load},
+		{"integrity", nsintegrity.Load},
 	}
 }
 

--- a/lib/integrity/README.md
+++ b/lib/integrity/README.md
@@ -1,0 +1,45 @@
+# integrity
+
+Builtins to attest and verify lisp source text: canonical formatting,
+hashing and digital signatures. Typical use: compute a stable digest of
+a `.lisp` file (formatting first, so cosmetic layout differences do not
+change the digest) and sign or verify it.
+
+## Functions
+
+| Function | Returns |
+|---|---|
+| `(fmt s)` | source `s` in canonical form (as `lisp --fmt`); errors if `s` does not parse |
+| `(sha2-256 s)` | SHA2-256 digest of `s`, lowercase hex |
+| `(ed25519-generate)` | key pair `{:public "…" :private "…"}`, base64 |
+| `(ed25519-sign private s)` | base64 signature of `s` |
+| `(ed25519-verify public s signature)` | `true` or `false` |
+
+Ed25519 signing is deterministic: the same key and message always yield
+the same signature bytes, so signatures are reproducible and
+diff-friendly.
+
+## Example
+
+```clojure
+(def keys (ed25519-generate))
+
+(def source (fmt (slurp "program.lisp")))
+(def digest (sha2-256 source))
+
+(def signature (ed25519-sign (get keys :private) digest))
+(ed25519-verify (get keys :public) digest signature) ;; => true
+```
+
+## Loading
+
+Go embedders load the namespace with:
+
+```go
+import "github.com/jig/lisp/lib/integrity/nsintegrity"
+
+nsintegrity.Load(env)
+```
+
+The library has no dependencies beyond `core` (the example above uses
+`slurp` and `get` from core). The `lisp` binary loads it by default.

--- a/lib/integrity/integrity.go
+++ b/lib/integrity/integrity.go
@@ -1,0 +1,96 @@
+// Package integrity provides builtins to attest and verify lisp source:
+// canonical formatting (fmt), hashing (sha2-256) and Ed25519 signatures
+// (ed25519-generate, ed25519-sign, ed25519-verify).
+//
+// Together they let a lisp program compute a stable digest of source
+// text — hashing the canonical form so cosmetic layout differences do
+// not change the digest — and sign or verify it. Ed25519 is used
+// because signing is deterministic: the same key and message always
+// produce the same signature bytes, so signatures are reproducible and
+// diff-friendly. Keys and signatures are exchanged as standard base64
+// strings; digests as lowercase hex.
+package integrity
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/jig/lisp/format"
+	"github.com/jig/lisp/lib/call"
+	. "github.com/jig/lisp/types"
+)
+
+func Load(env EnvType) {
+	// fmt clashes with the Go stdlib package name, so it cannot take
+	// its lisp name from the Go function name as the others do.
+	call.CallOverrideFN(env, "fmt", fmtSource)
+	call.Call(env, sha2_256)
+	call.Call(env, ed25519_generate)
+	call.Call(env, ed25519_sign)
+	call.Call(env, ed25519_verify)
+
+	call.Doc(env, "fmt", "[s]",
+		"Formats lisp source s into its canonical form (as lisp --fmt does); errors if s does not parse.")
+	call.Doc(env, "sha2-256", "[s]",
+		"SHA2-256 digest of string s, as lowercase hex.")
+	call.Doc(env, "ed25519-generate", "[]",
+		"Generates an Ed25519 key pair, as a map {:public :private} of base64 strings.")
+	call.Doc(env, "ed25519-sign", "[private s]",
+		"Signs string s with a base64 Ed25519 private key; returns the base64 signature (deterministic).")
+	call.Doc(env, "ed25519-verify", "[public s signature]",
+		"Reports whether the base64 signature of string s verifies against the base64 Ed25519 public key.")
+}
+
+func fmtSource(s string) (string, error) {
+	out, err := format.Source([]byte(s))
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func sha2_256(s string) (string, error) {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func ed25519_generate() (MalType, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	return HashMap{Val: map[string]MalType{
+		NewKeyword("public"):  base64.StdEncoding.EncodeToString(pub),
+		NewKeyword("private"): base64.StdEncoding.EncodeToString(priv),
+	}}, nil
+}
+
+func ed25519_sign(private, s string) (string, error) {
+	key, err := base64.StdEncoding.DecodeString(private)
+	if err != nil {
+		return "", fmt.Errorf("ed25519-sign: private key is not valid base64: %w", err)
+	}
+	if len(key) != ed25519.PrivateKeySize {
+		return "", fmt.Errorf("ed25519-sign: private key must be %d bytes, got %d", ed25519.PrivateKeySize, len(key))
+	}
+	return base64.StdEncoding.EncodeToString(ed25519.Sign(ed25519.PrivateKey(key), []byte(s))), nil
+}
+
+func ed25519_verify(public, s, signature string) (bool, error) {
+	key, err := base64.StdEncoding.DecodeString(public)
+	if err != nil {
+		return false, fmt.Errorf("ed25519-verify: public key is not valid base64: %w", err)
+	}
+	if len(key) != ed25519.PublicKeySize {
+		return false, fmt.Errorf("ed25519-verify: public key must be %d bytes, got %d", ed25519.PublicKeySize, len(key))
+	}
+	sig, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return false, fmt.Errorf("ed25519-verify: signature is not valid base64: %w", err)
+	}
+	return ed25519.Verify(ed25519.PublicKey(key), []byte(s), sig), nil
+}

--- a/lib/integrity/integrity_test.go
+++ b/lib/integrity/integrity_test.go
@@ -1,0 +1,112 @@
+package integrity_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/integrity"
+	"github.com/jig/lisp/types"
+)
+
+func newEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	if err := nscore.Load(ns); err != nil {
+		t.Fatalf("load core: %v", err)
+	}
+	integrity.Load(ns)
+	return ns
+}
+
+func run(t *testing.T, ns types.EnvType, src string) string {
+	t.Helper()
+	res, err := lisp.REPL(context.Background(), ns, src, types.NewCursorFile("test"))
+	if err != nil {
+		t.Fatalf("eval %q: %v", src, err)
+	}
+	s, ok := res.(string)
+	if !ok {
+		t.Fatalf("REPL returned %T for %q, want printed string", res, src)
+	}
+	return s
+}
+
+// Boolean-valued expressions keep the expected outputs independent of
+// how the printer renders strings.
+func assertTrue(t *testing.T, ns types.EnvType, name, src string) {
+	t.Helper()
+	if got := run(t, ns, src); got != "true" {
+		t.Errorf("%s: %s = %s, want true", name, src, got)
+	}
+}
+
+func TestSha2256(t *testing.T) {
+	ns := newEnv(t)
+	// FIPS 180-2 test vector for "abc".
+	assertTrue(t, ns, "known-vector",
+		`(= (sha2-256 "abc") "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")`)
+	assertTrue(t, ns, "empty-string",
+		`(= (sha2-256 "") "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")`)
+}
+
+func TestFmt(t *testing.T) {
+	ns := newEnv(t)
+	assertTrue(t, ns, "canonical-input-fixpoint",
+		`(= (fmt "(+ 1 2)\n") "(+ 1 2)\n")`)
+	assertTrue(t, ns, "normalises-spacing",
+		`(= (fmt "(+  1   2)") "(+ 1 2)\n")`)
+	assertTrue(t, ns, "collapses-blank-lines",
+		`(= (fmt "(+ 1 2)\n\n\n\n(+ 3 4)\n") "(+ 1 2)\n\n(+ 3 4)\n")`)
+	assertTrue(t, ns, "unbalanced-source-errors",
+		`(try (do (fmt "(((") false) (catch e true))`)
+}
+
+func TestEd25519(t *testing.T) {
+	ns := newEnv(t)
+	run(t, ns, `(def k (ed25519-generate))`)
+	run(t, ns, `(def sig (ed25519-sign (get k :private) "hello"))`)
+
+	assertTrue(t, ns, "verify-roundtrip",
+		`(ed25519-verify (get k :public) "hello" sig)`)
+	assertTrue(t, ns, "tampered-message-fails",
+		`(= false (ed25519-verify (get k :public) "hellO" sig))`)
+	assertTrue(t, ns, "deterministic-signature",
+		`(= sig (ed25519-sign (get k :private) "hello"))`)
+	assertTrue(t, ns, "other-key-fails",
+		`(= false (ed25519-verify (get (ed25519-generate) :public) "hello" sig))`)
+
+	assertTrue(t, ns, "bad-base64-private-errors",
+		`(try (do (ed25519-sign "not base64!" "hello") false) (catch e true))`)
+	assertTrue(t, ns, "short-public-key-errors",
+		`(try (do (ed25519-verify "c2hvcnQ=" "hello" sig) false) (catch e true))`)
+	assertTrue(t, ns, "bad-base64-signature-errors",
+		`(try (do (ed25519-verify (get k :public) "hello" "not base64!") false) (catch e true))`)
+}
+
+// TestIntegrityDocs asserts every integrity builtin carries doc
+// metadata with nil meta, as the other libraries' doc tests do.
+func TestIntegrityDocs(t *testing.T) {
+	ns := env.NewEnv()
+	integrity.Load(ns)
+	for _, name := range []string{"fmt", "sha2-256", "ed25519-generate", "ed25519-sign", "ed25519-verify"} {
+		v, err := ns.Get(types.Symbol{Val: name})
+		if err != nil {
+			t.Errorf("%q not registered", name)
+			continue
+		}
+		fn, ok := v.(types.Func)
+		if !ok {
+			t.Errorf("%q is %T, expected Func", name, v)
+			continue
+		}
+		if fn.Doc == "" || fn.Arglist == "" {
+			t.Errorf("%q missing doc fields", name)
+		}
+		if fn.Meta != nil {
+			t.Errorf("%q meta should stay nil, got %v", name, fn.Meta)
+		}
+	}
+}

--- a/lib/integrity/nsintegrity/nsintegrity.go
+++ b/lib/integrity/nsintegrity/nsintegrity.go
@@ -1,0 +1,11 @@
+package nsintegrity
+
+import (
+	"github.com/jig/lisp/lib/integrity"
+	"github.com/jig/lisp/types"
+)
+
+func Load(env types.EnvType) error {
+	integrity.Load(env)
+	return nil
+}


### PR DESCRIPTION
## Summary

New `lib/integrity` library with five builtins to attest and verify lisp source text:

- `(fmt s)` — canonical formatting, same as `lisp --fmt`, so cosmetic layout differences do not change a digest; errors if `s` does not parse
- `(sha2-256 s)` — SHA2-256 digest as lowercase hex
- `(ed25519-generate)` / `(ed25519-sign private s)` / `(ed25519-verify public s signature)` — Ed25519 signing with keys and signatures as base64 strings

Ed25519 is chosen for its deterministic signatures: the same key and message always produce the same signature bytes, so signatures are reproducible and diff-friendly.

Registered in the `lisp` binary's libraries list (so the docs-coverage guard applies), documented via `call.Doc`, plus README, CHANGELOG and main-README entries.

## Tests

- FIPS 180-2 sha2-256 vectors ("abc", empty string)
- `fmt` fixpoint, spacing normalisation, blank-line collapsing, unbalanced-source error
- Ed25519 roundtrip, tampered message, cross-key rejection, signature determinism, and error paths for malformed base64/short keys
- Doc-metadata guard for the five builtins (nil meta preserved)

`go test ./...` clean on plain and `lispdebug` tags; `go vet` (both tags) and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)