### PR TITLE
feat(dap): debugger power — conditional/exception breakpoints, setVariable, step return values

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,11 @@ LSP (Language Server Protocol) server, both enabled with the
 `lispdebug` build tag, plus a VSCode extension in
 [./tools/vscode-lisp](./tools/vscode-lisp). Together they provide:
 
-- **Debugger (DAP)**: breakpoints, step over / in / out, call stack,
-  locals, Debug Console evaluation (with watch and hover) and program
-  output.
+- **Debugger (DAP)**: breakpoints (including conditional breakpoints and
+  logpoints), exception breakpoints (stop where an error is raised),
+  step over / in / out, call stack, locals, editing variables while
+  paused, the return value of a stepped form, Debug Console evaluation
+  (with watch and hover) and program output.
 - **Language server (LSP)**: live parse diagnostics while you type,
   symbol completion (core library plus your `def`/`defn`), hover with
   definition signatures, and the document outline (Ctrl+Shift+O,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,36 +81,37 @@ matches corrupt sources** — needs conservative scope rules and tests
 around shadowing (`let`/`fn` params). *Effort: medium (after
 references). Impact: high.*
 
-### DAP: conditional breakpoints and logpoints
+### ~~DAP: conditional breakpoints and logpoints~~ (done)
 Breakpoints firing only when a condition holds, or logging without
-stopping. VSCode already sends `condition`/`logMessage` in
-`setBreakpoints`; the server must evaluate the condition in the paused
-frame's env — the `evaluate` machinery in
-[debugadapter/server.go](debugadapter/server.go) is reusable, but the
-evaluation happens inside the hook (debuggee goroutine), so watch for
-re-entrancy. *Effort: medium. Impact: high for real debugging
-sessions.*
+stopping. The condition/message is evaluated in the paused frame's env
+from inside the hook; an atomic `evalGuard` checked before `s.mu` is
+taken makes the nested EVAL return immediately instead of dead-locking.
+See [debugadapter/condeval.go](debugadapter/condeval.go).
 
 ## Invasive (plan before starting)
 
-### DAP: exception breakpoints
-Stop automatically where a lisp error is raised, before it unwinds.
-Needs a hook point in EVAL's error path ([mal.go](mal.go)) and the
-`exceptionBreakpointFilters` capability. **Touches the interpreter
-error path.** *Effort: medium. Impact: high — today errors just print
-after the fact.*
+### ~~DAP: exception breakpoints~~ (done)
+Stop automatically where a lisp error is raised, before it unwinds. A
+new optional `runtime.ErrorHook` (`OnError`) is dispatched from
+evalInternal's error-decoration defer, but only at the innermost frame
+the error passes through — detected by its stack still being empty
+before the first `AddStackFrame` — so it fires once, at the raise site,
+with the stack intact. The hook only observes; it never wraps or alters
+the propagating error. Offered as the single "All raised errors" filter.
 
-### DAP: `setVariable`
-Edit a variable from the Variables pane while paused. Mutating the
-paused env is easy (`env.Set`); the risk is semantic (shadowed scopes,
-values shared through closures). *Effort: small-medium. Impact:
-medium.*
+### ~~DAP: `setVariable`~~ (done)
+Edit a variable from the Variables pane while paused. The value
+expression is evaluated in the scope's env and rebound with `env.Set`.
+Only environment scopes (Locals / Closure / Globals) are writable; the
+immutable children of a composite value are rejected.
 
-### DAP: return value after step
-Show the result of the just-executed form as a synthetic `(result)`
-variable after F10/Shift-F11. Requires capturing EVAL results at frame
-pop — **hot-path change in [mal.go](mal.go)** (currently results are
-not recorded anywhere). *Effort: medium. Impact: medium.*
+### ~~DAP: return value after step~~ (done)
+Shows the result of the just-executed form as a synthetic "Return
+value" scope (a `(return)` variable) after F10/Shift-F11. The runtime's
+Thread records each frame's result as it completes; because a form's
+EVAL returns after its sub-forms, the outermost stepped form is the
+last to record. The recording is behind `runtime.Enabled`, so release
+builds are unaffected.
 
 ### DAP: multi-thread debugging (futures)
 The big one, tracked since 2026-07-03: breakpoints and stepping inside
@@ -166,10 +167,11 @@ Item-specific notes:
 
 ## Suggested order
 
-All three quick wins above are done (LISPPATH, module-change watching,
-signature help). Remaining, in order:
+Done: the three quick wins (LISPPATH, module-change watching, signature
+help) and the debugger-power set (conditional breakpoints / logpoints,
+exception breakpoints, setVariable, return value after step). Remaining,
+in order:
 
 1. Find references → rename (the navigation pair)
-2. Conditional breakpoints / logpoints (debugger power)
-3. Exception breakpoints (first invasive one; plan the EVAL hook point)
-4. Multi-thread futures (schedule real time for it)
+2. Multi-thread futures (schedule real time for it)
+3. Semantic tokens / formatting (cosmetic)

--- a/debugadapter/condeval.go
+++ b/debugadapter/condeval.go
@@ -1,0 +1,114 @@
+//go:build lispdebug
+
+package debugadapter
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/printer"
+	"github.com/jig/lisp/types"
+)
+
+// hookEvalTimeout bounds a breakpoint condition or logpoint expression so
+// a runaway expression cannot wedge the debuggee (the hook holds s.mu
+// while it runs).
+const hookEvalTimeout = 2 * time.Second
+
+// evalInHook evaluates expr in env from inside the hook, i.e. while the
+// caller holds s.mu on the debuggee goroutine. It sets evalGuard so the
+// nested EVAL's OnEval returns immediately instead of re-entering the
+// locked state, and runs on a fresh background context carrying no
+// runtime.Thread so it pushes no frames onto the debuggee's stack.
+func (s *state) evalInHook(expr string, env types.EnvType) (types.MalType, error) {
+	s.evalGuard.Store(true)
+	defer s.evalGuard.Store(false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), hookEvalTimeout)
+	defer cancel()
+
+	ast, err := lisp.READ(expr, types.NewAnonymousCursorHere(1, 1), env)
+	if err != nil {
+		return nil, err
+	}
+	return lisp.EVAL(ctx, ast, env)
+}
+
+// evalCondition reports whether a breakpoint condition holds. A condition
+// that fails to evaluate is treated as met, so a mistyped condition stops
+// (and surfaces) rather than silently disabling the breakpoint.
+func (s *state) evalCondition(_ context.Context, expr string, env types.EnvType) bool {
+	v, err := s.evalInHook(expr, env)
+	if err != nil {
+		return true
+	}
+	return truthy(v)
+}
+
+// emitLog interpolates a logpoint message and sends it to the client as
+// output, without pausing. Unlike the `stopped` event (which is sent from
+// a goroutine because pauseAndWait then blocks under s.mu), the send is
+// synchronous: a logpoint does not pause, so ordering the output before
+// execution continues is both safe and what the user expects. Transport
+// writes are serialised by their own mutex.
+func (s *state) emitLog(_ context.Context, msg string, env types.EnvType) {
+	out := s.interpolate(msg, env)
+	s.server.sendEvent("output", OutputEventBody{Category: "console", Output: out + "\n"})
+}
+
+// interpolate expands `{expr}` placeholders in a logpoint message by
+// evaluating each expression in env. `{{` and `}}` are literal braces.
+// An expression that errors is rendered inline as `{error: …}` so the
+// logpoint still produces output.
+func (s *state) interpolate(msg string, env types.EnvType) string {
+	var b strings.Builder
+	for i := 0; i < len(msg); {
+		switch c := msg[i]; c {
+		case '{':
+			if i+1 < len(msg) && msg[i+1] == '{' {
+				b.WriteByte('{')
+				i += 2
+				continue
+			}
+			rel := strings.IndexByte(msg[i+1:], '}')
+			if rel < 0 {
+				// Unbalanced brace: emit the remainder verbatim.
+				b.WriteString(msg[i:])
+				return b.String()
+			}
+			expr := msg[i+1 : i+1+rel]
+			if v, err := s.evalInHook(expr, env); err != nil {
+				b.WriteString("{error: " + err.Error() + "}")
+			} else {
+				b.WriteString(printer.Pr_str(v, false))
+			}
+			i += rel + 2
+		case '}':
+			if i+1 < len(msg) && msg[i+1] == '}' {
+				b.WriteByte('}')
+				i += 2
+				continue
+			}
+			b.WriteByte(c)
+			i++
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return b.String()
+}
+
+// truthy applies Lisp truthiness: everything except nil and boolean
+// false is truthy.
+func truthy(v types.MalType) bool {
+	if v == nil {
+		return false
+	}
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return true
+}

--- a/debugadapter/condeval_test.go
+++ b/debugadapter/condeval_test.go
@@ -1,0 +1,164 @@
+//go:build lispdebug
+
+package debugadapter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/runtime"
+	"github.com/jig/lisp/types"
+)
+
+// launchToConfig runs the initialize/launch/setBreakpoints/configurationDone
+// handshake for a script whose breakpoints carry conditions or log
+// messages, and returns nothing — the caller drives the session from there.
+func launchToConfig(t *testing.T, client *Transport, script string, bps []SourceBreakpoint) {
+	t.Helper()
+	sendRequest(t, client, 1, "initialize", nil)
+	readUntil(t, client, func(m map[string]interface{}) bool { return m["event"] == "initialized" })
+	sendRequest(t, client, 2, "launch", map[string]interface{}{"stopOnEntry": false})
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "launch" && m["type"] == "response"
+	})
+	sendRequest(t, client, 3, "setBreakpoints", SetBreakpointsArguments{
+		Source:      Source{Path: script},
+		Breakpoints: bps,
+	})
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "setBreakpoints" && m["type"] == "response"
+	})
+	sendRequest(t, client, 4, "configurationDone", nil)
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "configurationDone" && m["type"] == "response"
+	})
+}
+
+// TestConditionalBreakpoint verifies a breakpoint with a condition only
+// pauses on the iteration where the condition holds.
+func TestConditionalBreakpoint(t *testing.T) {
+	tmp := t.TempDir()
+	script := filepath.Join(tmp, "cond.lisp")
+	// The breakpoint sits on line 2, inside f's body; f is called three
+	// times so the line is hit with x = 1, 2, 3.
+	src := "(defn f [x]\n" +
+		"  (println x))\n" +
+		"(f 1)\n" +
+		"(f 2)\n" +
+		"(f 3)\n"
+	if err := os.WriteFile(script, []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runtime.Modules.Register(script, script)
+
+	client, server, closer := pair()
+	ns := fullEnv(t)
+	done := make(chan error, 1)
+	eval := func(ctx context.Context, env types.EnvType) error {
+		_, err := lisp.REPL(ctx, env, fmt.Sprintf("(load-file %q)", script), types.NewAnonymousCursorHere(1, 1))
+		done <- err
+		return err
+	}
+	srv := NewServer(server, eval, ns)
+	stop := runServer(t, srv, closer)
+	defer stop()
+
+	launchToConfig(t, client, script, []SourceBreakpoint{{Line: 2, Condition: "(= x 2)"}})
+
+	// It must stop exactly once, with x == 2.
+	if got := stoppedAt(t, client, 5); got != 2 {
+		t.Fatalf("expected stop on line 2, got %d", got)
+	}
+	sendRequest(t, client, 6, "evaluate", map[string]interface{}{
+		"expression": "x", "frameId": 0, "context": "watch",
+	})
+	resp := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "evaluate" && m["type"] == "response"
+	})
+	if body := resp["body"].(map[string]interface{}); body["result"] != "2" {
+		t.Fatalf("expected x=2 at the conditional stop, got %v", body["result"])
+	}
+
+	// Continuing runs to completion without another stop (x=3 fails).
+	sendRequest(t, client, 7, "continue", map[string]interface{}{"threadId": 1})
+	got := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["event"] == "stopped" || m["event"] == "terminated"
+	})
+	if got["event"] != "terminated" {
+		t.Fatalf("expected termination after continue, got another stop: %v", got)
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("eval did not finish")
+	}
+	sendRequest(t, client, 8, "disconnect", nil)
+}
+
+// TestLogpoint verifies a breakpoint with a logMessage emits interpolated
+// output instead of pausing.
+func TestLogpoint(t *testing.T) {
+	tmp := t.TempDir()
+	script := filepath.Join(tmp, "log.lisp")
+	src := "(def n 7)\n" +
+		"(println n)\n"
+	if err := os.WriteFile(script, []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runtime.Modules.Register(script, script)
+
+	client, server, closer := pair()
+	ns := fullEnv(t)
+	done := make(chan error, 1)
+	eval := func(ctx context.Context, env types.EnvType) error {
+		_, err := lisp.REPL(ctx, env, fmt.Sprintf("(load-file %q)", script), types.NewAnonymousCursorHere(1, 1))
+		done <- err
+		return err
+	}
+	srv := NewServer(server, eval, ns)
+	stop := runServer(t, srv, closer)
+	defer stop()
+
+	launchToConfig(t, client, script, []SourceBreakpoint{{Line: 2, LogMessage: "n is {n}!"}})
+
+	// Read to termination, recording that we never stop and that the
+	// interpolated logpoint output arrives.
+	var sawLog bool
+	for {
+		raw, err := client.ReadMessage()
+		if err != nil {
+			t.Fatalf("ReadMessage: %v", err)
+		}
+		var m map[string]interface{}
+		if err := json.Unmarshal(raw, &m); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if m["event"] == "stopped" {
+			t.Fatal("logpoint must not pause execution")
+		}
+		if m["event"] == "output" {
+			body, _ := m["body"].(map[string]interface{})
+			if out, _ := body["output"].(string); out == "n is 7!\n" {
+				sawLog = true
+			}
+		}
+		if m["event"] == "terminated" {
+			break
+		}
+	}
+	if !sawLog {
+		t.Fatal("did not observe the interpolated logpoint output \"n is 7!\"")
+	}
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("eval did not finish")
+	}
+	sendRequest(t, client, 8, "disconnect", nil)
+}

