### PR TITLE
feat(command): bind *FILE* to the script's absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   signatures (`ed25519-generate`, `ed25519-sign`, `ed25519-verify`)
 - `spit` — the write counterpart of `slurp`, Clojure-style, with
   `:append true` support
+- `*FILE*` — absolute path of the script being executed (cf. Clojure's
+  `*file*`); unset in the REPL and `-e`
 - LSP/DAP improvements (signature help, hover docs, macro-aware
   stepping) under the `lispdebug` build tag
 - Clojure-style docstrings on `defn`, and `call.Doc` for documenting Go

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Changes respect to [kanaka/mal](https://github.com/kanaka/mal):
 - `partial` function added (see [./tests/stepN_defn.mal.go](./tests/stepN_defn.mal) for an example of `partial` usage, or go to Clojure documentation)
 - `subs`, `starts-with?` and `ends-with?` string functions (Clojure-style; `subs` counts in Unicode code points)
 - `spit`, the write counterpart of `slurp` (Clojure-style): `(spit filename s)` creates or truncates, `(spit filename s :append true)` appends
+- `*FILE*` holds the absolute path of the script being executed (cf. Clojure's `*file*`), so a script can read its own source; unset in the REPL and `-e`
 - `cli` library for command-line option parsing, modelled on [clojure/tools.cli](https://github.com/clojure/tools.cli) — `(cli/parse-opts *ARGV* specs)`. See [./lib/cli/README.md](./lib/cli/README.md)
 - `integrity` library to attest and verify lisp source: `fmt` (canonical formatting, as `lisp --fmt`), `sha2-256`, and deterministic Ed25519 signatures (`ed25519-generate`, `ed25519-sign`, `ed25519-verify`). See [./lib/integrity/README.md](./lib/integrity/README.md)
 

--- a/command/file_var_test.go
+++ b/command/file_var_test.go
@@ -1,0 +1,58 @@
+package command
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/jig/lisp/types"
+)
+
+// TestRunScript_FileVar asserts *FILE* is bound to the absolute path
+// of the script being run, on both runScript paths (classic load-file
+// and the preamble path).
+func TestRunScript_FileVar(t *testing.T) {
+	script := writeScript(t, "self.lisp", "*FILE*\n")
+	abs, err := filepath.Abs(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ns := preambleTestEnv(t)
+	out, err := runScript(context.Background(), ns, script, nil, types.NewCursorHere(script, -3, 1))
+	if err != nil {
+		t.Fatalf("runScript: %v", err)
+	}
+	if out != `"`+abs+`"` {
+		t.Errorf("classic path: *FILE* = %v, want %q", out, abs)
+	}
+
+	// Preamble path (placeholder present forces the non-load-file path).
+	script2 := writeScript(t, "self2.lisp", ";; $A 1\n(str *FILE*)\n")
+	abs2, err := filepath.Abs(script2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ns2 := preambleTestEnv(t)
+	out, err = runScript(context.Background(), ns2, script2, nil, types.NewCursorHere(script2, -3, 1))
+	if err != nil {
+		t.Fatalf("runScript preamble path: %v", err)
+	}
+	if out != `"`+abs2+`"` {
+		t.Errorf("preamble path: *FILE* = %v, want %q", out, abs2)
+	}
+}
+
+// TestRunScript_FileVarSelfRead asserts the motivating use case: a
+// script reading its own source through *FILE*.
+func TestRunScript_FileVarSelfRead(t *testing.T) {
+	script := writeScript(t, "selfread.lisp", `(starts-with? (slurp *FILE*) "(starts-with?")`+"\n")
+	ns := preambleTestEnv(t)
+	out, err := runScript(context.Background(), ns, script, nil, types.NewCursorHere(script, -3, 1))
+	if err != nil {
+		t.Fatalf("runScript: %v", err)
+	}
+	if out != "true" {
+		t.Errorf("script could not read itself via *FILE*: got %v", out)
+	}
+}

--- a/command/preamble.go
+++ b/command/preamble.go
@@ -74,6 +74,13 @@ func runScript(ctx context.Context, env types.EnvType, fileName string, preamble
 	}
 	registerModule(fileName, abs)
 
+	// *FILE* is the absolute path of the script being executed — the
+	// self-referential counterpart of *ARGV* (cf. Clojure's *file*) —
+	// so a script can slurp or spit its own source. Defined for script
+	// runs only; the REPL and -e leave it unset. load-file does not
+	// rebind it: it always names the top-level script.
+	env.Set(types.Symbol{Val: "*FILE*"}, abs)
+
 	contentBytes, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Adds `*FILE*`, bound to the absolute path of the script being executed — the self-referential counterpart of `*ARGV*`, with Clojure's `*file*` as precedent. Motivating use case: a script that reads (or appends to) its own source, e.g. `(slurp *FILE*)`.

Semantics:
- bound in `runScript`, so both execution paths see it (classic `(load-file …)` bootstrap and the preamble/placeholder path)
- unset in the REPL and `-e` (referencing it there is a normal unknown-symbol error)
- `load-file` does not rebind it: it always names the top-level script

## Tests

- `*FILE*` equals the script's absolute path on both `runScript` paths
- self-read: a script asserts `(starts-with? (slurp *FILE*) …)` over its own first bytes

`go test ./...` clean on plain and `lispdebug` tags; `go vet` (both tags) and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)