### PR TITLE
feat(eval): recur in function tail position (Clojure fn-recur)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,15 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
 
 - `loop`/`recur` special forms; `into`, and `conj` accepting `[k v]`
   pairs / maps
+- `recur` in a function's tail position (Clojure semantics): the
+  function is a recursion point — `recur` rebinds its parameters and
+  restarts the body in constant stack, on both direct calls and the
+  `apply`/`map`/`swap!` paths. Previously it leaked the internal
+  `«recur»` sentinel as a value
+- multi-line `"…"` strings (Clojure-style): a literal newline is kept
+  verbatim; `¬…¬` remains for JSON and other escape-heavy content
+- fixed: the result of a `catch` body was evaluated twice, re-raising
+  `throw` forms carried as data (issue #87)
 - `require` with `:as` / `:refer` / `:refer :all`, a module search path
   and `LISPPATH`
 - `cli` library — command-line option parsing modelled on

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -158,7 +158,7 @@ Handled directly by the evaluator (they control when their arguments are evaluat
 | `catch` | `[binding & body]` | Inside try: binds the caught error and evaluates body. |
 | `finally` | `[& body]` | Inside try: body is always evaluated for side effects, error or not. |
 | `loop` | `[bindings & body]` | Like let, but a recursion point: recur in tail position rebinds the bindings and jumps back, in constant stack. |
-| `recur` | `[& args]` | In tail position, rebinds the nearest loop's bindings to args and iterates. |
+| `recur` | `[& args]` | In tail position, rebinds the nearest recursion point — the enclosing loop's bindings, or the enclosing function's parameters — to args and iterates. |
 | `context` | `[& body]` | Provides a Go context to the enclosed forms. |
 
 ### core

--- a/docmeta/docmeta.go
+++ b/docmeta/docmeta.go
@@ -45,5 +45,5 @@ var SpecialForms = map[string]Entry{
 	"finally":     {"[& body]", "special-forms", "Inside try: body is always evaluated for side effects, error or not."},
 	"context":     {"[& body]", "special-forms", "Provides a Go context to the enclosed forms."},
 	"loop":        {"[bindings & body]", "special-forms", "Like let, but a recursion point: recur in tail position rebinds the bindings and jumps back, in constant stack."},
-	"recur":       {"[& args]", "special-forms", "In tail position, rebinds the nearest loop's bindings to args and iterates."},
+	"recur":       {"[& args]", "special-forms", "In tail position, rebinds the nearest recursion point — the enclosing loop's bindings, or the enclosing function's parameters — to args and iterates."},
 }

--- a/mal.go
+++ b/mal.go
@@ -427,9 +427,12 @@ func do(ctx context.Context, ast MalType, from, to int, env EnvType) (MalType, e
 }
 
 // recurValue is the sentinel `recur` produces: the evaluated rebind values,
-// caught by the nearest enclosing `loop`. Using a distinct value (rather than
-// an error) means a `recur` left in non-tail position reaches a real consumer
-// (e.g. arithmetic) and fails there, instead of silently jumping.
+// caught by the nearest enclosing recursion point — a `loop`, or the function
+// whose body is being evaluated (which consumes it inside the trampoline or,
+// on the Go application path, in the MalFunc Eval closure). Using a distinct
+// value (rather than an error) means a `recur` left in non-tail position
+// reaches a real consumer (e.g. arithmetic) and fails there, instead of
+// silently jumping.
 type recurValue struct {
 	args []MalType
 }
@@ -446,12 +449,13 @@ func EVAL(ctx context.Context, ast MalType, env EnvType) (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
-	// A recurValue reaching here means no enclosing `loop` consumed it:
-	// `recur` was used outside any loop (top level, or a bare function
-	// body). Surface it as an error rather than leaking the internal
-	// sentinel — which otherwise prints as «recur» with a zero exit.
+	// A recurValue reaching here means no recursion point consumed it:
+	// `recur` was used outside any loop or function body (top level, or
+	// smuggled through a non-tail position). Surface it as an error rather
+	// than leaking the internal sentinel — which otherwise prints as
+	// «recur» with a zero exit.
 	if _, ok := res.(recurValue); ok {
-		return nil, lisperror.NewLispError(errors.New("recur used outside of a loop"), ast)
+		return nil, lisperror.NewLispError(errors.New("recur used outside of a loop or function"), ast)
 	}
 	return res, nil
 }
@@ -508,6 +512,15 @@ func evalInternal(ctx context.Context, ast MalType, env EnvType) (res MalType, e
 			}
 		}
 	}()