--- a/debugadapter/exception_test.go
+++ b/debugadapter/exception_test.go
@@ -1,0 +1,140 @@
+//go:build lispdebug
+
+package debugadapter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/runtime"
+	"github.com/jig/lisp/types"
+)
+
+// TestExceptionBreakpoint verifies that, with the "all" exception filter
+// enabled, execution pauses at the point a Lisp error is raised — with
+// the raising frame on top of the stack — and then runs to completion
+// when resumed.
+func TestExceptionBreakpoint(t *testing.T) {
+	tmp := t.TempDir()
+	script := filepath.Join(tmp, "boom.lisp")
+	src := "(defn boom []\n" +
+		"  (throw {:code 99}))\n" +
+		"(boom)\n"
+	if err := os.WriteFile(script, []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runtime.Modules.Register(script, script)
+
+	client, server, closer := pair()
+	ns := fullEnv(t)
+	done := make(chan error, 1)
+	eval := func(ctx context.Context, env types.EnvType) error {
+		_, err := lisp.REPL(ctx, env, fmt.Sprintf("(load-file %q)", script), types.NewAnonymousCursorHere(1, 1))
+		done <- err
+		return err
+	}
+	srv := NewServer(server, eval, ns)
+	stop := runServer(t, srv, closer)
+	defer stop()
+
+	sendRequest(t, client, 1, "initialize", nil)
+	readUntil(t, client, func(m map[string]interface{}) bool { return m["event"] == "initialized" })
+	sendRequest(t, client, 2, "launch", map[string]interface{}{"stopOnEntry": false})
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "launch" && m["type"] == "response"
+	})
+	sendRequest(t, client, 3, "setExceptionBreakpoints", SetExceptionBreakpointsArguments{Filters: []string{"all"}})
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "setExceptionBreakpoints" && m["type"] == "response"
+	})
+	sendRequest(t, client, 4, "configurationDone", nil)
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "configurationDone" && m["type"] == "response"
+	})
+
+	// Pause at the raise site: reason "exception", top frame on line 2
+	// (the (throw …) form inside boom).
+	stopped := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["event"] == "stopped"
+	})
+	body := stopped["body"].(map[string]interface{})
+	if body["reason"] != "exception" {
+		t.Fatalf("expected stopped reason=exception, got %v", body["reason"])
+	}
+	sendRequest(t, client, 5, "stackTrace", map[string]interface{}{"threadId": 1, "startFrame": 0, "levels": 20})
+	st := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "stackTrace" && m["type"] == "response"
+	})
+	frames := st["body"].(map[string]interface{})["stackFrames"].([]interface{})
+	top := frames[0].(map[string]interface{})
+	if line, _ := top["line"].(float64); int(line) != 2 {
+		t.Fatalf("expected exception raised on line 2, got %v", top["line"])
+	}
+
+	// Resume: the error keeps unwinding (no second stop) and the program
+	// terminates.
+	sendRequest(t, client, 6, "continue", map[string]interface{}{"threadId": 1})
+	got := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["event"] == "stopped" || m["event"] == "terminated"
+	})
+	if got["event"] != "terminated" {
+		t.Fatalf("expected termination after continue, got another stop: %v", got)
+	}
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected the thrown error to propagate out of eval")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("eval did not finish")
+	}
+	sendRequest(t, client, 7, "disconnect", nil)
+}
+
+// TestExceptionBreakpointDisabledByDefault verifies no pause happens when
+// the client never enables the exception filter.
+func TestExceptionBreakpointDisabledByDefault(t *testing.T) {
+	tmp := t.TempDir()
+	script := filepath.Join(tmp, "boom2.lisp")
+	if err := os.WriteFile(script, []byte("(throw {:code 1})\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runtime.Modules.Register(script, script)
+
+	client, server, closer := pair()
+	ns := fullEnv(t)
+	done := make(chan error, 1)
+	eval := func(ctx context.Context, env types.EnvType) error {
+		_, err := lisp.REPL(ctx, env, fmt.Sprintf("(load-file %q)", script), types.NewAnonymousCursorHere(1, 1))
+		done <- err
+		return err
+	}
+	srv := NewServer(server, eval, ns)
+	stop := runServer(t, srv, closer)
+	defer stop()
+
+	sendRequest(t, client, 1, "initialize", nil)
+	readUntil(t, client, func(m map[string]interface{}) bool { return m["event"] == "initialized" })
+	sendRequest(t, client, 2, "launch", map[string]interface{}{"stopOnEntry": false})
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "launch" && m["type"] == "response"
+	})
+	sendRequest(t, client, 3, "configurationDone", nil)
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "configurationDone" && m["type"] == "response"
+	})
+
+	got := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["event"] == "stopped" || m["event"] == "terminated"
+	})
+	if got["event"] != "terminated" {
+		t.Fatalf("expected no exception pause when the filter is off, got: %v", got)
+	}
+	<-done
+	sendRequest(t, client, 4, "disconnect", nil)
+}

