### PR TITLE
fix(lsp): stop reader-macro sigils mis-colouring the preceding token

### DIFF
--- a/lsp/analyse.go
+++ b/lsp/analyse.go
@@ -425,7 +425,7 @@ type semTok struct {
 // function/macro. It walks the parsed AST; quoted data is not descended
 // into. Tokens are returned in document order.
 func (a *analysis) semanticTokens(content string) []semTok {
-	b := &semBuilder{a: a, docScope: wholeContentRange(content)}
+	b := &semBuilder{a: a, docScope: wholeContentRange(content), lines: strings.Split(content, "\n")}
 	for _, f := range a.forms {
 		b.walk(f)
 	}
@@ -435,6 +435,7 @@ func (a *analysis) semanticTokens(content string) []semTok {
 type semBuilder struct {
 	a        *analysis
 	docScope Range
+	lines    []string
 	toks     []semTok
 }
 
@@ -442,7 +443,31 @@ func (b *semBuilder) emit(sym types.Symbol, typ, mods int) {
 	if sym.Cursor == nil {
 		return
 	}
-	b.toks = append(b.toks, semTok{rng: symbolRange(sym.Cursor, sym.Val), typ: typ, mods: mods})
+	rng := symbolRange(sym.Cursor, sym.Val)
+	// Reader macros ('x, `x, ~x, ~@x) synthesise head symbols whose Val
+	// ("quote", "unquote", …) is longer than their one-character source
+	// sigil, so symbolRange back-computes a range that is both mis-sized and
+	// shifted onto the preceding tokens. Emit only when the document text at
+	// the range actually spells the symbol; this also guards any other
+	// position/length mismatch (e.g. read-time $NAME placeholders).
+	if b.textAt(rng) != sym.Val {
+		return
+	}
+	b.toks = append(b.toks, semTok{rng: rng, typ: typ, mods: mods})
+}
+
+// textAt returns the document text covered by rng, or "" when rng is empty,
+// spans lines, or falls outside the document.
+func (b *semBuilder) textAt(rng Range) string {
+	if rng.Start.Line != rng.End.Line || rng.Start.Line < 0 || rng.Start.Line >= len(b.lines) {
+		return ""
+	}
+	line := b.lines[rng.Start.Line]
+	s, e := rng.Start.Character, rng.End.Character
+	if s < 0 || e > len(line) || s >= e {
+		return ""
+	}
+	return line[s:e]
 }
 
 // binding emits every symbol in a binding form as a parameter declaration.

--- a/lsp/semantictokens_test.go
+++ b/lsp/semantictokens_test.go
@@ -94,3 +94,30 @@ func TestSemanticTokens_WireFormat(t *testing.T) {
 		t.Fatalf("expected a non-empty multiple-of-5 token array, got %d ints", len(data))
 	}
 }
+
+// TestSemanticTokens_ReaderMacroNoGhostToken guards against reader macros
+// ('x, `x, ~x) leaking a mis-placed "quote"/"unquote" keyword token onto the
+// preceding text: the synthesised head symbol's Val is longer than its
+// one-character sigil, so its range would slide backwards. An explicit
+// (quote …) must still be classified. See the emit text guard in analyse.go.
+func TestSemanticTokens_ReaderMacroNoGhostToken(t *testing.T) {
+	// The ' sigil in `{:op '()}` must not colour the :op key.
+	a := analyseDocument("t.lisp", "[{:op '()}]\n")
+	for _, s := range a.semanticTokens("[{:op '()}]\n") {
+		t.Errorf("unexpected token at char %d..%d (type %d) for reader-macro quote",
+			s.rng.Start.Character, s.rng.End.Character, s.typ)
+	}
+
+	// An explicit (quote …) still yields a keyword token over "quote".
+	src := "(quote (a b))\n"
+	a = analyseDocument("t.lisp", src)
+	var gotKeyword bool
+	for _, s := range a.semanticTokens(src) {
+		if s.typ == tokKeyword && s.rng.Start.Character == 1 && s.rng.End.Character == 6 {
+			gotKeyword = true
+		}
+	}
+	if !gotKeyword {
+		t.Errorf("explicit (quote …) should emit a keyword token over chars 1..6")
+	}
+}


### PR DESCRIPTION
## Symptom

In forms like `[{:op '()}]`, the `:op` keyword rendered in the wrong colour (a semantic `keyword` colour instead of the grammar's green), while keywords elsewhere were fine.

## Cause

The `'` reader macro in `'()` expands to `(quote …)`. The synthesised `quote` head symbol carries the `Cursor` of the one-character `'` sigil but has `Val = "quote"` (5 chars). `symbolRange` recovers a token's start by subtracting `len(Val)` from the position just past the token, so the 5-char range slid **backwards** onto the preceding text (`:op '`) and emitted a stray `keyword` semantic token there — which overrides the TextMate grammar. It affected every sigil (`'` `` ` `` `~` `~@`) and was most visible when a keyword sat immediately before, as in `{:op`.

## Fix

Guard `semBuilder.emit`: emit a semantic token only when the document text at the computed range actually spells the symbol. This drops the reader-macro sigil heads (whose range never matches their `Val`) while still classifying an explicit `(quote …)`, and also guards other position/length mismatches (e.g. read-time `$NAME` placeholders).

Regression test added in `semantictokens_test.go`.

## Verification

`gofmt -l .` clean, `go vet ./...` and `go vet -tags lispdebug ./...` clean, `go test ./...` and `go test -tags lispdebug ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)