### PR TITLE
fix(vscode-lisp): colour keyword literals in syntax highlighting

### DIFF
--- a/tools/vscode-lisp/syntaxes/lisp.tmLanguage.json
+++ b/tools/vscode-lisp/syntaxes/lisp.tmLanguage.json
@@ -60,8 +60,9 @@
       "match": "(?<![\\w-])-?\\d+(\\.\\d+)?(?![\\w-])"
     },
     "keyword": {
-      "name": "constant.other.keyword.lisp",
-      "match": ":[\\w\\-?!*+<>=/]+"
+      "comment": "`:keyword` literals. Scope base is `support.type` because the generic `constant.other.*` family is left uncoloured by the default Dark+/Light+ themes, whereas `support.type` gives the distinct teal most themes use for Clojure-style keywords.",
+      "name": "support.type.keyword.lisp",
+      "match": "::?[\\w.\\-?!*+<>=/]+"
     },
     "special-form": {
       "name": "keyword.control.lisp",


### PR DESCRIPTION
## Problem

`:keyword` literals rendered almost entirely white in the editor, sometimes appearing to inherit the previous token's colour.

## Cause

The keyword rule used the scope `constant.other.keyword.lisp`. The default Dark+/Light+ themes leave the generic `constant.other.*` family uncoloured (only specific children like `constant.other.color.rgb-value` are styled), so keywords fell back to the default editor foreground.

## Fix

- Change the scope base to `support.type`, which themes render as the distinct teal commonly used for Clojure-style keywords — and which stays visually distinct from `nil`/`true`/`false` (`constant.language`).
- Extend the match pattern to also cover `::keyword` and dotted namespaced keywords (e.g. `:my.ns/key`).

The generic `$NAME` placeholder rules share the same `constant.other.*` theming gap but are left unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)