--- a/debugadapter/hook.go
+++ b/debugadapter/hook.go
@@ -177,10 +177,12 @@ func (h *StepHook) OnEval(ctx context.Context, ev runtime.EvalEvent) error {
 			break
 		}
 		if depth <= s.targetDepth {
+			s.captureStepResult()
 			s.pauseAndWait("step", "")
 		}
 	case modeStepOut:
 		if depth < s.targetDepth {
+			s.captureStepResult()
 			s.pauseAndWait("step", "")
 		}
 	default:
@@ -233,6 +235,16 @@ func exceptionMessage(err error) string {
 		return printer.Pr_str(le.ErrorValue(), true)
 	}
 	return err.Error()
+}
+
+// captureStepResult records the value the completing step produced (read
+// from the thread's recorder) so the next pause can surface it as the
+// "Return value" scope. Caller holds s.mu.
+func (s *state) captureStepResult() {
+	if v, ok := s.thread.LastResult(); ok {
+		s.stepResult = v
+		s.hasStepResult = true
+	}
 }
 
 // isDoForm reports whether ast is a `(do …)` special form.

--- a/debugadapter/hook.go
+++ b/debugadapter/hook.go
@@ -36,6 +36,16 @@ type StepHook struct {
 // OnEval implements runtime.EvalHook.
 func (h *StepHook) OnEval(ctx context.Context, ev runtime.EvalEvent) error {
 	s := h.st
+
+	// Re-entrancy guard: evaluating a breakpoint condition or logpoint
+	// message runs EVAL, which calls back into OnEval on this same
+	// goroutine while we already hold s.mu. Bail out before touching the
+	// mutex so that nested evaluation cannot deadlock (and is never
+	// itself paused or stepped).
+	if s.evalGuard.Load() {
+		return nil
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -97,9 +107,24 @@ func (h *StepHook) OnEval(ctx context.Context, ev runtime.EvalEvent) error {
 	}
 
 	// Breakpoint check first: a breakpoint always wins over step mode.
-	if s.matchBreakpoint(ev.Cursor, prevLine) {
-		s.pauseAndWait("breakpoint", "")
-		return nil
+	if bp, ok := s.matchBreakpoint(ev.Cursor, prevLine); ok {
+		switch {
+		case bp.logMessage != "":
+			// Logpoint: never pauses. Honour a condition if present.
+			if bp.condition == "" || s.evalCondition(ctx, bp.condition, ev.Env) {
+				s.emitLog(ctx, bp.logMessage, ev.Env)
+			}
+			// fall through to step handling below
+		case bp.condition != "":
+			if s.evalCondition(ctx, bp.condition, ev.Env) {
+				s.pauseAndWait("breakpoint", "")
+				return nil
+			}
+			// condition false: not a stop; fall through to step handling
+		default:
+			s.pauseAndWait("breakpoint", "")
+			return nil
+		}
 	}
 
 	// Don't pause inside library code: stop-on-entry and step modes

--- a/debugadapter/hook.go
+++ b/debugadapter/hook.go
@@ -194,6 +194,47 @@ func (h *StepHook) OnEval(ctx context.Context, ev runtime.EvalEvent) error {
 	return nil
 }
 
+// exceptionFilterAll is the id of the single exception-breakpoint filter
+// the server offers: stop wherever any Lisp error is raised.
+const exceptionFilterAll = "all"
+
+// OnError implements runtime.ErrorHook: it pauses the session at the
+// point a Lisp error is raised when exception breakpoints are enabled.
+// EVAL calls it at the innermost frame the error passes through, so the
+// live stack still describes the raise site.
+func (h *StepHook) OnError(ctx context.Context, ev runtime.ErrorEvent) {
+	s := h.st
+
+	// Errors thrown while the hook itself is evaluating a breakpoint
+	// condition or logpoint message must not pause (and would dead-lock
+	// on s.mu, which the evaluating goroutine already holds).
+	if s.evalGuard.Load() {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.disconnect || !s.stopOnException {
+		return
+	}
+	// Only the goroutine carrying this session's Thread participates:
+	// futures run detached and console evaluations carry no thread.
+	if runtime.ThreadFromContext(ctx) != s.thread {
+		return
+	}
+	s.pauseAndWait("exception", exceptionMessage(ev.Err))
+}
+
+// exceptionMessage renders a short description of a raised error for the
+// stopped event: the thrown Lisp value when available, else the Go error.
+func exceptionMessage(err error) string {
+	if le, ok := err.(lisperror.LispError); ok {
+		return printer.Pr_str(le.ErrorValue(), true)
+	}
+	return err.Error()
+}
+
 // isDoForm reports whether ast is a `(do …)` special form.
 func isDoForm(ast types.List) bool {
 	if len(ast.Val) == 0 {

--- a/debugadapter/protocol.go
+++ b/debugadapter/protocol.go
@@ -174,6 +174,14 @@ type VariablesArguments struct {
 	VariablesReference int `json:"variablesReference"`
 }
 
+// SetVariableArguments sets a variable within a scope (identified by the
+// scope's variablesReference) to the result of evaluating Value.
+type SetVariableArguments struct {
+	VariablesReference int    `json:"variablesReference"`
+	Name               string `json:"name"`
+	Value              string `json:"value"`
+}
+
 // ContinueArguments selects a thread.
 type ContinueArguments struct {
 	ThreadID int `json:"threadId"`

--- a/debugadapter/protocol.go
+++ b/debugadapter/protocol.go
@@ -50,6 +50,8 @@ type Capabilities struct {
 	SupportsTerminateRequest         bool `json:"supportsTerminateRequest"`
 	SupportsStepInTargetsRequest     bool `json:"supportsStepInTargetsRequest"`
 	SupportsEvaluateForHovers        bool `json:"supportsEvaluateForHovers"`
+	SupportsConditionalBreakpoints   bool `json:"supportsConditionalBreakpoints"`
+	SupportsLogPoints                bool `json:"supportsLogPoints"`
 }
 
 // EvaluateArguments is the payload of an `evaluate` request (Debug
@@ -69,6 +71,13 @@ type Source struct {
 // SourceBreakpoint is a breakpoint requested by the client.
 type SourceBreakpoint struct {
 	Line int `json:"line"`
+	// Condition is a lisp expression; the breakpoint fires only when it
+	// evaluates to a truthy value in the paused frame's environment.
+	Condition string `json:"condition,omitempty"`
+	// LogMessage turns the breakpoint into a logpoint: rather than
+	// pausing, its text is emitted as output with `{expr}` placeholders
+	// interpolated.
+	LogMessage string `json:"logMessage,omitempty"`
 }
 
 // Breakpoint is the server's confirmation back to the client.

--- a/debugadapter/protocol.go
+++ b/debugadapter/protocol.go
@@ -52,6 +52,18 @@ type Capabilities struct {
 	SupportsEvaluateForHovers        bool `json:"supportsEvaluateForHovers"`
 	SupportsConditionalBreakpoints   bool `json:"supportsConditionalBreakpoints"`
 	SupportsLogPoints                bool `json:"supportsLogPoints"`
+	SupportsSetVariable              bool `json:"supportsSetVariable"`
+
+	ExceptionBreakpointFilters []ExceptionBreakpointsFilter `json:"exceptionBreakpointFilters,omitempty"`
+}
+
+// ExceptionBreakpointsFilter is one selectable exception category the
+// client can toggle (advertised in `initialize`, toggled via
+// `setExceptionBreakpoints`).
+type ExceptionBreakpointsFilter struct {
+	Filter  string `json:"filter"`
+	Label   string `json:"label"`
+	Default bool   `json:"default,omitempty"`
 }
 
 // EvaluateArguments is the payload of an `evaluate` request (Debug
@@ -136,6 +148,12 @@ type LaunchArguments struct {
 type SetBreakpointsArguments struct {
 	Source      Source             `json:"source"`
 	Breakpoints []SourceBreakpoint `json:"breakpoints"`
+}
+
+// SetExceptionBreakpointsArguments lists the exception filters the client
+// wants active (by their advertised filter id).
+type SetExceptionBreakpointsArguments struct {
+	Filters []string `json:"filters"`
 }
 
 // StackTraceArguments selects a thread and a window of frames.

--- a/debugadapter/returnvalue_test.go
+++ b/debugadapter/returnvalue_test.go
@@ -1,0 +1,108 @@
+//go:build lispdebug
+
+package debugadapter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/runtime"
+	"github.com/jig/lisp/types"
+)
+
+// scopeNames returns the scope names reported for a frame, and the
+// variablesReference of the named scope (or -1).
+func scopeNames(t *testing.T, client *Transport, seq int, frameID int, want string) ([]string, int) {
+	t.Helper()
+	sendRequest(t, client, seq, "scopes", map[string]interface{}{"frameId": frameID})
+	resp := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "scopes" && m["type"] == "response"
+	})
+	scopes := resp["body"].(map[string]interface{})["scopes"].([]interface{})
+	names := make([]string, 0, len(scopes))
+	ref := -1
+	for _, sc := range scopes {
+		scope := sc.(map[string]interface{})
+		name := scope["name"].(string)
+		names = append(names, name)
+		if name == want {
+			ref = int(scope["variablesReference"].(float64))
+		}
+	}
+	return names, ref
+}
+
+// TestReturnValueAfterStep verifies that after stepping over a form, its
+// result appears as a synthetic "Return value" scope — and that a plain
+// breakpoint stop has no such scope.
+func TestReturnValueAfterStep(t *testing.T) {
+	tmp := t.TempDir()
+	script := filepath.Join(tmp, "ret.lisp")
+	src := "(+ 1 2)\n" +
+		"(println 9)\n"
+	if err := os.WriteFile(script, []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runtime.Modules.Register(script, script)
+
+	client, server, closer := pair()
+	ns := fullEnv(t)
+	done := make(chan error, 1)
+	eval := func(ctx context.Context, env types.EnvType) error {
+		_, err := lisp.REPL(ctx, env, fmt.Sprintf("(load-file %q)", script), types.NewAnonymousCursorHere(1, 1))
+		done <- err
+		return err
+	}
+	srv := NewServer(server, eval, ns)
+	stop := runServer(t, srv, closer)
+	defer stop()
+
+	launchToConfig(t, client, script, []SourceBreakpoint{{Line: 1}})
+
+	// Breakpoint stop on line 1: no return value yet.
+	if got := stoppedAt(t, client, 5); got != 1 {
+		t.Fatalf("expected stop on line 1, got %d", got)
+	}
+	if names, ref := scopeNames(t, client, 6, 0, "Return value"); ref != -1 {
+		t.Fatalf("breakpoint stop should have no Return value scope, got %v", names)
+	}
+
+	// Step over (+ 1 2): land on line 2 with its result surfaced.
+	sendRequest(t, client, 7, "next", map[string]interface{}{"threadId": 1})
+	readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "next" && m["type"] == "response"
+	})
+	if got := stoppedAt(t, client, 8); got != 2 {
+		t.Fatalf("expected step to land on line 2, got %d", got)
+	}
+	_, ref := scopeNames(t, client, 9, 0, "Return value")
+	if ref == -1 {
+		t.Fatal("expected a Return value scope after step-over")
+	}
+	sendRequest(t, client, 10, "variables", map[string]interface{}{"variablesReference": ref})
+	varsResp := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "variables" && m["type"] == "response"
+	})
+	vars := varsResp["body"].(map[string]interface{})["variables"].([]interface{})
+	if len(vars) != 1 {
+		t.Fatalf("expected one return variable, got %v", vars)
+	}
+	v := vars[0].(map[string]interface{})
+	if v["name"] != "(return)" || v["value"] != "3" {
+		t.Fatalf("expected (return)=3, got name=%v value=%v", v["name"], v["value"])
+	}
+
+	sendRequest(t, client, 11, "continue", map[string]interface{}{"threadId": 1})
+	readUntil(t, client, func(m map[string]interface{}) bool { return m["event"] == "terminated" })
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("eval did not finish")
+	}
+	sendRequest(t, client, 12, "disconnect", nil)
+}

--- a/debugadapter/server.go
+++ b/debugadapter/server.go
@@ -379,6 +379,12 @@ func (s *Server) handleScopes(req *Request) {
 	// ("Globals" — everything the session loaded, builtins included;
 	// marked expensive so the client keeps it collapsed by default).
 	scopes := []Scope{}
+	// After a step-over/step-out, surface the value the stepped form
+	// produced as a synthetic scope on the top frame.
+	if args.FrameID == 0 && s.state.hasStepResult {
+		ref := s.state.registerVarRef(varRef{kind: varRefReturn, value: s.state.stepResult})
+		scopes = append(scopes, Scope{Name: "Return value", VariablesReference: ref, Expensive: false})
+	}
 	level := 0
 	for e := frames[idx].Env; e != nil; level++ {
 		chain, ok := e.(envChain)
@@ -423,6 +429,8 @@ func (s *Server) handleVariables(req *Request) {
 		vars = s.varsForEnvLevel(entry.env)
 	case varRefValue:
 		vars = s.childrenOf(entry.value)
+	case varRefReturn:
+		vars = []Variable{s.formatVariable("(return)", entry.value)}
 	}
 	s.respond(req, true, "", map[string]interface{}{"variables": vars})
 }

--- a/debugadapter/server.go
+++ b/debugadapter/server.go
@@ -158,6 +158,8 @@ func (s *Server) dispatch(_ context.Context, req *Request) {
 			SupportsConfigurationDoneRequest: true,
 			SupportsTerminateRequest:         true,
 			SupportsEvaluateForHovers:        true,
+			SupportsConditionalBreakpoints:   true,
+			SupportsLogPoints:                true,
 		})
 		s.sendEvent("initialized", struct{}{})
 	case "launch":

--- a/debugadapter/server.go
+++ b/debugadapter/server.go
@@ -209,6 +209,8 @@ func (s *Server) dispatch(_ context.Context, req *Request) {
 		s.handleScopes(req)
 	case "variables":
 		s.handleVariables(req)
+	case "setVariable":
+		s.handleSetVariable(req)
 	case "evaluate":
 		s.handleEvaluate(req)
 	// For the four resume-style requests the response is written while
@@ -423,6 +425,65 @@ func (s *Server) handleVariables(req *Request) {
 		vars = s.childrenOf(entry.value)
 	}
 	s.respond(req, true, "", map[string]interface{}{"variables": vars})
+}
+
+// handleSetVariable serves `setVariable`: it evaluates the client's
+// expression and rebinds the named symbol in the scope's environment.
+// Only environment scopes (Locals / Closure / Globals) are writable —
+// the children of a composite value are immutable, so those references
+// are rejected.
+//
+// Like handleEvaluate, the expression runs on the server goroutine with a
+// detached background context while the debuggee is paused, so it pushes
+// no frames and the module-less cursor is ignored by the hook;
+// lastObservedLine is saved and restored so breakpoint line-transition
+// detection is unaffected.
+func (s *Server) handleSetVariable(req *Request) {
+	var args SetVariableArguments
+	_ = json.Unmarshal(req.Arguments, &args)
+
+	s.state.mu.Lock()
+	entry, ok := s.state.varRefs[args.VariablesReference]
+	if !ok || entry.kind != varRefScopeLocals || entry.env == nil {
+		s.state.mu.Unlock()
+		s.respond(req, false, "this variable cannot be edited", nil)
+		return
+	}
+	env := entry.env
+	savedLine := s.state.lastObservedLine
+	s.state.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var val types.MalType
+	ast, err := lisp.READ(args.Value, types.NewAnonymousCursorHere(1, 1), env)
+	if err == nil {
+		val, err = lisp.EVAL(ctx, ast, env)
+	}
+
+	s.state.mu.Lock()
+	s.state.lastObservedLine = savedLine
+	s.state.mu.Unlock()
+
+	if err != nil {
+		s.respond(req, false, err.Error(), nil)
+		return
+	}
+	env.Set(types.Symbol{Val: args.Name}, val)
+
+	s.state.mu.Lock()
+	ref := 0
+	switch val.(type) {
+	case types.List, types.Vector, types.HashMap, types.Set:
+		ref = s.state.registerVarRef(varRef{kind: varRefValue, value: val})
+	}
+	s.state.mu.Unlock()
+
+	s.respond(req, true, "", map[string]interface{}{
+		"value":              printer.Pr_str(val, true),
+		"type":               fmt.Sprintf("%T", val),
+		"variablesReference": ref,
+	})
 }
 
 // varsForEnvLevel returns the bindings of a single level of the

--- a/debugadapter/server.go
+++ b/debugadapter/server.go
@@ -160,6 +160,10 @@ func (s *Server) dispatch(_ context.Context, req *Request) {
 			SupportsEvaluateForHovers:        true,
 			SupportsConditionalBreakpoints:   true,
 			SupportsLogPoints:                true,
+			SupportsSetVariable:              true,
+			ExceptionBreakpointFilters: []ExceptionBreakpointsFilter{
+				{Filter: exceptionFilterAll, Label: "All raised errors"},
+			},
 		})
 		s.sendEvent("initialized", struct{}{})
 	case "launch":
@@ -183,6 +187,11 @@ func (s *Server) dispatch(_ context.Context, req *Request) {
 		_ = json.Unmarshal(req.Arguments, &args)
 		bps := s.state.setBreakpoints(args.Source, args.Breakpoints)
 		s.respond(req, true, "", map[string]interface{}{"breakpoints": bps})
+	case "setExceptionBreakpoints":
+		var args SetExceptionBreakpointsArguments
+		_ = json.Unmarshal(req.Arguments, &args)
+		s.state.setExceptionBreakpoints(args.Filters)
+		s.respond(req, true, "", nil)
 	case "configurationDone":
 		s.respond(req, true, "", nil)
 		select {

--- a/debugadapter/setvariable_test.go
+++ b/debugadapter/setvariable_test.go
@@ -1,0 +1,100 @@
+//go:build lispdebug
+
+package debugadapter
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/runtime"
+	"github.com/jig/lisp/types"
+)
+
+// TestSetVariable pauses inside a function and rebinds a local via
+// setVariable, then confirms the new value is visible in the frame.
+func TestSetVariable(t *testing.T) {
+	tmp := t.TempDir()
+	script := filepath.Join(tmp, "setvar.lisp")
+	src := "(defn f [x]\n" +
+		"  (println x)\n" +
+		"  (println x))\n" +
+		"(f 10)\n"
+	if err := os.WriteFile(script, []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runtime.Modules.Register(script, script)
+
+	client, server, closer := pair()
+	ns := fullEnv(t)
+	done := make(chan error, 1)
+	eval := func(ctx context.Context, env types.EnvType) error {
+		_, err := lisp.REPL(ctx, env, fmt.Sprintf("(load-file %q)", script), types.NewAnonymousCursorHere(1, 1))
+		done <- err
+		return err
+	}
+	srv := NewServer(server, eval, ns)
+	stop := runServer(t, srv, closer)
+	defer stop()
+
+	launchToConfig(t, client, script, []SourceBreakpoint{{Line: 2}})
+
+	if got := stoppedAt(t, client, 5); got != 2 {
+		t.Fatalf("expected stop on line 2, got %d", got)
+	}
+
+	// Find the Locals scope of the top frame.
+	sendRequest(t, client, 6, "scopes", map[string]interface{}{"frameId": 0})
+	scopesResp := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "scopes" && m["type"] == "response"
+	})
+	scopes := scopesResp["body"].(map[string]interface{})["scopes"].([]interface{})
+	localsRef := -1
+	for _, sc := range scopes {
+		scope := sc.(map[string]interface{})
+		if scope["name"] == "Locals" {
+			localsRef = int(scope["variablesReference"].(float64))
+		}
+	}
+	if localsRef < 0 {
+		t.Fatalf("no Locals scope in %v", scopes)
+	}
+
+	// Rebind x to 99.
+	sendRequest(t, client, 7, "setVariable", SetVariableArguments{
+		VariablesReference: localsRef, Name: "x", Value: "99",
+	})
+	setResp := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "setVariable" && m["type"] == "response"
+	})
+	if ok, _ := setResp["success"].(bool); !ok {
+		t.Fatalf("setVariable failed: %v", setResp)
+	}
+	if body := setResp["body"].(map[string]interface{}); body["value"] != "99" {
+		t.Fatalf("setVariable returned value %v, want 99", body["value"])
+	}
+
+	// The rebinding is visible when the expression is evaluated in the frame.
+	sendRequest(t, client, 8, "evaluate", map[string]interface{}{
+		"expression": "x", "frameId": 0, "context": "watch",
+	})
+	evalResp := readUntil(t, client, func(m map[string]interface{}) bool {
+		return m["command"] == "evaluate" && m["type"] == "response"
+	})
+	if body := evalResp["body"].(map[string]interface{}); body["result"] != "99" {
+		t.Fatalf("after setVariable, x evaluated to %v, want 99", body["result"])
+	}
+
+	sendRequest(t, client, 9, "continue", map[string]interface{}{"threadId": 1})
+	readUntil(t, client, func(m map[string]interface{}) bool { return m["event"] == "terminated" })
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("eval did not finish")
+	}
+	sendRequest(t, client, 10, "disconnect", nil)
+}

