### PR TITLE
fix(lsp): whole-symbol word selection + rename provider (F2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,9 @@ LSP (Language Server Protocol) server, both enabled with the
   (with watch and hover) and program output.
 - **Language server (LSP)**: live parse diagnostics while you type,
   symbol completion (core library plus your `def`/`defn`), hover with
-  definition signatures, and the document outline (Ctrl+Shift+O,
-  breadcrumbs), signature help while typing a call. `(require
+  definition signatures, the document outline (Ctrl+Shift+O,
+  breadcrumbs), signature help while typing a call, and rename (F2) of
+  a symbol defined in the file. `(require
   "module")` forms are resolved statically, so definitions from
   required modules are known to completion, hover, signature help,
   go-to-definition (F12) and the unknown-symbol check. Extra module

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,13 +73,16 @@ it needs to also record non-head symbol occurrences with positions, and
 a `textDocument/references` handler. *Effort: medium. Impact: high —
 the most requested navigation feature after go-to-definition.*
 
-### LSP: rename (F2)
-Consistent rename across all uses. Builds directly on find references
-(produce a `WorkspaceEdit` instead of a location list). **Less
-innocuous than the rest of the LSP items: it edits user code, so wrong
-matches corrupt sources** — needs conservative scope rules and tests
-around shadowing (`let`/`fn` params). *Effort: medium (after
-references). Impact: high.*
+### ~~LSP: rename (F2)~~ (done, conservatively)
+Rename a symbol and every use in the file. Implemented conservatively,
+given the edits-user-code risk: only symbols **defined in the document**
+(def/defn/defmacro) are renameable — builtins, require-imported and
+qualified names and preamble placeholders are refused via
+`prepareRename`. The rename is a whole-file, whole-token textual
+replacement that skips strings and comments. It is lexical, not
+scope-aware, so a shadowing `let`/`fn` local of the same name is also
+renamed; a future refinement could use scope analysis to narrow it. See
+`symbolOccurrences` / `handleRename` in [lsp](lsp/).
 
 ### ~~DAP: conditional breakpoints and logpoints~~ (done)
 Breakpoints firing only when a condition holds, or logging without
@@ -168,10 +171,11 @@ Item-specific notes:
 ## Suggested order
 
 Done: the three quick wins (LISPPATH, module-change watching, signature
-help) and the debugger-power set (conditional breakpoints / logpoints,
-exception breakpoints, setVariable, return value after step). Remaining,
-in order:
+help), the debugger-power set (conditional breakpoints / logpoints,
+exception breakpoints, setVariable, return value after step), and a
+conservative rename (F2). Remaining, in order:
 
-1. Find references → rename (the navigation pair)
+1. Find references (Shift-F12) — and, with the non-head occurrences it
+   records, upgrade rename to be scope-aware
 2. Multi-thread futures (schedule real time for it)
 3. Semantic tokens / formatting (cosmetic)

--- a/lsp/analyse.go
+++ b/lsp/analyse.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/jig/lisp/lisperror"
 	"github.com/jig/lisp/printer"
@@ -507,6 +508,125 @@ func symbolRangeAt(content string, line, char int) Range {
 		Start: Position{Line: line, Character: start},
 		End:   Position{Line: line, Character: end},
 	}
+}
+
+// symbolBreakRune is the rune-level counterpart of symbolBreak. Every
+// break character is ASCII, so a non-ASCII rune is never a break.
+func symbolBreakRune(r rune) bool {
+	return r < utf8.RuneSelf && symbolBreak(byte(r))
+}
+
+// validSymbolName reports whether name is a single lisp symbol token: it
+// must be non-empty and contain no character that would break it into
+// pieces. It guards a rename's new name so a rename cannot inject
+// whitespace or delimiters.
+func validSymbolName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if symbolBreakRune(r) || r == '¬' {
+			return false
+		}
+	}
+	return true
+}
+
+// symbolOccurrences returns the ranges of every whole-token occurrence of
+// sym in content, skipping string literals ("…" and multi-line ¬…¬) and
+// line comments so a rename never rewrites data or prose. Columns are
+// byte offsets within the line, matching symbolRangeAt and the rest of
+// the server. Symbol tokens never span a newline, so each range is on a
+// single line.
+func symbolOccurrences(content, sym string) []Range {
+	var out []Range
+	line, col := 0, 0
+	i := 0
+	for i < len(content) {
+		r, w := utf8.DecodeRuneInString(content[i:])
+		switch {
+		case r == '\n':
+			line++
+			col = 0
+			i += w
+		case r == ';':
+			// Line comment: skip to (but not past) the newline.
+			for i < len(content) && content[i] != '\n' {
+				i++
+				col++
+			}
+		case r == '"':
+			// Single-line string with backslash escapes.
+			i += w
+			col += w
+			for i < len(content) {
+				cr, cw := utf8.DecodeRuneInString(content[i:])
+				if cr == '\n' {
+					break
+				}
+				if cr == '\\' && i+cw < len(content) {
+					_, nw := utf8.DecodeRuneInString(content[i+cw:])
+					i += cw + nw
+					col += cw + nw
+					continue
+				}
+				i += cw
+				col += cw
+				if cr == '"' {
+					break
+				}
+			}
+		case r == '¬':
+			// Multi-line string; ¬¬ is an escaped ¬.
+			i += w
+			col += w
+			for i < len(content) {
+				cr, cw := utf8.DecodeRuneInString(content[i:])
+				if cr == '¬' {
+					if i+cw < len(content) {
+						if nr, nw := utf8.DecodeRuneInString(content[i+cw:]); nr == '¬' {
+							i += cw + nw
+							col += cw + nw
+							continue
+						}
+					}
+					i += cw
+					col += cw
+					break
+				}
+				if cr == '\n' {
+					line++
+					col = 0
+					i += cw
+					continue
+				}
+				i += cw
+				col += cw
+			}
+		case symbolBreakRune(r):
+			i += w
+			col += w
+		default:
+			// Start of a symbol token.
+			startCol := col
+			startI := i
+			for i < len(content) {
+				tr, tw := utf8.DecodeRuneInString(content[i:])
+				if tr == '¬' || symbolBreakRune(tr) {
+					break
+				}
+				i += tw
+				col += tw
+			}
+			if content[startI:i] == sym {
+				out = append(out, Range{
+					Start: Position{Line: line, Character: startCol},
+					End:   Position{Line: line, Character: col},
+				})
+			}
+		}
+	}
+	return out
 }
 
 // offsetOf converts a zero-based line/character to a byte offset into

--- a/lsp/protocol.go
+++ b/lsp/protocol.go
@@ -194,6 +194,27 @@ type ServerCapabilities struct {
 	DefinitionProvider         bool                 `json:"definitionProvider"`
 	SignatureHelpProvider      SignatureHelpOptions `json:"signatureHelpProvider"`
 	DocumentFormattingProvider bool                 `json:"documentFormattingProvider"`
+	RenameProvider             RenameOptions        `json:"renameProvider"`
+}
+
+// RenameOptions declares rename support, including the prepare step that
+// lets the server define the exact range being renamed (so hyphenated
+// symbols are selected whole) and reject symbols it cannot safely rename.
+type RenameOptions struct {
+	PrepareProvider bool `json:"prepareProvider"`
+}
+
+// RenameParams is the payload of textDocument/rename.
+type RenameParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	Position     Position               `json:"position"`
+	NewName      string                 `json:"newName"`
+}
+
+// WorkspaceEdit is the response to textDocument/rename: edits grouped by
+// document URI.
+type WorkspaceEdit struct {
+	Changes map[string][]TextEdit `json:"changes"`
 }
 
 // DocumentFormattingParams is the payload of textDocument/formatting. The

--- a/lsp/rename_test.go
+++ b/lsp/rename_test.go
@@ -1,0 +1,150 @@
+package lsp
+
+import (
+	"testing"
+)
+
+// TestServer_PrepareRename_WholeHyphenatedSymbol checks that prepareRename
+// returns the range of the entire hyphenated symbol, not a fragment.
+func TestServer_PrepareRename_WholeHyphenatedSymbol(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///rename.lisp"
+	didOpen(t, client, uri, "(defn my-func [x] x)\n(my-func 1)\n")
+
+	// Cursor on the "f" of my-func (line 0, char 9).
+	send(t, client, 10, "textDocument/prepareRename", TextDocumentPositionParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 0, Character: 9},
+	})
+	resp := readUntil(t, client, response(10))
+	result, ok := resp["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected a range from prepareRename, got %v", resp["result"])
+	}
+	start := result["start"].(map[string]interface{})
+	end := result["end"].(map[string]interface{})
+	if int(start["character"].(float64)) != 6 || int(end["character"].(float64)) != 13 {
+		t.Fatalf("expected the whole symbol range [6,13), got [%v,%v)", start["character"], end["character"])
+	}
+}
+
+// TestServer_PrepareRename_RefusesUndefinedSymbol checks that a symbol not
+// defined in the document (a builtin here) cannot be renamed.
+func TestServer_PrepareRename_RefusesUndefinedSymbol(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///refuse.lisp"
+	didOpen(t, client, uri, "(defn foo [x] x)\n(+ 1 2)\n")
+
+	// Cursor on the "+" (line 1, char 1) — a builtin, not a local def.
+	send(t, client, 11, "textDocument/prepareRename", TextDocumentPositionParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 1, Character: 1},
+	})
+	resp := readUntil(t, client, response(11))
+	if resp["result"] != nil {
+		t.Fatalf("expected null (cannot rename a builtin), got %v", resp["result"])
+	}
+}
+
+// TestServer_Rename renames a hyphenated definition and all its references.
+func TestServer_Rename(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///do-rename.lisp"
+	didOpen(t, client, uri, "(defn my-func [x] x)\n(my-func 1)\n")
+
+	send(t, client, 12, "textDocument/rename", RenameParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 0, Character: 9},
+		NewName:      "renamed",
+	})
+	resp := readUntil(t, client, response(12))
+	edits := renameEdits(t, resp, uri)
+	if len(edits) != 2 {
+		t.Fatalf("expected 2 edits (def + call), got %d: %v", len(edits), edits)
+	}
+	for _, e := range edits {
+		if e["newText"] != "renamed" {
+			t.Errorf("expected newText 'renamed', got %v", e["newText"])
+		}
+	}
+}
+
+// TestServer_Rename_SkipsStringsAndComments verifies textual occurrences
+// inside strings and comments are not rewritten.
+func TestServer_Rename_SkipsStringsAndComments(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///skip.lisp"
+	src := "(defn foo [x] x)\n" + // 0: definition
+		"(foo 1)\n" + // 1: call
+		";; foo in a comment\n" + // 2: comment
+		"(println \"foo bar\")\n" // 3: string
+	didOpen(t, client, uri, src)
+
+	send(t, client, 13, "textDocument/rename", RenameParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 1, Character: 2},
+		NewName:      "baz",
+	})
+	resp := readUntil(t, client, response(13))
+	edits := renameEdits(t, resp, uri)
+	if len(edits) != 2 {
+		t.Fatalf("expected 2 edits (def + call only), got %d: %v", len(edits), edits)
+	}
+	for _, e := range edits {
+		rng := e["range"].(map[string]interface{})
+		line := int(rng["start"].(map[string]interface{})["line"].(float64))
+		if line != 0 && line != 1 {
+			t.Errorf("edit on unexpected line %d (should skip comment/string)", line)
+		}
+	}
+}
+
+// TestServer_Rename_RejectsInvalidNewName refuses a new name containing a
+// delimiter.
+func TestServer_Rename_RejectsInvalidNewName(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///bad-name.lisp"
+	didOpen(t, client, uri, "(defn foo [x] x)\n")
+
+	send(t, client, 14, "textDocument/rename", RenameParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 0, Character: 7},
+		NewName:      "bad name",
+	})
+	resp := readUntil(t, client, response(14))
+	if resp["error"] == nil {
+		t.Fatalf("expected an error for an invalid new name, got %v", resp)
+	}
+}
+
+// renameEdits extracts the edit list for uri from a rename response.
+func renameEdits(t *testing.T, resp map[string]interface{}, uri string) []map[string]interface{} {
+	t.Helper()
+	result, ok := resp["result"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected a WorkspaceEdit result, got %v", resp["result"])
+	}
+	changes, ok := result["changes"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected changes in the WorkspaceEdit, got %v", result)
+	}
+	raw, ok := changes[uri].([]interface{})
+	if !ok {
+		t.Fatalf("expected edits for %s, got %v", uri, changes)
+	}
+	out := make([]map[string]interface{}, len(raw))
+	for i, e := range raw {
+		out[i] = e.(map[string]interface{})
+	}
+	return out
+}

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -109,6 +109,7 @@ func (s *Server) dispatch(req *requestMessage) {
 					RetriggerCharacters: []string{" "},
 				},
 				DocumentFormattingProvider: true,
+				RenameProvider:             RenameOptions{PrepareProvider: true},
 			},
 			ServerInfo: ServerInfo{Name: "jig-lisp-lsp"},
 		})
@@ -158,6 +159,10 @@ func (s *Server) dispatch(req *requestMessage) {
 		s.handleSignatureHelp(req)
 	case "textDocument/formatting":
 		s.handleFormatting(req)
+	case "textDocument/prepareRename":
+		s.handlePrepareRename(req)
+	case "textDocument/rename":
+		s.handleRename(req)
 	case "workspace/didChangeWatchedFiles":
 		// A .lisp file on disk changed (possibly a module required by an
 		// open document, and possibly not open itself). Re-analyse every
@@ -694,6 +699,85 @@ func (s *Server) handleDefinition(req *requestMessage) {
 		}
 	}
 	s.respond(req, nil)
+}
+
+// renameableSymbol reports whether sym (the token under the cursor) may
+// be renamed, and returns it. Rename is deliberately conservative: only
+// symbols defined in this document (def / defn / defmacro) qualify.
+// Builtins, names imported through require (and any qualified ns/name),
+// preamble placeholders and unresolved symbols are refused, because a
+// document-scoped textual rename could not update them correctly.
+func renameableSymbol(doc *document, sym string) bool {
+	if sym == "" || strings.HasPrefix(sym, "$") || strings.Contains(sym, "/") {
+		return false
+	}
+	for _, d := range doc.analysis.defs {
+		if d.name == sym {
+			return true
+		}
+	}
+	return false
+}
+
+// handlePrepareRename answers textDocument/prepareRename: it returns the
+// range of the whole symbol under the cursor (so hyphenated symbols are
+// selected as one token) when the symbol is renameable, or null so the
+// editor reports that the symbol cannot be renamed.
+func (s *Server) handlePrepareRename(req *requestMessage) {
+	var p TextDocumentPositionParams
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		s.respondError(req, codeInvalidParams, err.Error())
+		return
+	}
+	s.mu.Lock()
+	doc := s.docs[p.TextDocument.URI]
+	s.mu.Unlock()
+	if doc == nil {
+		s.respond(req, nil)
+		return
+	}
+	sym := symbolAt(doc.content, p.Position.Line, p.Position.Character)
+	if !renameableSymbol(doc, sym) {
+		s.respond(req, nil)
+		return
+	}
+	s.respond(req, symbolRangeAt(doc.content, p.Position.Line, p.Position.Character))
+}
+
+// handleRename answers textDocument/rename by replacing every whole-token
+// occurrence of the symbol in the document (outside strings and comments)
+// with the new name. The rename is document-scoped and lexical: it
+// rewrites every occurrence of the exact name, which is correct for a
+// file-level definition but does not distinguish a shadowing local of the
+// same name.
+func (s *Server) handleRename(req *requestMessage) {
+	var p RenameParams
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		s.respondError(req, codeInvalidParams, err.Error())
+		return
+	}
+	s.mu.Lock()
+	doc := s.docs[p.TextDocument.URI]
+	s.mu.Unlock()
+	if doc == nil {
+		s.respond(req, nil)
+		return
+	}
+	sym := symbolAt(doc.content, p.Position.Line, p.Position.Character)
+	if !renameableSymbol(doc, sym) {
+		s.respondError(req, codeInvalidParams, "this symbol cannot be renamed (only symbols defined in this file can be)")
+		return
+	}
+	if !validSymbolName(p.NewName) {
+		s.respondError(req, codeInvalidParams, "invalid new name: a symbol may not contain whitespace or delimiters")
+		return
+	}
+	ranges := symbolOccurrences(doc.content, sym)
+	edits := make([]TextEdit, len(ranges))
+	for i, r := range ranges {
+		edits[i] = TextEdit{Range: r, NewText: p.NewName}
+	}
+	s.respond(req, WorkspaceEdit{Changes: map[string][]TextEdit{p.TextDocument.URI: edits}})
 }
 
 func (s *Server) handleDocumentSymbol(req *requestMessage) {

--- a/lsp/server_test.go
+++ b/lsp/server_test.go
@@ -344,7 +344,7 @@ func TestServer_UnknownMethod(t *testing.T) {
 	client, stop := startSession(t)
 	defer stop()
 
-	send(t, client, 6, "textDocument/rename", map[string]interface{}{})
+	send(t, client, 6, "textDocument/thisMethodDoesNotExist", map[string]interface{}{})
 	resp := readUntil(t, client, response(6))
 	if resp["error"] == nil {
 		t.Fatalf("expected MethodNotFound error, got %v", resp)

--- a/tools/vscode-lisp/package.json
+++ b/tools/vscode-lisp/package.json
@@ -152,7 +152,8 @@
     "configurationDefaults": {
       "[lisp]": {
         "editor.formatOnSave": true,
-        "editor.defaultFormatter": "jig.vscode-lisp"
+        "editor.defaultFormatter": "jig.vscode-lisp",
+        "editor.wordSeparators": "()[]{}\"'`~@^;,"
       }
     }
   },


