### PR TITLE
feat(lsp): scope-aware find-references and rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ LSP (Language Server Protocol) server, both enabled with the
   symbol completion (core library plus your `def`/`defn`), hover with
   definition signatures, the document outline (Ctrl+Shift+O,
   breadcrumbs), signature help while typing a call, find all references
-  (Shift+F12), and rename (F2) of a symbol defined in the file. `(require
+  (Shift+F12), and scope-aware rename (F2) of a symbol defined in the
+  file or a local binding. `(require
   "module")` forms are resolved statically, so definitions from
   required modules are known to completion, hover, signature help,
   go-to-definition (F12) and the unknown-symbol check. Extra module

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,26 +66,31 @@ editor.
 
 ## High value, moderate effort (still surgical)
 
-### ~~LSP: find references (Shift-F12)~~ (done, lexical)
-List every use of a symbol. Implemented with the same whole-token,
-strings-and-comments-skipping scan as rename (`symbolOccurrences`), via a
-`textDocument/references` handler; `includeDeclaration=false` drops the
-definition sites. Read-only, so it is offered for any symbol (builtins
-and imported names included), unlike rename. Like rename it is lexical,
-not scope-aware — a shadowing local of the same name is listed too. A
-future scope-aware pass (an analysis that records each occurrence's
-binding) would sharpen both this and rename.
+### ~~LSP: find references (Shift-F12)~~ (done, scope-aware)
+List every use of a symbol, via a `textDocument/references` handler;
+`includeDeclaration=false` drops the definition sites. Read-only, so it
+is offered for any symbol (builtins and imported names included), unlike
+rename. Scope-aware (see below): find-references on a local lists only
+that binding's uses.
 
-### ~~LSP: rename (F2)~~ (done, conservatively)
-Rename a symbol and every use in the file. Implemented conservatively,
-given the edits-user-code risk: only symbols **defined in the document**
-(def/defn/defmacro) are renameable — builtins, require-imported and
-qualified names and preamble placeholders are refused via
-`prepareRename`. The rename is a whole-file, whole-token textual
-replacement that skips strings and comments. It is lexical, not
-scope-aware, so a shadowing `let`/`fn` local of the same name is also
-renamed; a future refinement could use scope analysis to narrow it. See
-`symbolOccurrences` / `handleRename` in [lsp](lsp/).
+### ~~LSP: rename (F2)~~ (done, scope-aware)
+Rename a symbol and every use in the file. A top-level definition
+(def/defn/defmacro) **or a lexical binding under the cursor** (fn/defn
+parameter, let/loop binding, catch variable) is renameable; builtins,
+require-imported and qualified names, and preamble placeholders are
+refused via `prepareRename`.
+
+### ~~LSP: scope-aware find-references / rename~~ (done)
+Both start from the complete lexical occurrences (`symbolOccurrences`,
+which skips strings and comments, so nothing that must change is missed)
+and filter by scope: `analysis.locals` records every lexical binding
+with its visibility range, and `occurrencesInScope` keeps the
+occurrences enclosed by the target binding's scope while dropping those
+inside a nested rebinding of the same name. So renaming a top-level def
+skips a shadowing local, renaming a local touches only its own scope, and
+a local can now be renamed at all. Scopes are a safe over-approximation
+(the whole enclosing form). Still lexical inside a scope — it does not
+follow a value through higher-order calls — but shadowing is handled.
 
 ### ~~DAP: conditional breakpoints and logpoints~~ (done)
 Breakpoints firing only when a condition holds, or logging without
@@ -139,11 +144,12 @@ qualified symbol) instead of the TextMate grammar. Additive, but the
 token-encoding protocol is fiddly. *Effort: medium-large. Impact:
 cosmetic.*
 
-### LSP: formatting
-Canonical lisp indentation for Format Document. Needs a pretty-printer
-with per-form indentation rules (`defn` vs `let` vs plain calls) —
-opinionated and easy to get wrong against existing code styles.
-*Effort: large. Impact: nice-to-have.*
+### ~~LSP: formatting~~ (done)
+Canonical lisp formatting for Format Document, shared with the `--fmt`
+CLI: the `format` package parses and re-prints the source, and
+`textDocument/formatting` returns a whole-document edit (a document that
+does not parse is left untouched). See [format](format/) and
+`handleFormatting`.
 
 ## Backward compatibility (vital)
 
@@ -175,11 +181,9 @@ Item-specific notes:
 
 Done: the three quick wins (LISPPATH, module-change watching, signature
 help), the debugger-power set (conditional breakpoints / logpoints,
-exception breakpoints, setVariable, return value after step), and the
-navigation pair — find references (Shift-F12) and rename (F2), both
-lexical. Remaining, in order:
+exception breakpoints, setVariable, return value after step), the
+scope-aware navigation pair (find references / rename), and formatting.
+Remaining:
 
-1. Scope-aware analysis (bind each occurrence to its declaration) to
-   sharpen find-references and rename around shadowing locals
-2. Multi-thread futures (schedule real time for it)
-3. Semantic tokens / formatting (cosmetic)
+1. Semantic tokens (cosmetic)
+2. Multi-thread futures (the DAP big one — schedule real time for it)

--- a/lsp/analyse.go
+++ b/lsp/analyse.go
@@ -44,6 +44,16 @@ type preambleDef struct {
 	line int    // zero-based line of the preamble entry
 }
 
+// scopeBinding is one lexical binding (a fn/defn parameter, a let/loop
+// binding, or a catch variable) and the source range over which it is
+// visible. The range is the whole enclosing binding form — a safe
+// over-approximation of the body the binding governs, which is all that
+// scope-aware reference resolution needs.
+type scopeBinding struct {
+	name  string
+	scope Range
+}
+
 // analysis is the result of parsing one document.
 type analysis struct {
 	diagnostics []Diagnostic
@@ -52,6 +62,7 @@ type analysis struct {
 
 	calls     []symbolRef     // symbols used as the head of a call form
 	bound     map[string]bool // every name bound anywhere in the document
+	locals    []scopeBinding  // lexical bindings with their visibility range
 	requires  []requireRef    // require'd module names (string literals)
 	preambles []preambleDef   // in-file placeholder defaults
 }
@@ -167,6 +178,7 @@ func (a *analysis) scan(form types.MalType) {
 		}
 		if head.Val != "def" && len(list.Val) >= 3 {
 			a.bindAll(list.Val[2])
+			a.bindLocals(list.Val[2], rangeOf(list.Cursor))
 		}
 		for _, c := range tail(list.Val, 2) {
 			a.scan(c)
@@ -174,11 +186,13 @@ func (a *analysis) scan(form types.MalType) {
 	case "fn":
 		if len(list.Val) >= 2 {
 			a.bindAll(list.Val[1])
+			a.bindLocals(list.Val[1], rangeOf(list.Cursor))
 		}
 		for _, c := range tail(list.Val, 2) {
 			a.scan(c)
 		}
-	case "let":
+	case "let", "loop":
+		scope := rangeOf(list.Cursor)
 		if len(list.Val) >= 2 {
 			var binds []types.MalType
 			switch b := list.Val[1].(type) {
@@ -189,6 +203,7 @@ func (a *analysis) scan(form types.MalType) {
 			}
 			for i := 0; i+1 < len(binds); i += 2 {
 				a.bindAll(binds[i])
+				a.bindLocals(binds[i], scope)
 				a.scan(binds[i+1])
 			}
 		}
@@ -198,6 +213,7 @@ func (a *analysis) scan(form types.MalType) {
 	case "catch":
 		if len(list.Val) >= 2 {
 			a.bindAll(list.Val[1])
+			a.bindLocals(list.Val[1], rangeOf(list.Cursor))
 		}
 		for _, c := range tail(list.Val, 2) {
 			a.scan(c)
@@ -268,6 +284,111 @@ func (a *analysis) bindAll(form types.MalType) {
 		for _, c := range n.Val {
 			a.bindAll(c)
 		}
+	}
+}
+
+// bindLocals records every symbol inside a binding form (a parameter
+// vector, possibly with `&`, or a plain symbol) as a lexical binding
+// visible over scope. It mirrors bindAll but keeps the visibility range.
+func (a *analysis) bindLocals(form types.MalType, scope Range) {
+	switch n := form.(type) {
+	case types.Symbol:
+		if n.Val != "&" {
+			a.locals = append(a.locals, scopeBinding{name: n.Val, scope: scope})
+		}
+	case types.Vector:
+		for _, c := range n.Val {
+			a.bindLocals(c, scope)
+		}
+	case types.List:
+		for _, c := range n.Val {
+			a.bindLocals(c, scope)
+		}
+	}
+}
+
+// posLess reports whether a is strictly before b.
+func posLess(a, b Position) bool {
+	return a.Line < b.Line || (a.Line == b.Line && a.Character < b.Character)
+}
+
+// rangeContains reports whether p lies within [r.Start, r.End).
+func rangeContains(r Range, p Position) bool {
+	return !posLess(p, r.Start) && posLess(p, r.End)
+}
+
+// rangeInside reports whether inner is fully contained in outer and is
+// not the same range — i.e. a strictly nested scope.
+func rangeInside(inner, outer Range) bool {
+	if inner == outer {
+		return false
+	}
+	return !posLess(inner.Start, outer.Start) && !posLess(outer.End, inner.End)
+}
+
+// resolveScope determines which binding the symbol sym refers to at pos.
+// It returns the visibility range of the innermost lexical binding of sym
+// enclosing pos (isLocal=true); when none encloses pos the symbol refers
+// to a top-level/free binding and the whole-document range is returned
+// (isLocal=false).
+func (a *analysis) resolveScope(sym string, pos Position, docScope Range) (scope Range, isLocal bool) {
+	best := docScope
+	found := false
+	for _, b := range a.locals {
+		if b.name != sym || !rangeContains(b.scope, pos) {
+			continue
+		}
+		// Innermost wins: for properly nested scopes the one with the
+		// latest start is the most deeply nested.
+		if !found || posLess(best.Start, b.scope.Start) {
+			best = b.scope
+			found = true
+		}
+	}
+	return best, found
+}
+
+// occurrencesInScope returns the ranges of every occurrence of sym that
+// resolves to the same binding as the one under pos. It starts from the
+// complete lexical occurrences (so nothing that must change is missed)
+// and drops those inside a nested rebinding of the same name (shadowing).
+func (a *analysis) occurrencesInScope(content, sym string, pos Position) []Range {
+	docScope := wholeContentRange(content)
+	target, _ := a.resolveScope(sym, pos, docScope)
+
+	// Nested same-name bindings whose scope shadows part of the target.
+	var shadows []Range
+	for _, b := range a.locals {
+		if b.name == sym && rangeInside(b.scope, target) {
+			shadows = append(shadows, b.scope)
+		}
+	}
+
+	var out []Range
+	for _, occ := range symbolOccurrences(content, sym) {
+		if !rangeContains(target, occ.Start) {
+			continue
+		}
+		shadowed := false
+		for _, s := range shadows {
+			if rangeContains(s, occ.Start) {
+				shadowed = true
+				break
+			}
+		}
+		if !shadowed {
+			out = append(out, occ)
+		}
+	}
+	return out
+}
+
+// wholeContentRange spans the entire document.
+func wholeContentRange(content string) Range {
+	lines := strings.Count(content, "\n")
+	return Range{
+		Start: Position{Line: 0, Character: 0},
+		End:   Position{Line: lines + 1, Character: 0},
 	}
 }
 

--- a/lsp/scope_test.go
+++ b/lsp/scope_test.go
@@ -1,0 +1,114 @@
+package lsp
+
+import (
+	"sort"
+	"testing"
+)
+
+// editLines returns the sorted set of distinct start lines of a rename
+// response's edits.
+func editLines(t *testing.T, resp map[string]interface{}, uri string) []int {
+	t.Helper()
+	seen := map[int]bool{}
+	for _, e := range renameEdits(t, resp, uri) {
+		rng := e["range"].(map[string]interface{})
+		seen[int(rng["start"].(map[string]interface{})["line"].(float64))] = true
+	}
+	out := make([]int, 0, len(seen))
+	for l := range seen {
+		out = append(out, l)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// TestServer_Rename_LocalIsScoped renames a parameter and checks only its
+// own function's occurrences change — not a same-named parameter in a
+// sibling function.
+func TestServer_Rename_LocalIsScoped(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///local.lisp"
+	didOpen(t, client, uri, "(defn f [x] (+ x 1))\n(defn g [x] (* x 2))\n")
+
+	// Cursor on the use of x inside f (line 0, char 15).
+	send(t, client, 30, "textDocument/rename", RenameParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 0, Character: 15},
+		NewName:      "y",
+	})
+	resp := readUntil(t, client, response(30))
+	edits := renameEdits(t, resp, uri)
+	if len(edits) != 2 {
+		t.Fatalf("expected 2 edits (param + use in f only), got %d: %v", len(edits), edits)
+	}
+	if lines := editLines(t, resp, uri); len(lines) != 1 || lines[0] != 0 {
+		t.Fatalf("expected all edits on line 0 (f), got lines %v", lines)
+	}
+}
+
+// TestServer_Rename_TopLevelExcludesShadow renames a top-level def and
+// checks a shadowing local of the same name is left untouched.
+func TestServer_Rename_TopLevelExcludesShadow(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///shadow.lisp"
+	didOpen(t, client, uri, "(def x 10)\n(defn f [x] x)\n(println x)\n")
+
+	// Cursor on the top-level def name x (line 0, char 5).
+	send(t, client, 31, "textDocument/rename", RenameParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 0, Character: 5},
+		NewName:      "z",
+	})
+	resp := readUntil(t, client, response(31))
+	lines := editLines(t, resp, uri)
+	// Def site (line 0) and the free use (line 2); the shadowed uses on
+	// line 1 must be excluded.
+	if len(lines) != 2 || lines[0] != 0 || lines[1] != 2 {
+		t.Fatalf("expected edits on lines [0 2] (shadow on line 1 excluded), got %v", lines)
+	}
+}
+
+// TestServer_References_LocalIsScoped checks find-references on a local
+// only lists that binding's occurrences.
+func TestServer_References_LocalIsScoped(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///local-refs.lisp"
+	didOpen(t, client, uri, "(defn f [x] (+ x 1))\n(defn g [x] (* x 2))\n")
+
+	send(t, client, 32, "textDocument/references", ReferenceParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 0, Character: 15},
+		Context:      ReferenceContext{IncludeDeclaration: true},
+	})
+	resp := readUntil(t, client, response(32))
+	lines := referenceLines(t, resp)
+	if len(lines) != 2 || lines[0] != 0 || lines[1] != 0 {
+		t.Fatalf("expected both references on line 0 (f's x), got %v", lines)
+	}
+}
+
+// TestServer_PrepareRename_AllowsLocal checks a local binding (not a
+// top-level def) is now renameable, and returns the whole-symbol range.
+func TestServer_PrepareRename_AllowsLocal(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///allow-local.lisp"
+	didOpen(t, client, uri, "(defn f [count] (+ count 1))\n")
+
+	// Cursor inside the local "count" use.
+	send(t, client, 33, "textDocument/prepareRename", TextDocumentPositionParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+		Position:     Position{Line: 0, Character: 20},
+	})
+	resp := readUntil(t, client, response(33))
+	if _, ok := resp["result"].(map[string]interface{}); !ok {
+		t.Fatalf("expected a range (local is renameable), got %v", resp["result"])
+	}
+}

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -740,7 +740,7 @@ func (s *Server) handleReferences(req *requestMessage) {
 	}
 
 	locations := []Location{}
-	for _, r := range symbolOccurrences(doc.content, sym) {
+	for _, r := range doc.analysis.occurrencesInScope(doc.content, sym, p.Position) {
 		if declStarts[r.Start] {
 			continue
 		}
@@ -749,13 +749,14 @@ func (s *Server) handleReferences(req *requestMessage) {
 	s.respond(req, locations)
 }
 
-// renameableSymbol reports whether sym (the token under the cursor) may
-// be renamed, and returns it. Rename is deliberately conservative: only
-// symbols defined in this document (def / defn / defmacro) qualify.
-// Builtins, names imported through require (and any qualified ns/name),
-// preamble placeholders and unresolved symbols are refused, because a
-// document-scoped textual rename could not update them correctly.
-func renameableSymbol(doc *document, sym string) bool {
+// renameableAt reports whether sym (the token under the cursor at pos)
+// may be renamed. Two kinds of symbol qualify, both resolvable within the
+// file: a top-level definition (def / defn / defmacro), or a lexical
+// binding (fn/defn parameter, let/loop binding, catch variable) enclosing
+// the cursor. Builtins, names imported through require, any qualified
+// ns/name, preamble placeholders and unresolved symbols are refused,
+// because the rename could not update them correctly.
+func renameableAt(doc *document, sym string, pos Position) bool {
 	if sym == "" || strings.HasPrefix(sym, "$") || strings.Contains(sym, "/") {
 		return false
 	}
@@ -764,7 +765,8 @@ func renameableSymbol(doc *document, sym string) bool {
 			return true
 		}
 	}
-	return false
+	_, isLocal := doc.analysis.resolveScope(sym, pos, wholeContentRange(doc.content))
+	return isLocal
 }
 
 // handlePrepareRename answers textDocument/prepareRename: it returns the
@@ -785,7 +787,7 @@ func (s *Server) handlePrepareRename(req *requestMessage) {
 		return
 	}
 	sym := symbolAt(doc.content, p.Position.Line, p.Position.Character)
-	if !renameableSymbol(doc, sym) {
+	if !renameableAt(doc, sym, p.Position) {
 		s.respond(req, nil)
 		return
 	}
@@ -812,15 +814,15 @@ func (s *Server) handleRename(req *requestMessage) {
 		return
 	}
 	sym := symbolAt(doc.content, p.Position.Line, p.Position.Character)
-	if !renameableSymbol(doc, sym) {
-		s.respondError(req, codeInvalidParams, "this symbol cannot be renamed (only symbols defined in this file can be)")
+	if !renameableAt(doc, sym, p.Position) {
+		s.respondError(req, codeInvalidParams, "this symbol cannot be renamed (only symbols defined in this file, or a local binding, can be)")
 		return
 	}
 	if !validSymbolName(p.NewName) {
 		s.respondError(req, codeInvalidParams, "invalid new name: a symbol may not contain whitespace or delimiters")
 		return
 	}
-	ranges := symbolOccurrences(doc.content, sym)
+	ranges := doc.analysis.occurrencesInScope(doc.content, sym, p.Position)
 	edits := make([]TextEdit, len(ranges))
 	for i, r := range ranges {
 		edits[i] = TextEdit{Range: r, NewText: p.NewName}


### PR DESCRIPTION
## What

Makes find-references (Shift+F12) and rename (F2) **scope-aware**, replacing the previous blind whole-file textual matching. This was the roadmap's top remaining navigation item.

## How

The analysis now records every lexical binding — `fn`/`defn` parameters, `let`/`loop` bindings, `catch` variables — with its **visibility range** (`analysis.locals`). `occurrencesInScope`:

1. starts from the **complete** lexical occurrences (`symbolOccurrences`, which already skips strings and comments — so nothing that must change is ever missed), then
2. keeps only those enclosed by the target binding's scope, **dropping any inside a nested rebinding of the same name** (shadowing).

Starting from the complete set and *filtering* keeps rename safe (it can't leave a straggler that breaks the code) while making it correct around shadowing.

## Effects

- Renaming a top-level `def` no longer touches a shadowing local of the same name; renaming a local touches only its own scope.
- **A local binding can now be renamed** (`prepareRename` accepts it) — the earlier restriction to top-level defs existed only because rename was blind.
- find-references on a local lists only that binding's uses.

Scopes are a safe over-approximation (the whole enclosing form). The analysis is still lexical *inside* a scope — it does not follow a value through higher-order calls — but shadowing is now handled.

Also marks **LSP formatting** done in the roadmap: it already shipped (the `format` package / `--fmt` and `handleFormatting`); the roadmap entry was stale.

## Tests / verification

New LSP tests: local rename stays in its function, top-level rename skips a shadowing local, find-references on a local is scoped, prepareRename accepts a local. `go test ./...` and `go vet ./lsp` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