--- a/debugadapter/state.go
+++ b/debugadapter/state.go
@@ -5,10 +5,24 @@ package debugadapter
 import (
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 
 	"github.com/jig/lisp/runtime"
 	"github.com/jig/lisp/types"
 )
+
+// breakpoint holds the client-supplied attributes of a single source
+// breakpoint. A plain (unconditional) breakpoint has both strings empty.
+type breakpoint struct {
+	// condition, when non-empty, is a lisp expression evaluated in the
+	// paused frame's environment; the breakpoint only fires when it
+	// evaluates to a truthy value.
+	condition string
+	// logMessage, when non-empty, turns the breakpoint into a logpoint:
+	// instead of pausing, the message is emitted as output with its
+	// {expr} placeholders interpolated.
+	logMessage string
+}
 
 // mode is the execution mode of the debuggee.
 type mode int
@@ -55,7 +69,16 @@ type state struct {
 	//                   of the same call". Frame pointers were unreliable because
 	//                   the GC can reuse popped frames' memory; IDs are stable.
 
-	breakpoints map[string]map[int]bool // abs path → line → set
+	breakpoints map[string]map[int]breakpoint // abs path → line → breakpoint
+
+	// evalGuard is set while the hook itself evaluates a breakpoint
+	// condition or logpoint message. It is read at the very top of
+	// OnEval — before s.mu is taken — so the nested EVAL those
+	// evaluations trigger returns immediately instead of dead-locking on
+	// the mutex we already hold. An atomic (not a plain bool under s.mu)
+	// is required precisely because the nested OnEval must observe it
+	// without acquiring the lock.
+	evalGuard atomic.Bool
 
 	thread *runtime.Thread
 
@@ -78,7 +101,7 @@ type state struct {
 func newState(s *Server) *state {
 	st := &state{
 		mode:        modeRunning,
-		breakpoints: map[string]map[int]bool{},
+		breakpoints: map[string]map[int]breakpoint{},
 		thread:      runtime.NewThread(),
 		server:      s,
 		varRefs:     map[int]varRef{},
@@ -101,10 +124,10 @@ func (s *state) setBreakpoints(src Source, requested []SourceBreakpoint) []Break
 		}
 		return out
 	}
-	lines := map[int]bool{}
+	lines := map[int]breakpoint{}
 	out := make([]Breakpoint, len(requested))
 	for i, bp := range requested {
-		lines[bp.Line] = true
+		lines[bp.Line] = breakpoint{condition: bp.Condition, logMessage: bp.LogMessage}
 		out[i] = Breakpoint{Verified: true, Line: bp.Line, Source: Source{Name: src.Name, Path: abs}}
 	}
 	s.breakpoints[abs] = lines
@@ -128,26 +151,28 @@ func (s *state) isUserCode(cursor *types.Position) bool {
 }
 
 // matchBreakpoint reports whether cursor is on a line with a registered
-// breakpoint *and* execution just transitioned onto that line. The
-// transition check (cursor.BeginRow != prevLine) prevents the BP from
-// re-firing for every sub-form on the same row.
-func (s *state) matchBreakpoint(cursor *types.Position, prevLine int) bool {
+// breakpoint *and* execution just transitioned onto that line, returning
+// the breakpoint's attributes. The transition check (cursor.BeginRow !=
+// prevLine) prevents the BP from re-firing for every sub-form on the
+// same row.
+func (s *state) matchBreakpoint(cursor *types.Position, prevLine int) (breakpoint, bool) {
 	if cursor == nil || cursor.Module == nil {
-		return false
+		return breakpoint{}, false
 	}
 	if cursor.BeginRow == prevLine {
-		return false
+		return breakpoint{}, false
 	}
 	resolved := runtime.Modules.Resolve(*cursor.Module)
 	abs := absolutize(resolved)
 	if abs == "" {
-		return false
+		return breakpoint{}, false
 	}
 	lines := s.breakpoints[abs]
 	if lines == nil {
-		return false
+		return breakpoint{}, false
 	}
-	return lines[cursor.BeginRow]
+	bp, ok := lines[cursor.BeginRow]
+	return bp, ok
 }
 
 // pauseAndWait sends a `stopped` event and blocks until the client

--- a/debugadapter/state.go
+++ b/debugadapter/state.go
@@ -42,12 +42,13 @@ type varRefKind int
 const (
 	varRefScopeLocals varRefKind = iota
 	varRefValue
+	varRefReturn // the single synthetic "(return)" variable
 )
 
 type varRef struct {
 	kind  varRefKind
 	env   types.EnvType // for scope-locals: one level of the env chain
-	value types.MalType // for value
+	value types.MalType // for value / return
 }
 
 // state holds the live debug session: mode, breakpoints, the thread
@@ -94,6 +95,12 @@ type state struct {
 	// enables the "all" filter: the session then pauses at the point any
 	// Lisp error is raised.
 	stopOnException bool
+
+	// stepResult holds the value of the form just completed by a
+	// step-over/step-out, surfaced as a synthetic "Return value" scope
+	// while paused. hasStepResult guards it (nil is a legitimate value).
+	stepResult    types.MalType
+	hasStepResult bool
 
 	// lastObservedLine is the BeginRow of the cursor seen on the
 	// previous OnEval. matchBreakpoint uses it to skip the cascade of
@@ -226,6 +233,11 @@ func (s *state) resume(m mode, depth int) {
 	s.mode = m
 	s.targetDepth = depth
 	s.stepFrameID = runtime.FrameID(s.thread.Top())
+	// Forget any step return value: it belongs to the pause we are
+	// leaving, and the thread's recorder starts fresh for the next step.
+	s.hasStepResult = false
+	s.stepResult = nil
+	s.thread.ResetLastResult()
 	tracef("resume mode=%d targetDepth=%d stepFrameID=%d (thread.Depth=%d)",
 		m, depth, s.stepFrameID, s.thread.Depth())
 	s.cond.Signal()

--- a/debugadapter/state.go
+++ b/debugadapter/state.go
@@ -90,6 +90,11 @@ type state struct {
 	stopOnEntry bool
 	disconnect  bool
 
+	// stopOnException is set by setExceptionBreakpoints when the client
+	// enables the "all" filter: the session then pauses at the point any
+	// Lisp error is raised.
+	stopOnException bool
+
 	// lastObservedLine is the BeginRow of the cursor seen on the
 	// previous OnEval. matchBreakpoint uses it to skip the cascade of
 	// matches that would otherwise fire on every sub-form sharing the
@@ -132,6 +137,19 @@ func (s *state) setBreakpoints(src Source, requested []SourceBreakpoint) []Break
 	}
 	s.breakpoints[abs] = lines
 	return out
+}
+
+// setExceptionBreakpoints enables pausing on raised errors when the
+// client turns on the "all" filter. Unknown filter ids are ignored.
+func (s *state) setExceptionBreakpoints(filters []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stopOnException = false
+	for _, f := range filters {
+		if f == exceptionFilterAll {
+			s.stopOnException = true
+		}
+	}
 }
 
 // isUserCode reports whether the cursor points at a file the client

--- a/mal.go
+++ b/mal.go
@@ -478,10 +478,21 @@ func evalInternal(ctx context.Context, ast MalType, env EnvType) (res MalType, e
 		}
 	}
 
-	// Add stack frame to any error that propagates out of this EVAL call
+	// Add stack frame to any error that propagates out of this EVAL call.
+	// In debug builds, first let an installed hook observe the error at
+	// its raise point — detected by the stack still being empty, which is
+	// true only at the innermost frame the error passes through — so
+	// exception breakpoints can stop with the full call stack intact,
+	// before it unwinds. The hook only observes; it must never wrap or
+	// alter the propagating error (external catch / error-parsing code
+	// depends on the format). In release builds runtime.Enabled is the
+	// constant false and the whole DispatchError branch is dead code.
 	defer func() {
 		if e != nil {
 			if lispErr, ok := e.(lisperror.LispError); ok {
+				if runtime.Enabled && len(lispErr.Stack) == 0 {
+					runtime.DispatchError(ctx, lispErr, ast, env, lisperror.GetPosition(ast), functionName)
+				}
 				e = lispErr.AddStackFrame(lisperror.GetPosition(ast), functionName)
 			}
 		}

--- a/mal.go
+++ b/mal.go
@@ -476,6 +476,17 @@ func evalInternal(ctx context.Context, ast MalType, env EnvType) (res MalType, e
 		} else {
 			frame = nil
 		}
+		// Record this frame's result as it completes, so the debugger can
+		// show the return value after a step. A form's own EVAL returns
+		// after its sub-forms, so the outermost stepped form records last.
+		// recurValue is an internal loop sentinel, not a user value.
+		defer func() {
+			if e == nil {
+				if _, isRecur := res.(recurValue); !isRecur {
+					runtime.RecordResult(ctx, res)
+				}
+			}
+		}()
 	}
 
 	// Add stack frame to any error that propagates out of this EVAL call.

--- a/runtime/active_debug.go
+++ b/runtime/active_debug.go
@@ -32,6 +32,24 @@ func Dispatch(ctx context.Context, ast types.MalType, env types.EnvType, cursor 
 	return h.OnEval(ctx, EvalEvent{AST: ast, Env: env, Cursor: cursor})
 }
 
+// DispatchError notifies the active hook of an error at its raise point,
+// if the hook implements ErrorHook. EVAL calls this from the innermost
+// frame the error passes through (stack still intact). Returns nothing:
+// an ErrorHook observes, it does not change the propagating error.
+func DispatchError(ctx context.Context, err error, ast types.MalType, env types.EnvType, cursor *types.Position, functionName string) {
+	eh, ok := Hook.(ErrorHook)
+	if !ok {
+		return
+	}
+	eh.OnError(ctx, ErrorEvent{
+		Err:          err,
+		AST:          ast,
+		Env:          env,
+		Cursor:       cursor,
+		FunctionName: functionName,
+	})
+}
+
 // PrintEvalHook reproduces the legacy DEBUG-EVAL printing behaviour:
 // when the symbol DEBUG-EVAL is bound to true in the active env, it prints
 // the source position followed by the form being evaluated.

--- a/runtime/active_debug.go
+++ b/runtime/active_debug.go
@@ -101,6 +101,14 @@ var nextFrameID atomic.Int64
 type Thread struct {
 	mu     sync.Mutex
 	frames []*Frame
+
+	// lastResult holds the value of the most recently completed EVAL
+	// frame on this thread. The debugger reads it after a step-over or
+	// step-out to show the stepped form's return value: because a form's
+	// own EVAL returns after all its sub-forms, the outermost stepped
+	// form is the last to record, so this is exactly its result.
+	lastResult    types.MalType
+	hasLastResult bool
 }
 
 // NewThread returns an empty Thread.
@@ -208,6 +216,39 @@ func (t *Thread) Snapshot() []Frame {
 		out[i] = *f
 	}
 	return out
+}
+
+// RecordResult stores res as the thread's most-recently-completed value.
+func (t *Thread) RecordResult(res types.MalType) {
+	t.mu.Lock()
+	t.lastResult = res
+	t.hasLastResult = true
+	t.mu.Unlock()
+}
+
+// LastResult returns the most-recently-recorded value and whether one is
+// available.
+func (t *Thread) LastResult() (types.MalType, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.lastResult, t.hasLastResult
+}
+
+// ResetLastResult forgets any recorded result. The debugger calls it when
+// resuming so a stale value is not shown at the next stop.
+func (t *Thread) ResetLastResult() {
+	t.mu.Lock()
+	t.lastResult = nil
+	t.hasLastResult = false
+	t.mu.Unlock()
+}
+
+// RecordResult stores res on the Thread carried by ctx, if any. EVAL
+// calls it as each frame completes successfully.
+func RecordResult(ctx context.Context, res types.MalType) {
+	if t := ThreadFromContext(ctx); t != nil {
+		t.RecordResult(res)
+	}
 }
 
 type ctxKey struct{}

--- a/runtime/active_release.go
+++ b/runtime/active_release.go
@@ -19,6 +19,12 @@ func Dispatch(_ context.Context, _ types.MalType, _ types.EnvType, _ *types.Posi
 	return nil
 }
 
+// DispatchError is a no-op in release builds. The constant `Enabled =
+// false` guarantees the call site is dead code and the compiler removes
+// it.
+func DispatchError(_ context.Context, _ error, _ types.MalType, _ types.EnvType, _ *types.Position, _ string) {
+}
+
 // Frame is a stub in release builds. The Frame contents only exist in
 // `lispdebug` builds; this empty struct keeps consumer code (mal.go,
 // debugadapter) compilable when wrapped in `if runtime.Enabled { ... }`.

--- a/runtime/active_release.go
+++ b/runtime/active_release.go
@@ -25,6 +25,10 @@ func Dispatch(_ context.Context, _ types.MalType, _ types.EnvType, _ *types.Posi
 func DispatchError(_ context.Context, _ error, _ types.MalType, _ types.EnvType, _ *types.Position, _ string) {
 }
 
+// RecordResult is a no-op in release builds. Dead code under
+// `if runtime.Enabled`.
+func RecordResult(_ context.Context, _ types.MalType) {}
+
 // Frame is a stub in release builds. The Frame contents only exist in
 // `lispdebug` builds; this empty struct keeps consumer code (mal.go,
 // debugadapter) compilable when wrapped in `if runtime.Enabled { ... }`.

--- a/runtime/hook.go
+++ b/runtime/hook.go
@@ -41,3 +41,24 @@ type EvalEvent struct {
 type EvalHook interface {
 	OnEval(ctx context.Context, ev EvalEvent) error
 }
+
+// ErrorEvent describes a Lisp error at the moment it is first raised,
+// before it unwinds the call stack.
+type ErrorEvent struct {
+	Err          error
+	AST          types.MalType
+	Env          types.EnvType
+	Cursor       *types.Position
+	FunctionName string
+}
+
+// ErrorHook is an optional interface an installed EvalHook may also
+// implement to observe errors. EVAL invokes it (via DispatchError) at the
+// deepest frame the error passes through — where the stack is still
+// intact — so a debugger can stop at the raise point. The hook must only
+// observe: it cannot alter or suppress the propagating error.
+//
+// Only meaningful in `lispdebug` builds; see package doc.
+type ErrorHook interface {
+	OnError(ctx context.Context, ev ErrorEvent)
+}


### PR DESCRIPTION
## What

Four debugger (DAP) features from `ROADMAP.md`, everything behind the `lispdebug` build tag — the release binary's semantics are unchanged. Multi-thread futures (the remaining big item) is deliberately out of scope.

Each feature is its own commit with tests.

## Features

- **Conditional breakpoints & logpoints** — a breakpoint with a `condition` only pauses when the expression is truthy in the paused frame's env; a `logMessage` turns it into a logpoint that emits interpolated (`{expr}`) output without pausing. The expressions run inside the hook on the debuggee goroutine; an atomic `evalGuard` checked before `s.mu` is taken keeps the nested EVAL from dead-locking.
- **Exception breakpoints** — an "All raised errors" filter. New optional `runtime.ErrorHook` (`OnError`) dispatched from `evalInternal`'s error-decoration defer, but only at the innermost frame the error passes through (its stack still empty, before the first `AddStackFrame`), so it fires once at the raise site with the stack intact. The hook only observes — it never wraps or alters the propagating error.
- **setVariable** — edit a variable while paused. The value is evaluated in the scope's env and rebound with `env.Set`; only environment scopes (Locals / Closure / Globals) are writable.
- **Return value after step** — after F10 / Shift-F11, the stepped form's result appears as a synthetic "Return value" scope. The runtime's `Thread` records each frame's result as it completes; the outermost stepped form is the last to record.

## Interpreter impact (`mal.go`)

Two additions in `evalInternal`, both dead code in release builds (`runtime.Enabled == false`):

- `runtime.DispatchError` in the error-decoration defer (exception breakpoints) — observes only, never alters the error, so the error-message format and `catch` behaviour are unchanged.
- `runtime.RecordResult` on successful frame completion (return values).

## Verification

- `go build` / `go vet` / `go test ./...` green in **both** the default and `-tags lispdebug` builds.
- New tests: conditional breakpoint, logpoint, exception breakpoint (+ disabled-by-default), setVariable, return-value-after-step.

VSCode needs no extension change: these are all runtime-negotiated DAP capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
