### PR TITLE
feat(reader): Clojure-style multi-line "…" strings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
-	github.com/jig/scanner v1.2.0
+	github.com/jig/scanner v1.3.0
 	modernc.org/sqlite v1.53.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jig/scanner v1.2.0 h1:j0b5qyF0M8iATyoj40JTXnCEsR48LpOJMGK0PM8j1N0=
 github.com/jig/scanner v1.2.0/go.mod h1:kzPu5snQZK1ukNRKBjJ3QA6dqIkXhrCJ8HhA+oJbExQ=
+github.com/jig/scanner v1.3.0 h1:AMX0E0Paw2sBxg1oECQId4GD8XpvTL7zMAsNfsq3U5A=
+github.com/jig/scanner v1.3.0/go.mod h1:zPzoEI9oDuBHDdDgNk5OVK6U82jghZCBaKmHtHPXBKo=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jig/lisp/lib/call"
 	"github.com/jig/lisp/lib/core/nscore"
 	"github.com/jig/lisp/lisperror"
+	"github.com/jig/lisp/printer"
 	"github.com/jig/lisp/reader"
 	"github.com/jig/lisp/types"
 )
@@ -122,6 +123,35 @@ func TestAdHocReaders(t *testing.T) {
 			t.Fatal()
 		default:
 			t.Fatal()
+		}
+	})
+}
+
+// TestMultilineString checks that a "…" literal may span physical lines
+// (Clojure-style): the literal newline is kept verbatim in the string value,
+// and an unterminated literal still errors at EOF.
+func TestMultilineString(t *testing.T) {
+	t.Run("literal newline is kept", func(t *testing.T) {
+		ast, err := reader.Read_str("\"line1\nline2\"", types.NewCursorFile(t.Name()), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s, ok := ast.(string); !ok || s != "line1\nline2" {
+			t.Fatalf("got %#v, want %q", ast, "line1\nline2")
+		}
+	})
+	t.Run("printed back as a single escaped line", func(t *testing.T) {
+		ast, err := reader.Read_str("\"a\nb\"", types.NewCursorFile(t.Name()), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := printer.Pr_str(ast, true); got != `"a\nb"` {
+			t.Fatalf("Pr_str = %s, want %q", got, `"a\nb"`)
+		}
+	})
+	t.Run("unterminated still errors", func(t *testing.T) {
+		if _, err := reader.Read_str("\"abc\n", types.NewCursorFile(t.Name()), nil); err == nil {
+			t.Fatal("expected an error for an unterminated string")
 		}
 	})
 }

--- a/tests/step6_file.mal
+++ b/tests/step6_file.mal
@@ -15,10 +15,10 @@
 (read-string "(+ 2 3)")
 ;=>(+ 2 3)
 
-;; TODO(jig): remove this test
-;; This is an invalid test
-;; (read-string "\"\n\"")
-;; ;=>"\n"
+;; A "…" string may contain a literal newline (Clojure-style), so read-string
+;; parses a source string whose only content is a newline.
+(read-string "\"\n\"")
+;=>"\n"
 
 (read-string "7 ;; comment")
 ;=>7


### PR DESCRIPTION
Lets a double-quoted `"…"` string span several physical lines, with the literal newline kept verbatim in the value — as in Clojure. Multi-line `"…"` strings are a frequent source of confusion for LLM-written code, which assumes Clojure semantics.

## Change

- Bumps `github.com/jig/scanner` to **v1.3.0** ([jig/scanner@821fdea](https://github.com/jig/scanner/commit/821fdea)), which drops the `\n`-terminates-a-string rule in `scanString`. Only real EOF now leaves a `"…"` literal unterminated.
- The reader needed **no change**: it unescapes `\\`, `\"`, `\n` by hand (no `strconv.Unquote`) and already preserves a literal newline in the value.
- Re-enables the previously-commented `step6_file.mal` `read-string` test (it was only invalid because of the old scanner restriction).
- Adds `reader.TestMultilineString`: literal newline kept, single-line escaped round-trip through the printer, and an unterminated string still errors.

## Unaffected (verified)

- **Printer**: `pr-str` still escapes `\n` on output, so runtime values print on a single canonical line; `¬…¬` is still used for JSON-shaped strings.
- **Formatter**: its own lexer already accepted multi-line strings and emits them verbatim, so a hand-written multi-line string keeps its layout on format.
- `¬…¬` raw strings remain the tool for JSON and other escape-heavy content.

## Trade-off

A forgotten closing quote now consumes text up to the next `"` or EOF, so the error is reported further from the mistake — the same behaviour as Clojure.

## Verification

`gofmt -l .` clean, `go vet ./...` and `-tags lispdebug` clean, `go test ./...` and `-tags lispdebug` all green (against the published scanner v1.3.0, no local replace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)