### PR DESCRIPTION
Two related fixes for renaming/selecting symbols with hyphens (and other lisp symbol characters).

## 1. Word selection treated `-` as a separator (`fix(vscode)`)

Selecting a symbol containing `-` (or `?`, `*`, `+`, `<`, `>`, `=`, `/`, …) split it — visible on F2 and Cmd/Ctrl-hover. Two settings define "a word": the language `wordPattern` (fixed in 64f1884) and the low-level `editor.wordSeparators`, whose default includes `-` and was never overridden. Added a lisp-scoped `editor.wordSeparators` containing only the real delimiters — the same set as the LSP's `symbolBreak` (`()[]{}"'`~@^;,`).

## 2. Rename provider — F2 (`feat(lsp)`)

Previously there was no rename provider at all. Added `textDocument/prepareRename` + `textDocument/rename`:

- **prepareRename** returns the whole-symbol range (hyphenated symbols select as one token) and **refuses** what it can't rename safely: only symbols **defined in the document** (def/defn/defmacro) qualify; builtins, require-imported and qualified `ns/name` references, and `$` preamble placeholders return null → "cannot rename".
- **rename** does a document-scoped, whole-token textual replacement that **skips string literals** (`"…"` and multi-line `¬…¬`) **and line comments**, so it never rewrites data or prose. A new name containing whitespace/delimiters is rejected.

Deliberately conservative per the ROADMAP's caution about edits corrupting sources. It is lexical, not scope-aware: a shadowing `let`/`fn` local of the same name is also renamed — documented, and narrowable later once find-references records non-head occurrences.

## Tests / verification

- New LSP tests: prepareRename returns the whole hyphenated range, refuses a builtin, rename edits def+call, rename skips strings/comments, invalid new name is rejected.
- `go test ./...` and `go vet ./lsp` green.

## Trying it

The `wordSeparators` change is a `package.json` contribution, so repackage + reinstall the extension: `npx @vscode/vsce package` → `code --install-extension vscode-lisp-*.vsix`. The rename provider is picked up automatically from the server's capabilities (no extension code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
