### PR TITLE
feat(lsp): semantic tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ LSP (Language Server Protocol) server, both enabled with the
   symbol completion (core library plus your `def`/`defn`), hover with
   definition signatures, the document outline (Ctrl+Shift+O,
   breadcrumbs), signature help while typing a call, find all references
-  (Shift+F12), and scope-aware rename (F2) of a symbol defined in the
-  file or a local binding. `(require
+  (Shift+F12), scope-aware rename (F2) of a symbol defined in the
+  file or a local binding, and semantic highlighting. `(require
   "module")` forms are resolved statically, so definitions from
   required modules are known to completion, hover, signature help,
   go-to-definition (F12) and the unknown-symbol check. Extra module

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -138,11 +138,16 @@ Impact: high for concurrent programs; zero for sequential scripts.*
 
 ## Cosmetic / large
 
-### LSP: semantic tokens
-Real semantic highlighting (macro vs function vs local binding vs
-qualified symbol) instead of the TextMate grammar. Additive, but the
-token-encoding protocol is fiddly. *Effort: medium-large. Impact:
-cosmetic.*
+### ~~LSP: semantic tokens~~ (done)
+Semantic highlighting on top of the TextMate grammar:
+`textDocument/semanticTokens/full` classifies every symbol from the
+parsed AST — special forms as keywords, def/defn/defmacro names as
+variable/function/macro declarations, fn/defn/let/loop/catch bindings and
+their local uses as parameters, qualified `ns/name` references as
+namespaces, and call heads as function/macro (a document-local macro
+reads as a macro). All standard LSP token types, so themes colour them
+without extra configuration. See `analysis.semanticTokens` /
+`handleSemanticTokens`.
 
 ### ~~LSP: formatting~~ (done)
 Canonical lisp formatting for Format Document, shared with the `--fmt`
@@ -182,8 +187,7 @@ Item-specific notes:
 Done: the three quick wins (LISPPATH, module-change watching, signature
 help), the debugger-power set (conditional breakpoints / logpoints,
 exception breakpoints, setVariable, return value after step), the
-scope-aware navigation pair (find references / rename), and formatting.
-Remaining:
+scope-aware navigation pair (find references / rename), formatting, and
+semantic tokens. Remaining:
 
-1. Semantic tokens (cosmetic)
-2. Multi-thread futures (the DAP big one — schedule real time for it)
+1. Multi-thread futures (the DAP big one — schedule real time for it)

--- a/lsp/analyse.go
+++ b/lsp/analyse.go
@@ -392,6 +392,232 @@ func wholeContentRange(content string) Range {
 	}
 }
 
+// Semantic token types, in the order of the legend advertised to the
+// client (SemanticTokensLegend.TokenTypes). The integers a token carries
+// index into that list.
+const (
+	tokNamespace = iota
+	tokFunction
+	tokMacro
+	tokVariable
+	tokParameter
+	tokKeyword
+)
+
+// semanticTokenTypes / semanticTokenModifiers are the legend. Modifier
+// values are a bitset over this list.
+var semanticTokenTypes = []string{"namespace", "function", "macro", "variable", "parameter", "keyword"}
+var semanticTokenModifiers = []string{"declaration"}
+
+const tokModDeclaration = 1 << 0
+
+// semTok is one classified token before delta-encoding.
+type semTok struct {
+	rng  Range
+	typ  int
+	mods int
+}
+
+// semanticTokens classifies every symbol in the document for semantic
+// highlighting: special forms as keywords, definition names as
+// function/macro/variable, binding sites and local uses as parameters,
+// qualified ns/name references as namespaces, and call heads as
+// function/macro. It walks the parsed AST; quoted data is not descended
+// into. Tokens are returned in document order.
+func (a *analysis) semanticTokens(content string) []semTok {
+	b := &semBuilder{a: a, docScope: wholeContentRange(content)}
+	for _, f := range a.forms {
+		b.walk(f)
+	}
+	return b.toks
+}
+
+type semBuilder struct {
+	a        *analysis
+	docScope Range
+	toks     []semTok
+}
+
+func (b *semBuilder) emit(sym types.Symbol, typ, mods int) {
+	if sym.Cursor == nil {
+		return
+	}
+	b.toks = append(b.toks, semTok{rng: symbolRange(sym.Cursor, sym.Val), typ: typ, mods: mods})
+}
+
+// binding emits every symbol in a binding form as a parameter declaration.
+func (b *semBuilder) binding(form types.MalType) {
+	switch n := form.(type) {
+	case types.Symbol:
+		if n.Val != "&" {
+			b.emit(n, tokParameter, tokModDeclaration)
+		}
+	case types.Vector:
+		for _, c := range n.Val {
+			b.binding(c)
+		}
+	case types.List:
+		for _, c := range n.Val {
+			b.binding(c)
+		}
+	}
+}
+
+func (b *semBuilder) walk(form types.MalType) {
+	switch n := form.(type) {
+	case types.Symbol:
+		b.ref(n)
+	case types.Vector:
+		for _, c := range n.Val {
+			b.walk(c)
+		}
+	case types.HashMap:
+		for _, v := range n.Val {
+			b.walk(v)
+		}
+	case types.List:
+		b.list(n)
+	}
+}
+
+func (b *semBuilder) list(n types.List) {
+	if len(n.Val) == 0 {
+		return
+	}
+	head, ok := n.Val[0].(types.Symbol)
+	if !ok {
+		for _, c := range n.Val {
+			b.walk(c)
+		}
+		return
+	}
+	switch head.Val {
+	case "quote", "quasiquote", "quasiquoteexpand":
+		b.emit(head, tokKeyword, 0) // data, not code: do not descend
+	case "def", "defn", "defmacro":
+		b.emit(head, tokKeyword, 0)
+		if len(n.Val) >= 2 {
+			if name, ok := n.Val[1].(types.Symbol); ok {
+				typ := tokVariable
+				switch head.Val {
+				case "defn":
+					typ = tokFunction
+				case "defmacro":
+					typ = tokMacro
+				}
+				b.emit(name, typ, tokModDeclaration)
+			}
+		}
+		if head.Val == "def" {
+			for _, c := range tail(n.Val, 2) {
+				b.walk(c)
+			}
+		} else {
+			if len(n.Val) >= 3 {
+				b.binding(n.Val[2])
+			}
+			// Body starts after the parameter vector (index 3), so the
+			// parameters are not re-emitted as value references.
+			for _, c := range tail(n.Val, 3) {
+				b.walk(c)
+			}
+		}
+	case "fn":
+		b.emit(head, tokKeyword, 0)
+		if len(n.Val) >= 2 {
+			b.binding(n.Val[1])
+		}
+		for _, c := range tail(n.Val, 2) {
+			b.walk(c)
+		}
+	case "let", "loop":
+		b.emit(head, tokKeyword, 0)
+		if len(n.Val) >= 2 {
+			var binds []types.MalType
+			switch bb := n.Val[1].(type) {
+			case types.Vector:
+				binds = bb.Val
+			case types.List:
+				binds = bb.Val
+			}
+			for i := 0; i+1 < len(binds); i += 2 {
+				b.binding(binds[i])
+				b.walk(binds[i+1])
+			}
+		}
+		for _, c := range tail(n.Val, 2) {
+			b.walk(c)
+		}
+	case "catch":
+		b.emit(head, tokKeyword, 0)
+		if len(n.Val) >= 2 {
+			b.binding(n.Val[1])
+		}
+		for _, c := range tail(n.Val, 2) {
+			b.walk(c)
+		}
+	default:
+		if specialForms[head.Val] {
+			b.emit(head, tokKeyword, 0)
+		} else {
+			b.emit(head, b.headType(head.Val), 0)
+		}
+		for _, c := range tail(n.Val, 1) {
+			b.walk(c)
+		}
+	}
+}
+
+// headType classifies a call head: a document-local macro reads as macro,
+// anything else (a defn, a builtin, an imported name) as a function.
+func (b *semBuilder) headType(name string) int {
+	if strings.Contains(name, "/") {
+		return tokFunction // a qualified call is still a call
+	}
+	for _, d := range b.a.defs {
+		if d.name == name {
+			if d.kind == "defmacro" {
+				return tokMacro
+			}
+			return tokFunction
+		}
+	}
+	return tokFunction
+}
+
+// ref classifies a symbol used in value position (not a call head).
+func (b *semBuilder) ref(sym types.Symbol) {
+	name := sym.Val
+	switch {
+	case specialForms[name]:
+		b.emit(sym, tokKeyword, 0)
+	case strings.Contains(name, "/"):
+		b.emit(sym, tokNamespace, 0)
+	default:
+		if sym.Cursor != nil {
+			pos := symbolRange(sym.Cursor, name).Start
+			if _, isLocal := b.a.resolveScope(name, pos, b.docScope); isLocal {
+				b.emit(sym, tokParameter, 0)
+				return
+			}
+		}
+		for _, d := range b.a.defs {
+			if d.name == name {
+				switch d.kind {
+				case "defmacro":
+					b.emit(sym, tokMacro, 0)
+				case "defn":
+					b.emit(sym, tokFunction, 0)
+				default:
+					b.emit(sym, tokVariable, 0)
+				}
+				return
+			}
+		}
+		b.emit(sym, tokVariable, 0)
+	}
+}
+
 // diagnosticFromError converts a reader error into an LSP diagnostic.
 // Rows are shifted by -1 to undo the `(do\n` wrapper line; LSP positions
 // are zero-based while the reader's are one-based.

--- a/lsp/protocol.go
+++ b/lsp/protocol.go
@@ -187,16 +187,16 @@ type InitializeResult struct {
 
 // ServerCapabilities declares what this server implements.
 type ServerCapabilities struct {
-	TextDocumentSync           int                  `json:"textDocumentSync"` // 1 = full
-	CompletionProvider         struct{}             `json:"completionProvider"`
-	HoverProvider              bool                 `json:"hoverProvider"`
-	DocumentSymbolProvider     bool                 `json:"documentSymbolProvider"`
-	DefinitionProvider         bool                 `json:"definitionProvider"`
-	SignatureHelpProvider      SignatureHelpOptions `json:"signatureHelpProvider"`
-	DocumentFormattingProvider bool                 `json:"documentFormattingProvider"`
-	RenameProvider             RenameOptions          `json:"renameProvider"`
-	ReferencesProvider         bool                   `json:"referencesProvider"`
-	SemanticTokensProvider     SemanticTokensOptions  `json:"semanticTokensProvider"`
+	TextDocumentSync           int                   `json:"textDocumentSync"` // 1 = full
+	CompletionProvider         struct{}              `json:"completionProvider"`
+	HoverProvider              bool                  `json:"hoverProvider"`
+	DocumentSymbolProvider     bool                  `json:"documentSymbolProvider"`
+	DefinitionProvider         bool                  `json:"definitionProvider"`
+	SignatureHelpProvider      SignatureHelpOptions  `json:"signatureHelpProvider"`
+	DocumentFormattingProvider bool                  `json:"documentFormattingProvider"`
+	RenameProvider             RenameOptions         `json:"renameProvider"`
+	ReferencesProvider         bool                  `json:"referencesProvider"`
+	SemanticTokensProvider     SemanticTokensOptions `json:"semanticTokensProvider"`
 }
 
 // SemanticTokensOptions declares semantic-highlighting support and the

--- a/lsp/protocol.go
+++ b/lsp/protocol.go
@@ -194,8 +194,36 @@ type ServerCapabilities struct {
 	DefinitionProvider         bool                 `json:"definitionProvider"`
 	SignatureHelpProvider      SignatureHelpOptions `json:"signatureHelpProvider"`
 	DocumentFormattingProvider bool                 `json:"documentFormattingProvider"`
-	RenameProvider             RenameOptions        `json:"renameProvider"`
-	ReferencesProvider         bool                 `json:"referencesProvider"`
+	RenameProvider             RenameOptions          `json:"renameProvider"`
+	ReferencesProvider         bool                   `json:"referencesProvider"`
+	SemanticTokensProvider     SemanticTokensOptions  `json:"semanticTokensProvider"`
+}
+
+// SemanticTokensOptions declares semantic-highlighting support and the
+// legend (the ordered token-type / modifier names the encoded token
+// integers index into).
+type SemanticTokensOptions struct {
+	Legend SemanticTokensLegend `json:"legend"`
+	Full   bool                 `json:"full"`
+}
+
+// SemanticTokensLegend names the token types and modifiers, in the order
+// their indices refer to.
+type SemanticTokensLegend struct {
+	TokenTypes     []string `json:"tokenTypes"`
+	TokenModifiers []string `json:"tokenModifiers"`
+}
+
+// SemanticTokensParams is the payload of textDocument/semanticTokens/full.
+type SemanticTokensParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+// SemanticTokens is the response: a flat array of 5-tuples
+// (deltaLine, deltaStartChar, length, tokenType, tokenModifiers),
+// each token delta-encoded relative to the previous one.
+type SemanticTokens struct {
+	Data []int `json:"data"`
 }
 
 // ReferenceParams is the payload of textDocument/references.

--- a/lsp/semantictokens_test.go
+++ b/lsp/semantictokens_test.go
@@ -26,11 +26,11 @@ func TestSemanticTokens_Classification(t *testing.T) {
 	}
 
 	want := map[int]tk{
-		1:  {tokKeyword, 0},                    // defn
-		6:  {tokFunction, tokModDeclaration},   // my-func (declaration)
-		15: {tokParameter, tokModDeclaration},  // x (binding)
-		19: {tokFunction, 0},                   // + (builtin call head)
-		21: {tokParameter, 0},                  // x (use)
+		1:  {tokKeyword, 0},                   // defn
+		6:  {tokFunction, tokModDeclaration},  // my-func (declaration)
+		15: {tokParameter, tokModDeclaration}, // x (binding)
+		19: {tokFunction, 0},                  // + (builtin call head)
+		21: {tokParameter, 0},                 // x (use)
 	}
 	if len(got) != len(want) {
 		t.Fatalf("expected %d tokens, got %d: %v", len(want), len(got), got)

--- a/lsp/semantictokens_test.go
+++ b/lsp/semantictokens_test.go
@@ -1,0 +1,96 @@
+package lsp
+
+import (
+	"testing"
+)
+
+// TestSemanticTokens_Classification checks each symbol is classified with
+// the expected token type: special forms as keywords, the defn name as a
+// function declaration, parameters (binding and use) as parameters, and a
+// builtin call head as a function.
+func TestSemanticTokens_Classification(t *testing.T) {
+	src := "(defn my-func [x] (+ x 1))\n"
+	a := analyseDocument("t.lisp", src)
+	toks := a.semanticTokens(src)
+
+	type tk struct {
+		typ  int
+		mods int
+	}
+	got := map[int]tk{} // keyed by start char (all on line 0)
+	for _, s := range toks {
+		if s.rng.Start.Line != 0 {
+			t.Fatalf("unexpected token on line %d", s.rng.Start.Line)
+		}
+		got[s.rng.Start.Character] = tk{s.typ, s.mods}
+	}
+
+	want := map[int]tk{
+		1:  {tokKeyword, 0},                    // defn
+		6:  {tokFunction, tokModDeclaration},   // my-func (declaration)
+		15: {tokParameter, tokModDeclaration},  // x (binding)
+		19: {tokFunction, 0},                   // + (builtin call head)
+		21: {tokParameter, 0},                  // x (use)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d tokens, got %d: %v", len(want), len(got), got)
+	}
+	for char, w := range want {
+		g, ok := got[char]
+		if !ok {
+			t.Errorf("no token at char %d (want %v)", char, w)
+			continue
+		}
+		if g != w {
+			t.Errorf("token at char %d: got %v, want %v", char, g, w)
+		}
+	}
+}
+
+// TestSemanticTokens_MacroAndDef checks defmacro names and def names are
+// distinguished, and a macro call head reads as a macro.
+func TestSemanticTokens_MacroAndDef(t *testing.T) {
+	src := "(def answer 42)\n(defmacro twice [x] x)\n(twice answer)\n"
+	a := analyseDocument("t.lisp", src)
+	toks := a.semanticTokens(src)
+
+	byPos := map[[2]int]int{}
+	for _, s := range toks {
+		byPos[[2]int{s.rng.Start.Line, s.rng.Start.Character}] = s.typ
+	}
+	// "answer" def name (line 0, char 5) is a variable.
+	if byPos[[2]int{0, 5}] != tokVariable {
+		t.Errorf("def name should be variable, got %v", byPos[[2]int{0, 5}])
+	}
+	// "twice" defmacro name (line 1, char 10) is a macro declaration.
+	if byPos[[2]int{1, 10}] != tokMacro {
+		t.Errorf("defmacro name should be macro, got %v", byPos[[2]int{1, 10}])
+	}
+	// "twice" call head (line 2, char 1) reads as a macro.
+	if byPos[[2]int{2, 1}] != tokMacro {
+		t.Errorf("macro call head should be macro, got %v", byPos[[2]int{2, 1}])
+	}
+	// "answer" use (line 2, char 7) reads as a variable.
+	if byPos[[2]int{2, 7}] != tokVariable {
+		t.Errorf("variable use should be variable, got %v", byPos[[2]int{2, 7}])
+	}
+}
+
+// TestSemanticTokens_WireFormat checks the delta-encoded response is
+// well-formed (a multiple of five integers) and non-empty.
+func TestSemanticTokens_WireFormat(t *testing.T) {
+	client, stop := startSession(t)
+	defer stop()
+
+	uri := "file:///sem.lisp"
+	didOpen(t, client, uri, "(defn f [x] (+ x 1))\n")
+
+	send(t, client, 40, "textDocument/semanticTokens/full", SemanticTokensParams{
+		TextDocument: TextDocumentIdentifier{URI: uri},
+	})
+	resp := readUntil(t, client, response(40))
+	data := resp["result"].(map[string]interface{})["data"].([]interface{})
+	if len(data) == 0 || len(data)%5 != 0 {
+		t.Fatalf("expected a non-empty multiple-of-5 token array, got %d ints", len(data))
+	}
+}

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -111,6 +111,13 @@ func (s *Server) dispatch(req *requestMessage) {
 				DocumentFormattingProvider: true,
 				RenameProvider:             RenameOptions{PrepareProvider: true},
 				ReferencesProvider:         true,
+				SemanticTokensProvider: SemanticTokensOptions{
+					Legend: SemanticTokensLegend{
+						TokenTypes:     semanticTokenTypes,
+						TokenModifiers: semanticTokenModifiers,
+					},
+					Full: true,
+				},
 			},
 			ServerInfo: ServerInfo{Name: "jig-lisp-lsp"},
 		})
@@ -162,6 +169,8 @@ func (s *Server) dispatch(req *requestMessage) {
 		s.handleFormatting(req)
 	case "textDocument/references":
 		s.handleReferences(req)
+	case "textDocument/semanticTokens/full":
+		s.handleSemanticTokens(req)
 	case "textDocument/prepareRename":
 		s.handlePrepareRename(req)
 	case "textDocument/rename":
@@ -702,6 +711,53 @@ func (s *Server) handleDefinition(req *requestMessage) {
 		}
 	}
 	s.respond(req, nil)
+}
+
+// handleSemanticTokens answers textDocument/semanticTokens/full: it
+// classifies every symbol (see analysis.semanticTokens) and returns them
+// delta-encoded per the LSP wire format — each token is five integers
+// relative to the previous one: line delta, start-char delta (from the
+// previous token when on the same line, else absolute), length, type
+// index and modifier bitset.
+func (s *Server) handleSemanticTokens(req *requestMessage) {
+	var p SemanticTokensParams
+	if err := json.Unmarshal(req.Params, &p); err != nil {
+		s.respondError(req, codeInvalidParams, err.Error())
+		return
+	}
+	s.mu.Lock()
+	doc := s.docs[p.TextDocument.URI]
+	s.mu.Unlock()
+	if doc == nil {
+		s.respond(req, SemanticTokens{Data: []int{}})
+		return
+	}
+
+	toks := doc.analysis.semanticTokens(doc.content)
+	sort.Slice(toks, func(i, j int) bool {
+		a, b := toks[i].rng.Start, toks[j].rng.Start
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		return a.Character < b.Character
+	})
+
+	data := make([]int, 0, len(toks)*5)
+	prevLine, prevChar := 0, 0
+	for _, t := range toks {
+		line, char := t.rng.Start.Line, t.rng.Start.Character
+		length := t.rng.End.Character - t.rng.Start.Character
+		if length <= 0 {
+			continue
+		}
+		deltaChar := char
+		if line == prevLine {
+			deltaChar = char - prevChar
+		}
+		data = append(data, line-prevLine, deltaChar, length, t.typ, t.mods)
+		prevLine, prevChar = line, char
+	}
+	s.respond(req, SemanticTokens{Data: data})
 }
 
 // handleReferences answers textDocument/references (Shift-F12): every


### PR DESCRIPTION
> **Stacked on #81 (scope-aware).** Base is `feat/lsp-scope-aware`; merge #81 first and GitHub will retarget this to `develop`. The diff here is only the semantic-tokens commit.

## What

Semantic highlighting for the LSP: `textDocument/semanticTokens/full`, on top of the existing TextMate grammar. The last remaining LSP roadmap item.

## How

`analysis.semanticTokens` walks the parsed AST and classifies every symbol:

- special forms (`def`, `let`, `if`, `fn`, `try`, …) → **keyword**
- `def` / `defn` / `defmacro` names → **variable** / **function** / **macro** (declaration)
- `fn`/`defn`/`let`/`loop`/`catch` bindings and their local uses → **parameter**
- qualified `ns/name` references → **namespace**
- call heads → **function**, or **macro** when the head is a document-local `defmacro`

Quoted data is not descended into. `handleSemanticTokens` delta-encodes the tokens per the LSP wire format (five ints per token, relative to the previous).

All types are standard LSP semantic token types, so editor themes colour them automatically — **no extension change** (vscode-languageclient negotiates it from the advertised legend).

## Tests / verification

- Classification unit tests (keyword / function-decl / parameter / builtin-call-head; def vs defmacro; macro call head), plus a wire-format smoke test (non-empty, multiple of five).
- `go test ./...` and `go vet ./lsp` green.

## After this

With semantic tokens done, the only ROADMAP item left is **multi-thread futures** (DAP) — which you asked to leave out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
