### PR TITLE
feat(core): add spit, the write counterpart of slurp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,8 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
 - `integrity` library — attest and verify lisp source: `fmt` (canonical
   formatting, as `lisp --fmt`), `sha2-256`, and deterministic Ed25519
   signatures (`ed25519-generate`, `ed25519-sign`, `ed25519-verify`)
+- `spit` — the write counterpart of `slurp`, Clojure-style, with
+  `:append true` support
 - LSP/DAP improvements (signature help, hover docs, macro-aware
   stepping) under the `lispdebug` build tag
 - Clojure-style docstrings on `defn`, and `call.Doc` for documenting Go

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Changes respect to [kanaka/mal](https://github.com/kanaka/mal):
 - Go builtins can be documented from the code that registers them with `call.Doc(env, name, arglist, doc)`; the docs travel with the value in the environment, so the LSP and `(doc name)` describe exactly the builtins an interpreter loads — including an embedder's own. Native-function `meta` stays `nil` (kanaka/mal compatible): documentation lives in dedicated fields, not metadata
 - `partial` function added (see [./tests/stepN_defn.mal.go](./tests/stepN_defn.mal) for an example of `partial` usage, or go to Clojure documentation)
 - `subs`, `starts-with?` and `ends-with?` string functions (Clojure-style; `subs` counts in Unicode code points)
+- `spit`, the write counterpart of `slurp` (Clojure-style): `(spit filename s)` creates or truncates, `(spit filename s :append true)` appends
 - `cli` library for command-line option parsing, modelled on [clojure/tools.cli](https://github.com/clojure/tools.cli) — `(cli/parse-opts *ARGV* specs)`. See [./lib/cli/README.md](./lib/cli/README.md)
 - `integrity` library to attest and verify lisp source: `fmt` (canonical formatting, as `lisp --fmt`), `sha2-256`, and deterministic Ed25519 signatures (`ed25519-generate`, `ed25519-sign`, `ed25519-verify`). See [./lib/integrity/README.md](./lib/integrity/README.md)
 

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -285,6 +285,7 @@ func drop_last(n int, arg MalType) (MalType, error) {
 
 func LoadInput(env EnvType) {
 	call.Call(env, slurp)
+	call.Call(env, spit, 2, 4)
 	call.Call(env, readLine)
 
 	loadInputDocs(env)
@@ -488,6 +489,43 @@ func slurp(fileName string) (MalType, error) {
 		}
 	}
 	return string(b), nil
+}
+
+// spit is the write counterpart of slurp, following Clojure's:
+// (spit filename s) creates or truncates the file, and
+// (spit filename s :append true) appends instead.
+func spit(fileName, contents string, opts ...MalType) error {
+	if len(opts)%2 != 0 {
+		return fmt.Errorf("spit: options must be keyword value pairs")
+	}
+	appendMode := false
+	for i := 0; i < len(opts); i += 2 {
+		switch opts[i] {
+		case NewKeyword("append"):
+			b, ok := opts[i+1].(bool)
+			if !ok {
+				return fmt.Errorf("spit: :append expects a boolean (it was %T)", opts[i+1])
+			}
+			appendMode = b
+		default:
+			return fmt.Errorf("spit: unknown option %s", printer.Pr_str(opts[i], true))
+		}
+	}
+	flags := os.O_WRONLY | os.O_CREATE
+	if appendMode {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+	}
+	f, err := os.OpenFile(fileName, flags, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.WriteString(contents); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 // Number functions

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -521,11 +521,12 @@ func spit(fileName, contents string, opts ...MalType) error {
 	if err != nil {
 		return err
 	}
-	if _, err := f.WriteString(contents); err != nil {
-		f.Close()
-		return err
+	_, werr := f.WriteString(contents)
+	cerr := f.Close()
+	if werr != nil {
+		return werr
 	}
-	return f.Close()
+	return cerr
 }
 
 // Number functions

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -28,6 +28,7 @@ func loadInputDocs(env EnvType) {
 
 var inputDocs = []struct{ name, arglist, doc string }{
 	{"slurp", "[filename]", "Reads a file and returns its contents as a string."},
+	{"spit", "[filename s & opts]", "Writes string s to a file, creating or truncating it; with :append true, appends instead."},
 	{"readline", "[prompt]", "Prints prompt and reads a line from input."},
 }
 

--- a/lib/core/spit_test.go
+++ b/lib/core/spit_test.go
@@ -1,0 +1,102 @@
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/types"
+)
+
+func newEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	if err := nscore.Load(ns); err != nil {
+		t.Fatalf("load core: %v", err)
+	}
+	if err := nscore.LoadInput(ns); err != nil {
+		t.Fatalf("load core input: %v", err)
+	}
+	return ns
+}
+
+func run(t *testing.T, ns types.EnvType, src string) string {
+	t.Helper()
+	res, err := lisp.REPL(context.Background(), ns, src, types.NewCursorFile("test"))
+	if err != nil {
+		t.Fatalf("eval %q: %v", src, err)
+	}
+	s, ok := res.(string)
+	if !ok {
+		t.Fatalf("REPL returned %T for %q, want printed string", res, src)
+	}
+	return s
+}
+
+func TestSpit(t *testing.T) {
+	ns := newEnv(t)
+	path := filepath.Join(t.TempDir(), "out.txt")
+
+	if got := run(t, ns, fmt.Sprintf(`(spit %q "hello")`, path)); got != "nil" {
+		t.Errorf("spit returned %s, want nil", got)
+	}
+	if got := run(t, ns, fmt.Sprintf(`(slurp %q)`, path)); got != `"hello"` {
+		t.Errorf("after spit, slurp = %s, want \"hello\"", got)
+	}
+
+	// Default mode truncates.
+	run(t, ns, fmt.Sprintf(`(spit %q "bye")`, path))
+	if got := run(t, ns, fmt.Sprintf(`(slurp %q)`, path)); got != `"bye"` {
+		t.Errorf("after overwrite, slurp = %s, want \"bye\"", got)
+	}
+
+	// :append true appends.
+	run(t, ns, fmt.Sprintf(`(spit %q "!" :append true)`, path))
+	if got := run(t, ns, fmt.Sprintf(`(slurp %q)`, path)); got != `"bye!"` {
+		t.Errorf("after append, slurp = %s, want \"bye!\"", got)
+	}
+
+	// :append false behaves like the default.
+	run(t, ns, fmt.Sprintf(`(spit %q "fresh" :append false)`, path))
+	if got := run(t, ns, fmt.Sprintf(`(slurp %q)`, path)); got != `"fresh"` {
+		t.Errorf("after :append false, slurp = %s, want \"fresh\"", got)
+	}
+
+	// :append with a file that does not exist yet creates it.
+	path2 := filepath.Join(t.TempDir(), "new.txt")
+	run(t, ns, fmt.Sprintf(`(spit %q "first" :append true)`, path2))
+	if got := run(t, ns, fmt.Sprintf(`(slurp %q)`, path2)); got != `"first"` {
+		t.Errorf("append-to-new-file, slurp = %s, want \"first\"", got)
+	}
+}
+
+func TestSpitErrors(t *testing.T) {
+	ns := newEnv(t)
+	path := filepath.Join(t.TempDir(), "out.txt")
+
+	for name, src := range map[string]string{
+		"odd-options":        fmt.Sprintf(`(spit %q "x" :append)`, path),
+		"unknown-option":     fmt.Sprintf(`(spit %q "x" :nonsense true)`, path),
+		"non-boolean-append": fmt.Sprintf(`(spit %q "x" :append 1)`, path),
+	} {
+		if _, err := lisp.REPL(context.Background(), ns, src, types.NewCursorFile("test")); err == nil {
+			t.Errorf("%s: %s should error", name, src)
+		}
+	}
+
+	// A failed spit must not create the file.
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file %s should not exist after failed spits (stat err: %v)", path, err)
+	}
+
+	// Unwritable path errors.
+	if _, err := lisp.REPL(context.Background(), ns,
+		`(spit "/nonexistent-dir/x.txt" "x")`, types.NewCursorFile("test")); err == nil {
+		t.Error("spit to an unwritable path should error")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `spit`, Clojure-style, registered in core `LoadInput` next to `slurp`:

- `(spit filename s)` — creates or truncates the file, writes `s`, returns `nil`
- `(spit filename s :append true)` — appends instead (creates the file if missing)

Options are validated before the file is opened, so a malformed call (odd option count, unknown option, non-boolean `:append`) leaves the filesystem untouched.

Documented in `inputDocs` (covered by the docs guards), plus README and CHANGELOG entries.

## Tests

REPL-level tests: write/read roundtrip via `slurp`, truncate-by-default, append, `:append false`, create-on-append, and the error paths including an unwritable path and the no-file-created-on-error guarantee.

`go test ./...` clean on plain and `lispdebug` tags; `go vet` (both tags) and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)