+
+	// Current function recursion point (Clojure fn-recur). Set when a
+	// MalFunc is applied in this trampoline: every tail form after that
+	// belongs to its body, so a tail `recur` rebinds recurParams over
+	// recurEnv and restarts recurExp, in constant stack. Loop bodies are
+	// evaluated in nested calls where these stay nil, so a `recur` that
+	// belongs to a `loop` still reaches it as the sentinel value.
+	var recurExp, recurParams MalType
+	var recurEnv EnvType
 
 	for {
 		if ctx != nil {
@@ -668,6 +681,18 @@ func evalInternal(ctx context.Context, ast MalType, env EnvType) (res MalType, e
 				}
 				vals[i] = v
 			}
+			// Inside a function body the function itself is the nearest
+			// recursion point: rebind its parameters and restart the body.
+			// (Same routing as the try-tail sentinel below.)
+			if recurExp != nil {
+				new_env, e := NewSubordinateEnvWithBinds(recurEnv, recurParams, List{Val: vals, Cursor: ast.(List).Cursor})
+				if e != nil {
+					return nil, lisperror.NewLispError(fmt.Errorf("recur: %s", e), ast)
+				}
+				ast = recurExp
+				env = new_env
+				continue
+			}
 			return recurValue{args: vals}, nil
 		case "quote": // '
 			return a1, nil
@@ -763,6 +788,19 @@ func evalInternal(ctx context.Context, ast MalType, env EnvType) (res MalType, e
 			defer func() { _, _ = do(ctx, finallyDo, 0, 0, env) }()
 
 			if e == nil {
+				// The try body is evaluated in a nested call, so a `recur` in
+				// its tail position surfaces here as the sentinel. Rebind the
+				// enclosing function's recursion point (as in case "recur");
+				// with no function active, return it for an enclosing loop.
+				if rv, ok := exp.(recurValue); ok && recurExp != nil {
+					new_env, err := NewSubordinateEnvWithBinds(recurEnv, recurParams, List{Val: rv.args, Cursor: ast.(List).Cursor})
+					if err != nil {
+						return nil, lisperror.NewLispError(fmt.Errorf("recur: %s", err), ast)
+					}
+					ast = recurExp
+					env = new_env
+					continue
+				}
 				return exp, nil
 			} else {
 				if catchDo != nil {
@@ -820,7 +858,6 @@ func evalInternal(ctx context.Context, ast MalType, env EnvType) (res MalType, e
 				body = l[2:]
 			}
 			fn := MalFunc{
-				Eval:    EVAL,
 				Exp:     List{Val: append([]MalType{Symbol{Val: "do"}}, body...), Cursor: ast.(List).Cursor},
 				Env:     env,
 				Params:  a1,
@@ -828,6 +865,27 @@ func evalInternal(ctx context.Context, ast MalType, env EnvType) (res MalType, e
 				GenEnv:  NewSubordinateEnvWithBinds,
 				Meta:    nil,
 				Cursor:  ast.(List).Cursor,
+			}
+			// Go-side application (types.Apply: apply, map, swap!, …) goes
+			// through Eval, which is the function's recursion point there: a
+			// tail `recur` escaping the body as the sentinel rebinds the
+			// parameters and restarts, exactly as a direct lisp call does in
+			// the trampoline.
+			fn.Eval = func(ctx context.Context, exp MalType, fenv EnvType) (MalType, error) {
+				for {
+					res, err := evalInternal(ctx, exp, fenv)
+					if err != nil {
+						return nil, err
+					}
+					rv, ok := res.(recurValue)
+					if !ok {
+						return res, nil
+					}
+					fenv, err = NewSubordinateEnvWithBinds(fn.Env, fn.Params, List{Val: rv.args})
+					if err != nil {
+						return nil, lisperror.NewLispError(fmt.Errorf("recur: %s", err), exp)
+					}
+				}
 			}
 			return fn, nil
 		default:
@@ -851,6 +909,10 @@ func evalInternal(ctx context.Context, ast MalType, env EnvType) (res MalType, e
 						return nil, lisperror.NewLispError(e, ast)
 					}
 				}
+				// The applied function is now the recursion point for any
+				// tail `recur` reached through this trampoline; a tail call
+				// to another function moves the point to that function.
+				recurExp, recurParams, recurEnv = fn.Exp, fn.Params, fn.Env
 			} else {
 				fn, ok := f.(Func)
 				if !ok {

--- a/tests/stepO_loop_recur.mal
+++ b/tests/stepO_loop_recur.mal
@@ -73,6 +73,59 @@ shadowed
 ;=>nil
 
 ;;
+;; Testing recur in function tail position (the function is the recursion point)
+
+(defn count-up [x] (if (> x 3) x (recur (inc x))))
+(count-up 0)
+;=>4
+(count-up 10)
+;=>10
+
+;; anonymous function
+((fn [i acc] (if (= i 0) acc (recur (- i 1) (+ acc i)))) 5 0)
+;=>15
+
+;; fn recur is TCO: deep self-recursion runs in constant stack
+(defn spin [i] (if (< i 100000) (recur (inc i)) i))
+(spin 0)
+;=>100000
+
+;; recur binds to the nearest recursion point: a loop inside a fn wins
+(defn sum-below [n] (loop [i 0 acc 0] (if (< i n) (recur (inc i) (+ acc i)) acc)))
+(sum-below 4)
+;=>6
+
+;; a function called from a loop body recurs to itself, not the caller's loop
+(loop [i 0] (if (< i 2) (recur (inc i)) (count-up 0)))
+;=>4
+
+;; a tail call moves the recursion point to the called function
+(defn pong [x] (if (> x 2) :pong-done (recur (+ x 1))))
+(defn ping [x] (pong x))
+(ping 0)
+;=>:pong-done
+
+;; fn recur through the Go application path: apply, map and swap!
+(apply count-up [0])
+;=>4
+(map count-up [0 10])
+;=>(4 10)
+(def counter (atom 0))
+(swap! counter (fn [v] (if (< v 5) (recur (inc v)) v)))
+;=>5
+
+;; recur from the try body's tail position restarts the function
+(defn retry [x] (try (if (< x 3) (recur (inc x)) x) (catch e :nope)))
+(retry 0)
+;=>3
+
+;; recur arity must match the function parameters
+(defn bad-arity [x] (if false x (recur 1 2)))
+(bad-arity 0)
+;/.*recur: too many arguments passed.*
+;=>nil
+
+;;
 ;; Testing loop/recur with try/catch
 
 ;; recur in catch tail position jumps back to the enclosing loop


### PR DESCRIPTION
Implements **fn-recur**: a function is a recursion point, so `recur` in its body's tail position rebinds the parameters and restarts the body in constant stack — Clojure semantics.

## Before

`recur` only worked inside `loop`. In a function without one, a tail `recur` **leaked the internal `«recur»` sentinel to the caller as a value** (the `EVAL` boundary only caught it at top level):

```lisp
(defn f [x] (if (> x 3) x (recur (inc x))))
(f 0)   ;; => «recur»   (!)
```

## After

```lisp
(f 0)         ;; => 4
(apply f [0]) ;; => 4, same on map / swap! / any Go-side application
```

## Design

- The trampoline tracks the applied `MalFunc` as the **current recursion point**; a tail call to another function moves the point to the callee. `case "recur"` rebinds the parameters and continues when a point is active, and still returns the sentinel otherwise.
- **`loop` keeps winning as the nearest recursion point**: loop bodies evaluate in nested `evalInternal` calls where no function point is active, so their `recur` reaches the loop exactly as before. No behavioural change for existing loop code.
- The `try` success path routes a sentinel escaping the (nested) try body the same way, so `recur` from a try tail restarts the function.
- The Go application path (`types.Apply`: `apply`, `map`, `swap!`, …) goes through the `MalFunc` `Eval` closure, which consumes the sentinel by rebinding — both call paths agree.
- Arity is enforced by the binder (`recur: too many/too few arguments passed`, with `&` varargs handled). A `recur` escaping every recursion point now errors with "recur used outside of a loop **or function**".

## Tests

`stepO_loop_recur.mal` gains a fn-recur section: named and anonymous functions, 100k-deep constant-stack self-recursion, nearest-point precedence (loop inside fn, fn called from a loop body, tail-call handover), the `apply`/`map`/`swap!` paths, `recur` from a try tail, and the arity-mismatch error. Docs (`docmeta`, regenerated `LANGUAGE.md`) and `CHANGELOG.md` updated.

## Verification

`gofmt` clean; `go vet` (plain + `lispdebug`) clean; `go test ./...` (plain + `lispdebug`) green; `-race` on root and concurrent packages green; mal suite stable across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)