### PR TITLE
feat(core): Clojure-style variadic arithmetic over ints, floats and big ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,15 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   `«recur»` sentinel as a value
 - multi-line `"…"` strings (Clojure-style): a literal newline is kept
   verbatim; `¬…¬` remains for JSON and other escape-heavy content
+- Clojure-style arithmetic: `+ - * /` are variadic — `(+)`→0, `(*)`→1,
+  `(+ x)`→x, `(- x)`→negation, `(/ x)`→1/x, `(- a b c)` folds left —
+  and the ordering builtins `< <= > >=` chain (`(< 1 2 3)`). The
+  numeric tower now spans machine ints, floats and big ints with
+  Clojure-style contagion (int→float, int→big); big ints and floats do
+  not mix. Floats previously had **no** arithmetic at all. Division by
+  zero on ints/bigs is a catchable `"division by zero"` error (was a
+  wrapped Go runtime panic); non-numbers report
+  `"not a number (was of type T)"`
 - `time-format` / `time-parse` — RFC 3339 UTC timestamps to and from
   the epoch milliseconds of `time-ms`
 - printer: dedicated renderings for Go values — `time.Time` and

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -170,12 +170,12 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `*` | `[& numbers]` | Product of its arguments (1 with none). |
 | `+` | `[& numbers]` | Sum of its arguments (0 with none). |
 | `-` | `[x & more]` | Subtracts the remaining arguments from x; negates x when alone. |
-| `/` | `[x & more]` | Divides x by the remaining arguments. |
-| `<` | `[a b]` | Less-than. |
-| `<=` | `[a b]` | Less-than-or-equal. |
+| `/` | `[x & more]` | Divides x by the remaining arguments; (/ x) is the inverse 1/x. |
+| `<` | `[x & more]` | True when the arguments are monotonically increasing. |
+| `<=` | `[x & more]` | True when the arguments are monotonically non-decreasing. |
 | `=` | `[a b]` | Value equality. |
