### PR TITLE
feat(lsp): find references (Shift+F12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ LSP (Language Server Protocol) server, both enabled with the
 - **Language server (LSP)**: live parse diagnostics while you type,
   symbol completion (core library plus your `def`/`defn`), hover with
   definition signatures, the document outline (Ctrl+Shift+O,
-  breadcrumbs), signature help while typing a call, and rename (F2) of
-  a symbol defined in the file. `(require
+  breadcrumbs), signature help while typing a call, find all references
+  (Shift+F12), and rename (F2) of a symbol defined in the file. `(require
   "module")` forms are resolved statically, so definitions from
   required modules are known to completion, hover, signature help,
   go-to-definition (F12) and the unknown-symbol check. Extra module

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,12 +66,15 @@ editor.
 
 ## High value, moderate effort (still surgical)
 
-### LSP: find references (Shift-F12)
-List every use of a symbol. The scan in
-[lsp/analyse.go](lsp/analyse.go) already collects call-head references;
-it needs to also record non-head symbol occurrences with positions, and
-a `textDocument/references` handler. *Effort: medium. Impact: high —
-the most requested navigation feature after go-to-definition.*
+### ~~LSP: find references (Shift-F12)~~ (done, lexical)
+List every use of a symbol. Implemented with the same whole-token,
+strings-and-comments-skipping scan as rename (`symbolOccurrences`), via a
+`textDocument/references` handler; `includeDeclaration=false` drops the
+definition sites. Read-only, so it is offered for any symbol (builtins
+and imported names included), unlike rename. Like rename it is lexical,
+not scope-aware — a shadowing local of the same name is listed too. A
+future scope-aware pass (an analysis that records each occurrence's
+binding) would sharpen both this and rename.
 
 ### ~~LSP: rename (F2)~~ (done, conservatively)
 Rename a symbol and every use in the file. Implemented conservatively,
@@ -172,10 +175,11 @@ Item-specific notes:
 
 Done: the three quick wins (LISPPATH, module-change watching, signature
 help), the debugger-power set (conditional breakpoints / logpoints,
-exception breakpoints, setVariable, return value after step), and a
-conservative rename (F2). Remaining, in order:
+exception breakpoints, setVariable, return value after step), and the
+navigation pair — find references (Shift-F12) and rename (F2), both
+lexical. Remaining, in order:
 
-1. Find references (Shift-F12) — and, with the non-head occurrences it
-   records, upgrade rename to be scope-aware
+1. Scope-aware analysis (bind each occurrence to its declaration) to
+   sharpen find-references and rename around shadowing locals
 2. Multi-thread futures (schedule real time for it)
 3. Semantic tokens / formatting (cosmetic)

--- a/lsp/protocol.go
+++ b/lsp/protocol.go
@@ -195,6 +195,20 @@ type ServerCapabilities struct {
 	SignatureHelpProvider      SignatureHelpOptions `json:"signatureHelpProvider"`
 	DocumentFormattingProvider bool                 `json:"documentFormattingProvider"`
 	RenameProvider             RenameOptions        `json:"renameProvider"`
+	ReferencesProvider         bool                 `json:"referencesProvider"`
+}
+
+// ReferenceParams is the payload of textDocument/references.
+type ReferenceParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	Position     Position               `json:"position"`
+	Context      ReferenceContext       `json:"context"`
+}
+
+// ReferenceContext controls whether the symbol's own declaration is
+// included in the results.
+type ReferenceContext struct {
+	IncludeDeclaration bool `json:"includeDeclaration"`
 }
 
 // RenameOptions declares rename support, including the prepare step that

--- a/lsp/references_test.go
+++ b/lsp/references_test.go
@@ -1,0 +1,86 @@
+package lsp
+
+import (
+	"sort"
+	"testing"
+)
+
+// referenceLines returns the sorted 0-based start lines of a references
+// response.
+func referenceLines(t *testing.T, resp map[string]interface{}) []int {
+	t.Helper()
+	raw, ok := resp["result"].([]interface{})
+	if !ok {
+		t.Fatalf("expected a locations array, got %v", resp["result"])
+	}
+	lines := make([]int, 0, len(raw))
+	for _, loc := range raw {
+		rng := loc.(map[string]interface{})["range"].(map[string]interface{})
+		start := rng["start"].(map[string]interface{})
+		lines = append(lines, int(start["line"].(float64)))
+	}
+	sort.Ints(lines)
+	return lines
+}
+
+func TestServer_References_IncludesDeclaration(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///refs.lisp"
+	didOpen(t, client, uri, "(defn my-func [x] x)\n(my-func 1)\n(my-func 2)\n")
+
+	send(t, client, 20, "textDocument/references", ReferenceParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 0, Character: 9},
+		Context:      ReferenceContext{IncludeDeclaration: true},
+	})
+	resp := readUntil(t, client, response(20))
+	got := referenceLines(t, resp)
+	want := []int{0, 1, 2} // definition + two calls
+	if len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Fatalf("expected references on lines %v, got %v", want, got)
+	}
+}
+
+func TestServer_References_ExcludesDeclaration(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///refs2.lisp"
+	didOpen(t, client, uri, "(defn my-func [x] x)\n(my-func 1)\n(my-func 2)\n")
+
+	send(t, client, 21, "textDocument/references", ReferenceParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 1, Character: 2},
+		Context:      ReferenceContext{IncludeDeclaration: false},
+	})
+	resp := readUntil(t, client, response(21))
+	got := referenceLines(t, resp)
+	if len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("expected only the two call sites (lines 1,2), got %v", got)
+	}
+}
+
+func TestServer_References_SkipsStringsAndComments(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///refs3.lisp"
+	src := "(defn foo [x] x)\n" + // 0: def
+		"(foo 1)\n" + // 1: call
+		";; foo mentioned\n" + // 2: comment
+		"(println \"foo\")\n" // 3: string
+	didOpen(t, client, uri, src)
+
+	send(t, client, 22, "textDocument/references", ReferenceParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 1, Character: 2},
+		Context:      ReferenceContext{IncludeDeclaration: true},
+	})
+	resp := readUntil(t, client, response(22))
+	got := referenceLines(t, resp)
+	if len(got) != 2 || got[0] != 0 || got[1] != 1 {
+		t.Fatalf("expected references only on lines 0,1 (def+call), got %v", got)
+	}
+}

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -110,6 +110,7 @@ func (s *Server) dispatch(req *requestMessage) {
 				},
 				DocumentFormattingProvider: true,
 				RenameProvider:             RenameOptions{PrepareProvider: true},
+				ReferencesProvider:         true,
 			},
 			ServerInfo: ServerInfo{Name: "jig-lisp-lsp"},
 		})
@@ -159,6 +160,8 @@ func (s *Server) dispatch(req *requestMessage) {
 		s.handleSignatureHelp(req)
 	case "textDocument/formatting":
 		s.handleFormatting(req)
+	case "textDocument/references":
+		s.handleReferences(req)
 	case "textDocument/prepareRename":
 		s.handlePrepareRename(req)
 	case "textDocument/rename":
@@ -699,6 +702,51 @@ func (s *Server) handleDefinition(req *requestMessage) {
 		}
 	}
 	s.respond(req, nil)
+}
+
+// handleReferences answers textDocument/references (Shift-F12): every
+// whole-token occurrence of the symbol under the cursor in the document,
+// skipping strings and comments (via symbolOccurrences). Unlike rename it
+// is read-only, so it is offered for any symbol — including builtins and
+// imported names. When the client sets includeDeclaration to false, the
+// symbol's own definition sites are dropped.
+func (s *Server) handleReferences(req *requestMessage) {
+	var p ReferenceParams
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		s.respondError(req, codeInvalidParams, err.Error())
+		return
+	}
+	s.mu.Lock()
+	doc := s.docs[p.TextDocument.URI]
+	s.mu.Unlock()
+	if doc == nil {
+		s.respond(req, []Location{})
+		return
+	}
+	sym := symbolAt(doc.content, p.Position.Line, p.Position.Character)
+	if sym == "" {
+		s.respond(req, []Location{})
+		return
+	}
+
+	// Declaration ranges to drop when the client does not want them.
+	declStarts := map[Position]bool{}
+	if !p.Context.IncludeDeclaration {
+		for _, d := range doc.analysis.defs {
+			if d.name == sym {
+				declStarts[symbolRange(d.namePos, d.name).Start] = true
+			}
+		}
+	}
+
+	locations := []Location{}
+	for _, r := range symbolOccurrences(doc.content, sym) {
+		if declStarts[r.Start] {
+			continue
+		}
+		locations = append(locations, Location{URI: p.TextDocument.URI, Range: r})
+	}
+	s.respond(req, locations)
 }
 
 // renameableSymbol reports whether sym (the token under the cursor) may


### PR DESCRIPTION
## What

Implements **Find All References (Shift+F12)** for the LSP: `textDocument/references` + the `referencesProvider` capability.

## How

Lists every whole-token occurrence of the symbol under the cursor in the document, reusing the `symbolOccurrences` scan added for rename — so **string literals** (`"…"` and multi-line `¬…¬`) **and line comments are skipped**. When the client requests `includeDeclaration=false`, the symbol's own `def`/`defn`/`defmacro` name sites are dropped.

Being read-only, references is offered for **any** symbol (builtins and imported names included), unlike the deliberately-restricted rename. It shares rename's limitation: lexical, not scope-aware, so a shadowing local of the same name is listed too. A future scope-aware analysis (binding each occurrence to its declaration) would sharpen both find-references and rename — now the single remaining LSP navigation item on the roadmap.

## Tests / verification

- New LSP tests: references with `includeDeclaration` true (def + all calls) and false (calls only), and skipping strings/comments.
- `go test ./...` and `go vet ./lsp` green.

Picked up automatically from server capabilities — no extension change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