-| `>` | `[a b]` | Greater-than. |
-| `>=` | `[a b]` | Greater-than-or-equal. |
+| `>` | `[x & more]` | True when the arguments are monotonically decreasing. |
+| `>=` | `[x & more]` | True when the arguments are monotonically non-increasing. |
 | `apply` | `[f & args]` | Calls f with args, the last of which is a sequence spread as arguments. |
 | `assert` | `[expr & error]` | Returns nil when expr is truthy, otherwise raises error (or a default). |
 | `assoc` | `[map key val & kvs]` | Copy of map with the given key/value pairs added or replaced. |

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -47,14 +48,14 @@ func Load(env EnvType) {
 	call.Call(env, assoc_in)
 	call.Call(env, update)
 	call.Call(env, update_in)
-	call.CallOverrideFN(env, "<", func(a, b int) (bool, error) { return a < b, nil })
-	call.CallOverrideFN(env, "<=", func(a, b int) (bool, error) { return a <= b, nil })
-	call.CallOverrideFN(env, ">", func(a, b int) (bool, error) { return a > b, nil })
-	call.CallOverrideFN(env, ">=", func(a, b int) (bool, error) { return a >= b, nil })
-	call.CallOverrideFN(env, "+", func(a, b int) (int, error) { return a + b, nil })
-	call.CallOverrideFN(env, "-", func(a, b int) (int, error) { return a - b, nil })
-	call.CallOverrideFN(env, "*", func(a, b int) (int, error) { return a * b, nil })
-	call.CallOverrideFN(env, "/", func(a, b int) (int, error) { return a / b, nil })
+	call.CallOverrideFN(env, "<", ltN, 1)
+	call.CallOverrideFN(env, "<=", leN, 1)
+	call.CallOverrideFN(env, ">", gtN, 1)
+	call.CallOverrideFN(env, ">=", geN, 1)
+	call.CallOverrideFN(env, "+", addN)
+	call.CallOverrideFN(env, "-", subN, 1)
+	call.CallOverrideFN(env, "*", mulN)
+	call.CallOverrideFN(env, "/", divN, 1)
 	call.CallOverrideFN(env, "=", func(a, b MalType) (MalType, error) { return Equal_Q(a, b), nil })
 	call.CallOverrideFN(env, "not=", func(a, b MalType) (MalType, error) { return !Equal_Q(a, b), nil })
 	call.Call(env, get)
@@ -539,6 +540,234 @@ func time_ms() (int, error) {
 func time_ns() (int, error) {
 	return int(time.Now().UnixNano()), nil
 }
+
+// Numeric tower for the arithmetic and ordering builtins: machine ints,
+// floats and *big.Int, folded variadically with Clojure-style contagion —
+// int∘int stays int, a float makes the result float, a big int makes it
+// big. Big ints and floats do not mix (no unambiguous conversion). The
+// lisp float type is float32 (as read); folds run in float64 and convert
+// back on return.
+
+type number struct {
+	f     float64
+	b     *big.Int
+	isBig bool
+	isFlt bool
+	i     int
+}
+
+func toNumber(v MalType) (number, error) {
+	switch v := v.(type) {
+	case int:
+		return number{i: v}, nil
+	case float32:
+		return number{f: float64(v), isFlt: true}, nil
+	case float64:
+		return number{f: v, isFlt: true}, nil
+	case *big.Int:
+		return number{b: v, isBig: true}, nil
+	default:
+		return number{}, fmt.Errorf("not a number (was of type %T)", v)
+	}
+}
+
+func (n number) toMal() MalType {
+	switch {
+	case n.isBig:
+		return n.b
+	case n.isFlt:
+		return float32(n.f)
+	default:
+		return n.i
+	}
+}
+
+// promote lifts a pair of numbers to their common kind.
+func promote(a, b number) (number, number, error) {
+	if a.isBig || b.isBig {
+		if a.isFlt || b.isFlt {
+			return a, b, errors.New("cannot mix a big int and a float")
+		}
+		if !a.isBig {
+			a = number{b: big.NewInt(int64(a.i)), isBig: true}
+		}
+		if !b.isBig {
+			b = number{b: big.NewInt(int64(b.i)), isBig: true}
+		}
+		return a, b, nil
+	}
+	if a.isFlt || b.isFlt {
+		if !a.isFlt {
+			a = number{f: float64(a.i), isFlt: true}
+		}
+		if !b.isFlt {
+			b = number{f: float64(b.i), isFlt: true}
+		}
+		return a, b, nil
+	}
+	return a, b, nil
+}
+
+type numOp struct {
+	onInt   func(a, b int) (int, error)
+	onFloat func(a, b float64) (float64, error)
+	onBig   func(a, b *big.Int) (*big.Int, error)
+}
+
+func (op numOp) apply(a, b number) (number, error) {
+	a, b, err := promote(a, b)
+	if err != nil {
+		return number{}, err
+	}
+	switch {
+	case a.isBig:
+		r, err := op.onBig(a.b, b.b)
+		return number{b: r, isBig: true}, err
+	case a.isFlt:
+		r, err := op.onFloat(a.f, b.f)
+		return number{f: r, isFlt: true}, err
+	default:
+		r, err := op.onInt(a.i, b.i)
+		return number{i: r}, err
+	}
+}
+
+// fold reduces args with op starting from identity; with a single
+// argument and unary set, it applies op to (unary, arg) instead — the
+// Clojure shapes (- x) → negation and (/ x) → inverse.
+func numFold(op numOp, identity number, unary *number, args []MalType) (MalType, error) {
+	acc := identity
+	if len(args) == 1 && unary != nil {
+		n, err := toNumber(args[0])
+		if err != nil {
+			return nil, err
+		}
+		r, err := op.apply(*unary, n)
+		if err != nil {
+			return nil, err
+		}
+		return r.toMal(), nil
+	}
+	for i, arg := range args {
+		n, err := toNumber(arg)
+		if err != nil {
+			return nil, err
+		}
+		if i == 0 && unary != nil {
+			acc = n // subtraction/division fold from the first argument
+			continue
+		}
+		acc, err = op.apply(acc, n)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return acc.toMal(), nil
+}
+
+var (
+	addOp = numOp{
+		onInt:   func(a, b int) (int, error) { return a + b, nil },
+		onFloat: func(a, b float64) (float64, error) { return a + b, nil },
+		onBig:   func(a, b *big.Int) (*big.Int, error) { return new(big.Int).Add(a, b), nil },
+	}
+	subOp = numOp{
+		onInt:   func(a, b int) (int, error) { return a - b, nil },
+		onFloat: func(a, b float64) (float64, error) { return a - b, nil },
+		onBig:   func(a, b *big.Int) (*big.Int, error) { return new(big.Int).Sub(a, b), nil },
+	}
+	mulOp = numOp{
+		onInt:   func(a, b int) (int, error) { return a * b, nil },
+		onFloat: func(a, b float64) (float64, error) { return a * b, nil },
+		onBig:   func(a, b *big.Int) (*big.Int, error) { return new(big.Int).Mul(a, b), nil },
+	}
+	divOp = numOp{
+		onInt: func(a, b int) (int, error) {
+			if b == 0 {
+				return 0, errors.New("division by zero")
+			}
+			return a / b, nil
+		},
+		// float division by zero yields ±Inf, as in Go and Clojure
+		onFloat: func(a, b float64) (float64, error) { return a / b, nil },
+		onBig: func(a, b *big.Int) (*big.Int, error) {
+			if b.Sign() == 0 {
+				return nil, errors.New("division by zero")
+			}
+			return new(big.Int).Quo(a, b), nil
+		},
+	}
+)
+
+func addN(xs ...MalType) (MalType, error) { return numFold(addOp, number{i: 0}, nil, xs) }
+func mulN(xs ...MalType) (MalType, error) { return numFold(mulOp, number{i: 1}, nil, xs) }
+func subN(xs ...MalType) (MalType, error) {
+	zero := number{i: 0}
+	return numFold(subOp, number{}, &zero, xs)
+}
+func divN(xs ...MalType) (MalType, error) {
+	one := number{i: 1}
+	return numFold(divOp, number{}, &one, xs)
+}
+
+// numCmp orders two numbers after promotion (big∘float does not mix).
+func numCmp(a, b number) (int, error) {
+	a, b, err := promote(a, b)
+	if err != nil {
+		return 0, err
+	}
+	switch {
+	case a.isBig:
+		return a.b.Cmp(b.b), nil
+	case a.isFlt:
+		switch {
+		case a.f < b.f:
+			return -1, nil
+		case a.f > b.f:
+			return 1, nil
+		default:
+			return 0, nil
+		}
+	default:
+		switch {
+		case a.i < b.i:
+			return -1, nil
+		case a.i > b.i:
+			return 1, nil
+		default:
+			return 0, nil
+		}
+	}
+}
+
+// chainCmp implements the variadic ordering builtins: true when every
+// adjacent pair satisfies ok, as in Clojure ((< 1 2 3), (< x) → true).
+func chainCmp(ok func(int) bool, xs []MalType) (MalType, error) {
+	prev, err := toNumber(xs[0])
+	if err != nil {
+		return nil, err
+	}
+	for _, x := range xs[1:] {
+		n, err := toNumber(x)
+		if err != nil {
+			return nil, err
+		}
+		c, err := numCmp(prev, n)
+		if err != nil {
+			return nil, err
+		}
+		if !ok(c) {
+			return false, nil
+		}
+		prev = n
+	}
+	return true, nil
+}
+
+func ltN(xs ...MalType) (MalType, error) { return chainCmp(func(c int) bool { return c < 0 }, xs) }
+func leN(xs ...MalType) (MalType, error) { return chainCmp(func(c int) bool { return c <= 0 }, xs) }
+func gtN(xs ...MalType) (MalType, error) { return chainCmp(func(c int) bool { return c > 0 }, xs) }
+func geN(xs ...MalType) (MalType, error) { return chainCmp(func(c int) bool { return c >= 0 }, xs) }
 
 // rfc3339Milli is time.RFC3339 with fixed millisecond precision, matching
 // the resolution of time-ms (a variable-width fraction would not sort

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -37,15 +37,15 @@ var coreDocs = []struct{ name, arglist, doc string }{
 	{"+", "[& numbers]", "Sum of its arguments (0 with none)."},
 	{"-", "[x & more]", "Subtracts the remaining arguments from x; negates x when alone."},
 	{"*", "[& numbers]", "Product of its arguments (1 with none)."},
-	{"/", "[x & more]", "Divides x by the remaining arguments."},
+	{"/", "[x & more]", "Divides x by the remaining arguments; (/ x) is the inverse 1/x."},
 
 	// Comparison
 	{"=", "[a b]", "Value equality."},
 	{"not=", "[a b]", "Logical negation of =."},
-	{"<", "[a b]", "Less-than."},
-	{"<=", "[a b]", "Less-than-or-equal."},
-	{">", "[a b]", "Greater-than."},
-	{">=", "[a b]", "Greater-than-or-equal."},
+	{"<", "[x & more]", "True when the arguments are monotonically increasing."},
+	{"<=", "[x & more]", "True when the arguments are monotonically non-decreasing."},
+	{">", "[x & more]", "True when the arguments are monotonically decreasing."},
+	{">=", "[x & more]", "True when the arguments are monotonically non-increasing."},
 
 	// Collections
 	{"list", "[& items]", "Creates a list of the given items."},

--- a/tests/step9_gocompat.mal
+++ b/tests/step9_gocompat.mal
@@ -16,7 +16,7 @@
 (try (a) (catch err (str err)))
 ;=>"«go-error \"wrapped sample\"»"
 (try (/ 0 0) (catch err err))
-;=>«go-error "github.com/jig/lisp/lib/core[/]: runtime error: integer divide by zero"»
+;=>«go-error "division by zero"»
 (type? (try (a) (catch err err)))
 ;=>"go-error"
 (def b (fn [] (a)))

--- a/tests/step9_try.mal
+++ b/tests/step9_try.mal
@@ -444,4 +444,4 @@
 
 (try (/ 0 0) (catch e (prn e)))
 ;=>nil
-;/^.*integer divide by zero.*
+;/^.*division by zero.*

--- a/tests/stepD_casterror.mal
+++ b/tests/stepD_casterror.mal
@@ -1,26 +1,26 @@
 (/ 0 0)
-;/.*runtime error: integer divide by zero"»
+;/.*division by zero"»
 ;=>nil
 
 (/ 1 0)
-;/^.*integer divide by zero.*$
+;/^.*division by zero.*$
 ;=>nil
 
 (+ 1 :hello)
-;/^.*using string as type int"
+;/^.*not a number \(was of type string\)"
 ;=>nil
 
 (+ 1 "hello")
-;/^.*using string as type int"
+;/^.*not a number \(was of type string\)"
 ;=>nil
 
 (try (/ 1 0))
-;/.*runtime error: integer divide by zero"»
+;/.*division by zero"»
 ;=>nil
 
 (try (/ 1 0) (catch e e))
 ;/^$
-;=>«go-error "github.com/jig/lisp/lib/core[/]: runtime error: integer divide by zero"»
+;=>«go-error "division by zero"»
 
 «go-error "simple error"»
 ;=>«go-error "simple error"»

--- a/tests/stepJ_future.mal
+++ b/tests/stepJ_future.mal
@@ -50,7 +50,7 @@
 ;=>true
 
 @(future (/ 1 0))
-;/.*integer divide by zero"»$
+;/.*division by zero"»$
 ;=>nil
 
 (def async-bad (future (/ 1 0)))
@@ -60,7 +60,7 @@
 (future-done? async-bad)
 ;=>true
 @async-bad
-;/.*integer divide by zero"»$
+;/.*division by zero"»$
 ;=>nil
 (future-cancelled? async-bad)
 ;=>false

--- a/tests/stepK_numbers.mal
+++ b/tests/stepK_numbers.mal
@@ -126,3 +126,85 @@
 ;=>4.2e+11
 01234567890E-10
 ;=>0.12345679
+
+;; Variadic arithmetic, Clojure-style
+(+)
+;=>0
+(+ 5)
+;=>5
+(+ 1 1 1)
+;=>3
+(+ 1 2 3 4 5)
+;=>15
+(*)
+;=>1
+(* 2 3 4)
+;=>24
+(- 10)
+;=>-10
+(- 10 1 2)
+;=>7
+(/ 12 2 3)
+;=>2
+(/ 7 2)
+;=>3
+(/ 2)
+;=>0
+(/ 1)
+;=>1
+(/ 0)
+;/.*division by zero.*
+;=>nil
+(/ 1 0)
+;/.*division by zero.*
+;=>nil
+
+;; floats join the numeric tower (int contagion to float)
+(+ 1.5 2.5)
+;=>4
+(+ 1 0.5)
+;=>1.5
+(* 2 1.5)
+;=>3
+(- 1 0.25 0.25)
+;=>0.5
+
+;; big ints participate in arithmetic; ints promote to big
+(+ 0x01 0x02)
+;=>0x03
+(+ 0x01 1)
+;=>0x02
+(- 0x01 2)
+;=>-0x01
+(- 0xFF)
+;=>-0xFF
+(* 0x10 0x10)
+;=>0x0100
+(/ 0x10 0x03)
+;=>0x05
+(* 0xFFFF_FFFF_FFFF_FFFF 0x10)
+;=>0x0FFFFFFFFFFFFFFFF0
+;; big ints and floats do not mix
+(+ 0x01 1.5)
+;/.*cannot mix a big int and a float.*
+;=>nil
+
+;; ordering builtins chain variadically and span the tower
+(< 1 2 3)
+;=>true
+(< 1 3 2)
+;=>false
+(< 5)
+;=>true
+(<= 1 1 2)
+;=>true
+(> 3 2 1)
+;=>true
+(>= 3 3 1)
+;=>true
+(< 1 1.5 2)
+;=>true
+(< 0x01 0x02)
+;=>true
+(< 0x01 2)
+;=>true


### PR DESCRIPTION
Closes the two arithmetic gaps queued after the radix-literal work (#90).

## Variadic operators, Clojure shapes

```lisp
(+)            ;=> 0          (*)          ;=> 1
(+ 1 1 1)      ;=> 3          (* 2 3 4)    ;=> 24
(- 10)         ;=> -10        (- 10 1 2)   ;=> 7
(/ 12 2 3)     ;=> 2          (/ 2)        ;=> 0    ; (/ x) = 1/x, int division
(< 1 2 3)      ;=> true       (< 5)        ;=> true ; orderings chain
```

## Numeric tower with contagion

`int ∘ int → int`; a float makes the result float; a big int makes it big; **big ∘ float errors** (no unambiguous conversion):

```lisp
(+ 1 0.5)      ;=> 1.5        ; floats previously had NO arithmetic at all
(+ 0x01 1)     ;=> 0x02       ; ints promote to big
(- 0x01 2)     ;=> -0x01
(* 0xFFFF_FFFF_FFFF_FFFF 0x10) ;=> 0x0FFFFFFFFFFFFFFFF0   ; no overflow
(+ 0x01 1.5)   ;; error: cannot mix a big int and a float
```

`=` keeps its structural semantics (`(= 0x0A 10)` stays `false`); the ordering builtins compare numerically across the tower.

## Error-text changes (tests updated)

- Division by zero on ints/bigs: catchable `"division by zero"` instead of the wrapped Go runtime panic text.
- Non-numeric argument: `"not a number (was of type T)"` instead of the reflection cast message.
- Adjusted accordingly: `stepD_casterror.mal`, `step9_gocompat.mal`, `step9_try.mal` (one regex), `stepJ_future.mal` — assertion-text updates forced by the behaviour change, no new cases added to the original step files. New coverage lives in `stepK_numbers.mal`.

Float division by zero keeps Go/Clojure semantics (±Inf). Machine-int overflow keeps Go wrap-around semantics (Clojure-style auto-promotion to big was deliberately left out).

## Verification

`gofmt`/`go vet` clean (plain + `lispdebug`), full suite green (plain + `lispdebug` + `-race` on root and lib/core), exercised end-to-end with the real binary. `LANGUAGE.md` regenerated; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)