### PR TITLE
feat: lisp unit testing (deftest/is/are), CLI runner, and test coverage in VS Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,18 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   `«recur»` sentinel as a value
 - multi-line `"…"` strings (Clojure-style): a literal newline is kept
   verbatim; `¬…¬` remains for JSON and other escape-heavy content
+- `test` library — Clojure-style unit testing for lisp code: `deftest`,
+  `is` (with expected/actual reporting for `(is (= …))`), `are`
+  templates and `test/run-tests!`. The CLI runner grew with it:
+  `--test` now also accepts a single file, runs registered tests after
+  loading (legacy `*_test.mal` suites keep working), reports Go-style
+  failures, exits non-zero, and `--test-json FILE` writes a machine
+  report. In `lispdebug` builds, `--coverage FILE` records per-line
+  execution of the lisp sources (lcov; test files excluded) for any run
+  or test suite. The VS Code extension (0.9.0) integrates both: a
+  Testing panel with per-test run buttons and failure diffs, and a
+  **Coverage** profile that paints covered/uncovered lisp lines through
+  VS Code's native coverage view
 - Clojure-style arithmetic: `+ - * /` are variadic — `(+)`→0, `(*)`→1,
   `(+ x)`→x, `(- x)`→negation, `(/ x)`→1/x, `(- a b c)` folds left —
   and the ordering builtins `< <= > >=` chain (`(< 1 2 3)`). The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,12 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   Testing panel with per-test run buttons and failure diffs, and a
   **Coverage** profile that paints covered/uncovered lisp lines through
   VS Code's native coverage view
+- core promotions: `and`, `or`, `when`, `inc`, `dec`, `gensym` moved
+  from `coreextended` into the core header (their Clojure counterparts
+  live in clojure.core), and `load-file-once` sits next to `load-file`
+  (as a Go builtin: its seen-set needs mutable state and atoms belong
+  to the concurrent library). Library headers can now rely on all of
+  them with only core loaded; loading `coreextended` behaves as before
 - Clojure-style arithmetic: `+ - * /` are variadic — `(+)`→0, `(*)`→1,
   `(+ x)`→x, `(- x)`→negation, `(/ x)`→1/x, `(- a b c)` folds left —
   and the ordering builtins `< <= > >=` chain (`(< 1 2 3)`). The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,12 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   Testing panel with per-test run buttons and failure diffs, and a
   **Coverage** profile that paints covered/uncovered lisp lines through
   VS Code's native coverage view
+- `deftests/` — a deftest replica of the historical `tests/step*.mal`
+  suites (208 tests, 1200+ value-based checks), run by `TestDeftests`
+  and by `lisp --test deftests/`; the originals stay untouched under
+  the line-based harness. The replica also pins a documented
+  divergence: commas are not whitespace in jig/lisp (they read as a
+  `,` symbol), unlike kanaka/mal and Clojure
 - core promotions: `and`, `or`, `when`, `inc`, `dec`, `gensym` moved
   from `coreextended` into the core header (their Clojure counterparts
   live in clojure.core), and `load-file-once` sits next to `load-file`

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -450,6 +450,19 @@ Attest and verify lisp source (formatting, hashing, Ed25519 signatures).
 | `fmt` | `[s]` | Formats lisp source s into its canonical form (as lisp --fmt does); errors if s does not parse. |
 | `sha2-256` | `[s]` | SHA2-256 digest of string s, as lowercase hex. |
 
+### test
+
+| Name | Arguments | Description |
+| ---- | --------- | ----------- |
+| `are ⁽ᵐ⁾` | `[argv expr & rows]` | Template assertion: substitutes each row of values for argv in expr and asserts every instance, e.g. (are [x y] (= x y) 2 (+ 1 1) 4 (* 2 2)). |
+| `deftest ⁽ᵐ⁾` | `[name & body]` | Registers body as the test named name; run with the --test runner or (test/run-tests!). |
+| `is ⁽ᵐ⁾` | `[form & msg]` | Asserts form is truthy; inside deftest it records the outcome, outside it throws on failure. (is (= expected actual)) reports both values. |
+| `test/check!` | `[form thunk & msg]` | Records form's outcome in the running test; (is …) expands to this. |
+| `test/check-eq!` | `[form expected-thunk actual-thunk & msg]` | Records an equality check with expected/actual reporting; (is (= a b)) expands to this. |
+| `test/expand-are` | `[argv expr rows]` | Macro helper: expands an (are …) template into a do of is forms. |
+| `test/register!` | `[name fn]` | Registers fn as the test named name; deftest expands to this. |
+| `test/run-tests!` | `[]` | Runs every registered test and returns the results as data. |
+
 ⁽ᵐ⁾ = macro (arguments are not evaluated before the call).
 
 <!-- END GENERATED BUILTINS -->

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -176,6 +176,7 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `=` | `[a b]` | Value equality. |
 | `>` | `[x & more]` | True when the arguments are monotonically decreasing. |
 | `>=` | `[x & more]` | True when the arguments are monotonically non-increasing. |
+| `and ⁽ᵐ⁾` | `[& xs]` | Evaluates its arguments in order, returning the first falsey one, or the last (true with none). |
 | `apply` | `[f & args]` | Calls f with args, the last of which is a sequence spread as arguments. |
 | `assert` | `[expr & error]` | Returns nil when expr is truthy, otherwise raises error (or a default). |
 | `assoc` | `[map key val & kvs]` | Copy of map with the given key/value pairs added or replaced. |
@@ -188,6 +189,7 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `cons` | `[x seq]` | Prepends x to seq. |
 | `contains?` | `[coll key]` | Whether coll has the given key/index. |
 | `count` | `[coll]` | Number of elements in coll. |
+| `dec` | `[x]` | Returns x - 1. |
 | `defn ⁽ᵐ⁾` | `[name & fdecl]` | Defines a named function (defn name [params] body…); an optional docstring may follow name. |
 | `deref` | `[ref]` | Current value of an atom or other dereferenceable (also @ref). |
 | `dissoc` | `[map & keys]` | Copy of map without the given keys. |
@@ -201,12 +203,14 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `false?` | `[x]` | Whether x is boolean false. |
 | `first` | `[coll]` | First element of coll, or nil. |
 | `fn?` | `[x]` | Whether x is callable. |
+| `gensym` | `[]` | Returns a fresh, hopefully-unique symbol like G__N (for writing hygienic macros). |
 | `get` | `[coll key]` | Value at key in a map/vector, or nil. |
 | `get-in` | `[coll keys]` | Nested value reached by following the vector of keys. |
 | `go-error` | `[format & args]` | Creates a Go error from a format string and arguments. |
 | `hash-map` | `[& kvs]` | Creates a hash-map from alternating key/value arguments. |
 | `hash-map-decode` | `[factory json]` | Decodes JSON into a Go-backed hash-map. |
 | `hash-set` | `[& items]` | Creates a set of the given items. |
+| `inc` | `[x]` | Returns x + 1. |
 | `json-decode` | `[factory json]` | Decodes a JSON string into a lisp value. |
 | `json-encode` | `[obj]` | Encodes a lisp value (or Go object) to a JSON string. |
 | `keys` | `[map]` | Vector of the map's keys. |
@@ -226,6 +230,7 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `not=` | `[a b]` | Logical negation of =. |
 | `nth` | `[coll n]` | The element of coll at zero-based index n. |
 | `number?` | `[x]` | Whether x is a number. |
+| `or ⁽ᵐ⁾` | `[& xs]` | Evaluates its arguments in order, returning the first truthy one, or nil. |
 | `panic` | `[value]` | Raises value as a Go panic. |
 | `pr-str` | `[& args]` | Like str but with readable (quoted) representations. |
 | `println` | `[& args]` | Prints its arguments (unquoted) separated by spaces, then a newline. |
@@ -268,6 +273,7 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `vector` | `[& items]` | Creates a vector of the given items. |
 | `vector?` | `[x]` | Whether x is a vector. |
 | `version` | `[]` | Interpreter build information as a hash-map. |
+| `when ⁽ᵐ⁾` | `[condition & body]` | Evaluates body in an implicit do when condition is truthy; otherwise nil. |
 | `with-meta` | `[obj m]` | Copy of obj with metadata m. |
 
 Runtime variables: `*host-language*`
@@ -279,6 +285,7 @@ Reading and writing files and stdin.
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
 | `load-file` | `[file-path]` | Reads and evaluates the lisp file at file-path in the current environment; returns the value of its last form. |
+| `load-file-once` | `[file-path]` | Like load-file, but never loads the same path twice. |
 | `readline` | `[prompt]` | Prints prompt and reads a line from input. |
 | `slurp` | `[filename]` | Reads a file and returns its contents as a string. |
 | `spit` | `[filename s & opts]` | Writes string s to a file, creating or truncating it; with :append true, appends instead. |
@@ -318,10 +325,8 @@ Higher-order helpers written in lisp (the prelude): reduce, map, partial, protoc
 | `-> ⁽ᵐ⁾` | `[x & xs]` | Thread-first: inserts each stage's result as the first argument of the next form. |
 | `->> ⁽ᵐ⁾` | `[x & xs]` | Thread-last: inserts each stage's result as the last argument of the next form. |
 | `abs` | `[n]` | Absolute value of n. |
-| `and ⁽ᵐ⁾` | `[& xs]` | Evaluates its arguments in order, returning the first falsey one, or the last (true with none). |
 | `benchmark ⁽ᵐ⁾` | `[expr n]` | Evaluates expr n times, returning a vector with the elapsed milliseconds of each run. |
 | `benchmark*` | `[f n results]` | Runs f n times, collecting the elapsed milliseconds of each run (helper for benchmark). |
-| `dec` | `[a]` | Returns a - 1 (integer predecessor). |
 | `defprotocol ⁽ᵐ⁾` | `[proto-name & methods]` | Defines a protocol proto-name and its methods, dispatching on the argument's type. |
 | `even?` | `[n]` | Whether n is even. |
 | `every?` | `[pred xs]` | Whether (pred x) is truthy for every x in xs. |
@@ -329,18 +334,14 @@ Higher-order helpers written in lisp (the prelude): reduce, map, partial, protoc
 | `filter` | `[pred xs]` | List of the items in xs for which (pred x) is truthy. |
 | `find-type` | `[obj]` | Returns a keyword naming obj's type (overridable via :type metadata). |
 | `foldr` | `[f init xs]` | Right fold: (f x1 (f x2 (.. (f xn init)))) over the elements of xs. |
-| `gensym` | `[]` | Returns a fresh, hopefully-unique symbol like G__N. |
 | `identity` | `[x]` | Returns its argument unchanged. |
-| `inc` | `[a]` | Returns a + 1 (integer successor). |
 | `into` | `[to from]` | Pours every item of from into to using conj; the result keeps to's type. |
-| `load-file-once` | `[filename]` | Like load-file, but never loads the same path twice. |
 | `max` | `[a & more]` | Largest of one or more numbers. |
 | `memoize` | `[f]` | Returns a caching version of f: results are stored by argument and reused. |
 | `min` | `[a & more]` | Smallest of one or more numbers. |
 | `mod` | `[a b]` | Modulo of a by b; the sign follows the divisor b. |
 | `neg?` | `[n]` | Whether n is less than 0. |
 | `odd?` | `[n]` | Whether n is odd. |
-| `or ⁽ᵐ⁾` | `[& xs]` | Evaluates its arguments in order, returning the first truthy one, or nil. |
 | `partial` | `[f & args]` | Returns a function that calls f with the given args plus any it is later called with. |
 | `pos?` | `[n]` | Whether n is greater than 0. |
 | `pprint` | `[obj]` | Pretty-prints a lisp value with indentation. |
@@ -354,7 +355,6 @@ Higher-order helpers written in lisp (the prelude): reduce, map, partial, protoc
 | `some` | `[pred xs]` | Returns the first truthy (pred x) over xs, or nil. |
 | `take-while` | `[pred xs]` | Leading items of xs while (pred x) is truthy. |
 | `time ⁽ᵐ⁾` | `[exp]` | Evaluates exp, prints the elapsed time, and returns its value. |
-| `when ⁽ᵐ⁾` | `[condition & body]` | Evaluates body in an implicit do when condition is truthy; otherwise nil. |
 | `zero?` | `[n]` | Whether n equals 0. |
 
 ### assert

--- a/README.md
+++ b/README.md
@@ -67,6 +67,44 @@ There are some benchmarks as well:
 go test -benchmem -benchtime 5s -bench '^.+$' github.com/jig/lisp
 ```
 
+### Testing lisp code (deftest/is/are)
+
+The `test` library provides Clojure-style unit testing for lisp code
+itself. Tests live in `*_test.lisp` files:
+
+```clojure
+(load-file "mylib.lisp")
+
+(deftest double-works
+  (is (= 4 (double 2)))
+  (are [in out] (= out (double in))
+    0 0
+    5 10))
+```
+
+Run a directory (or a single file) with the CLI runner, which exits
+non-zero on failure:
+
+```bash
+lisp --test ./tests               # human summary
+lisp --test ./tests --test-json report.json
+```
+
+`(is (= expected actual))` reports both values on failure; a failing
+`is` outside `deftest` throws, so it also works in plain scripts. With
+the debug build, add `--coverage cov.lcov` to write an lcov report of
+the lisp lines executed (test files excluded), consumable by any lcov
+tool and by the VS Code extension's **Coverage** test profile, which
+paints covered/uncovered lines in the editor:
+
+```bash
+lisp-debug --test ./tests --coverage cov.lcov
+```
+
+Coverage is recorded per form and mapped to lines; lines holding only
+literal atoms (e.g. a lone keyword in an `if` branch) carry no source
+position and are not counted as coverable.
+
 ### Changes respect to `kanaka/mal`
 
 There almost 100 implementations on almost 100 languages available on repository [kanaka/mal](https://github.com/kanaka/mal).

--- a/cmd/lisp/main.go
+++ b/cmd/lisp/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jig/lisp/lib/require/nsrequire"
 	"github.com/jig/lisp/lib/sql/nssql"
 	"github.com/jig/lisp/lib/system/nssystem"
+	"github.com/jig/lisp/lib/test/nstest"
 	"github.com/jig/lisp/types"
 )
 
@@ -45,6 +46,7 @@ func libraries(scriptArgs []string) []library {
 		{"sql", nssql.Load},
 		{"cli", nscli.Load},
 		{"integrity", nsintegrity.Load},
+		{"test", nstest.Load},
 	}
 }
 

--- a/command/command.go
+++ b/command/command.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
-	"strings"
 
 	"github.com/alexflint/go-arg"
 	"github.com/jig/lisp"
@@ -18,7 +17,9 @@ import (
 // args represents command line arguments for the Lisp interpreter
 type args struct {
 	Version   bool     `arg:"-v,--version" help:"show version information"`
-	Test      string   `arg:"-t,--test" help:"run test suite from directory" placeholder:"DIR"`
+	Test      string   `arg:"-t,--test" help:"run the test suite from a directory or a single test file" placeholder:"DIR|FILE"`
+	TestJSON  string   `arg:"--test-json" help:"with --test, also write a JSON report to the given file" placeholder:"FILE"`
+	Coverage  string   `arg:"--coverage" help:"write an lcov coverage report of the executed lisp code (requires lispdebug build)" placeholder:"FILE"`
 	Debug     bool     `arg:"--debug" help:"enable DEBUG-EVAL support (requires lispdebug build)"`
 	Eval      string   `arg:"-e,--eval" help:"evaluate expression and exit" placeholder:"EXPR"`
 	Fmt       bool     `arg:"--fmt" help:"format lisp source (files given as arguments, or stdin) and print the result"`
@@ -137,9 +138,24 @@ func Execute(cmdArgs []string, repl_env types.EnvType) error {
 		return nil
 	}
 
+	// Coverage collection wraps the evaluating modes (--test and script
+	// execution). In release builds startCoverage returns an error when a
+	// coverage file is requested.
+	stopCoverage := func() error { return nil }
+	if parsedArgs.Coverage != "" {
+		stopCoverage, err = startCoverage(parsedArgs.Coverage)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Handle --test
 	if parsedArgs.Test != "" {
-		return runTests(parsedArgs.Test, repl_env)
+		testErr := runTests(parsedArgs.Test, parsedArgs.TestJSON, repl_env)
+		if err := stopCoverage(); err != nil {
+			return err
+		}
+		return testErr
 	}
 
 	// Handle file execution or stdin
@@ -159,6 +175,9 @@ func Execute(cmdArgs []string, repl_env types.EnvType) error {
 			result, err := runScript(context.Background(), repl_env, parsedArgs.Script, parsedArgs.Preamble,
 				types.NewCursorHere(parsedArgs.Script, -3, 1))
 			if err != nil {
+				return err
+			}
+			if err := stopCoverage(); err != nil {
 				return err
 			}
 			if parsedArgs.Eval == "" {
@@ -187,27 +206,6 @@ func Execute(cmdArgs []string, repl_env types.EnvType) error {
 		return fmt.Errorf("internal error: %s", err)
 	}
 	return repl.Execute(ctx, repl_env)
-}
-
-// runTests executes all *_test.mal files in the given directory
-func runTests(dir string, repl_env types.EnvType) error {
-	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() && strings.HasSuffix(info.Name(), "_test.mal") {
-			testParams := fmt.Sprintf(`(def *test-params* {:test-file %q :test-absolute-path %q})`, info.Name(), path)
-
-			ctx := context.Background()
-			if _, err := lisp.REPL(ctx, repl_env, testParams, types.NewCursorFile(info.Name())); err != nil {
-				return err
-			}
-			if _, err := lisp.REPL(ctx, repl_env, `(load-file "`+path+`")`, types.NewCursorHere(path, -3, 1)); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
 }
 
 // ExecuteFile executes a file on the given path

--- a/command/coverage_debug.go
+++ b/command/coverage_debug.go
@@ -1,0 +1,190 @@
+//go:build lispdebug
+
+package command
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jig/lisp/reader"
+	"github.com/jig/lisp/runtime"
+	"github.com/jig/lisp/types"
+)
+
+// covCollector is an EvalHook that counts evaluated forms per source
+// line. It chains to any previously installed hook so --coverage can
+// coexist with --debug.
+type covCollector struct {
+	next runtime.EvalHook
+	// hits: module → line → evaluation count. Access is not synchronised:
+	// the runner evaluates on one goroutine; forms evaluated inside
+	// (future …) run detached and are counted too, racing benignly at
+	// worst on a counter — acceptable for coverage. A mutex would sit on
+	// the interpreter's hottest path.
+	hits map[string]map[int]int
+}
+
+func (c *covCollector) OnEval(ctx context.Context, ev runtime.EvalEvent) error {
+	if ev.Cursor != nil && ev.Cursor.Module != nil && ev.Cursor.BeginRow > 0 {
+		lines, ok := c.hits[*ev.Cursor.Module]
+		if !ok {
+			lines = map[int]int{}
+			c.hits[*ev.Cursor.Module] = lines
+		}
+		lines[ev.Cursor.BeginRow]++
+	}
+	if c.next != nil {
+		return c.next.OnEval(ctx, ev)
+	}
+	return nil
+}
+
+// startCoverage installs the collecting hook and returns a stop function
+// that uninstalls it and writes the lcov report.
+func startCoverage(path string) (func() error, error) {
+	col := &covCollector{next: runtime.Hook, hits: map[string]map[int]int{}}
+	runtime.Hook = col
+	return func() error {
+		runtime.Hook = col.next
+		return writeLcov(path, col.hits)
+	}, nil
+}
+
+// coverableLines parses a lisp source file and returns the set of lines
+// holding at least one form — the denominator of the coverage report.
+func coverableLines(path string) (map[int]bool, error) {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	// Files hold many top-level forms; wrap in (do …) like the LSP does
+	// and shift rows back by the extra first line.
+	ast, err := reader.Read_str("(do\n"+string(src)+"\n)", types.NewCursorFile(path), nil)
+	if err != nil {
+		return nil, err
+	}
+	lines := map[int]bool{}
+	var walk func(form types.MalType)
+	mark := func(cur *types.Position) {
+		if cur != nil && cur.BeginRow > 1 {
+			lines[cur.BeginRow-1] = true
+		}
+	}
+	walk = func(form types.MalType) {
+		switch f := form.(type) {
+		case types.List:
+			mark(f.Cursor)
+			for _, c := range f.Val {
+				walk(c)
+			}
+		case types.Vector:
+			mark(f.Cursor)
+			for _, c := range f.Val {
+				walk(c)
+			}
+		case types.HashMap:
+			mark(f.Cursor)
+			for _, c := range f.Val {
+				walk(c)
+			}
+		case types.Symbol:
+			mark(f.Cursor)
+		}
+	}
+	if do, ok := ast.(types.List); ok && len(do.Val) > 1 {
+		for _, c := range do.Val[1:] {
+			walk(c)
+		}
+	}
+	return lines, nil
+}
+
+// resolveModule maps a Cursor module identifier to an absolute path of an
+// existing regular file, or "" when the module does not correspond to a
+// coverable source file (REPL, -e, $-prefixed library headers, …).
+func resolveModule(module string) string {
+	path := module
+	if p, ok := runtime.Modules.Lookup(module); ok {
+		path = p
+	}
+	if strings.HasPrefix(filepath.Base(path), "$") {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	info, err := os.Stat(abs)
+	if err != nil || info.IsDir() {
+		return ""
+	}
+	return abs
+}
+
+// isTestFile reports whether path is a test source, excluded from the
+// coverage report the way Go excludes _test.go files.
+func isTestFile(path string) bool {
+	return strings.HasSuffix(path, "_test.lisp") || strings.HasSuffix(path, "_test.mal")
+}
+
+// writeLcov merges hit counts into per-file line records and writes an
+// lcov tracefile. Lines are the union of the statically coverable lines
+// and the lines actually hit (macro-expanded code may execute lines the
+// static walk cannot attribute).
+func writeLcov(path string, hits map[string]map[int]int) error {
+	// Merge modules resolving to the same file (relative vs absolute).
+	byFile := map[string]map[int]int{}
+	for module, lines := range hits {
+		abs := resolveModule(module)
+		if abs == "" || isTestFile(abs) {
+			continue
+		}
+		m, ok := byFile[abs]
+		if !ok {
+			m = map[int]int{}
+			byFile[abs] = m
+		}
+		for line, n := range lines {
+			m[line] += n
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("TN:\n")
+	files := make([]string, 0, len(byFile))
+	for f := range byFile {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+	for _, file := range files {
+		lineHits := byFile[file]
+		all := map[int]int{}
+		if coverable, err := coverableLines(file); err == nil {
+			for line := range coverable {
+				all[line] = 0
+			}
+		}
+		for line, n := range lineHits {
+			all[line] += n
+		}
+		lines := make([]int, 0, len(all))
+		for line := range all {
+			lines = append(lines, line)
+		}
+		sort.Ints(lines)
+		fmt.Fprintf(&b, "SF:%s\n", file)
+		covered := 0
+		for _, line := range lines {
+			fmt.Fprintf(&b, "DA:%d,%d\n", line, all[line])
+			if all[line] > 0 {
+				covered++
+			}
+		}
+		fmt.Fprintf(&b, "LF:%d\nLH:%d\nend_of_record\n", len(lines), covered)
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o644)
+}

--- a/command/coverage_debug_test.go
+++ b/command/coverage_debug_test.go
@@ -1,0 +1,63 @@
+//go:build lispdebug
+
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCoverageLcov runs a small suite under the coverage collector and
+// checks the lcov output: the library file is reported with hit and
+// unhit lines, and the test file itself is excluded.
+func TestCoverageLcov(t *testing.T) {
+	dir := t.TempDir()
+	lib := filepath.Join(dir, "mylib.lisp")
+	if err := os.WriteFile(lib, []byte(`(defn double [x] (* 2 x))
+
+(defn never-called [x]
+  (str "unused " x))
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "my_test.lisp"), []byte(`(load-file "`+lib+`")
+(deftest doubles (is (= 4 (double 2))))
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lcov := filepath.Join(dir, "cov.lcov")
+	stop, err := startCoverage(lcov)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runErr := runTests(dir, "", newTestRunnerEnv(t))
+	if err := stop(); err != nil {
+		t.Fatal(err)
+	}
+	if runErr != nil {
+		t.Fatalf("runTests: %v", runErr)
+	}
+
+	data, err := os.ReadFile(lcov)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "SF:"+lib) {
+		t.Fatalf("lcov misses the library file:\n%s", out)
+	}
+	if strings.Contains(out, "my_test.lisp") {
+		t.Fatalf("lcov must exclude test files:\n%s", out)
+	}
+	// line 1 (defn double) is executed; line 4 (the body of never-called)
+	// is parsed as coverable but never hit.
+	if !strings.Contains(out, "DA:1,") || strings.Contains(out, "DA:1,0") {
+		t.Fatalf("expected line 1 hit:\n%s", out)
+	}
+	if !strings.Contains(out, "DA:4,0") {
+		t.Fatalf("expected line 4 unhit:\n%s", out)
+	}
+}

--- a/command/coverage_release.go
+++ b/command/coverage_release.go
@@ -1,0 +1,12 @@
+//go:build !lispdebug
+
+package command
+
+import "errors"
+
+// startCoverage is unavailable in release builds: the eval hook that
+// feeds the collector is compiled out. Build with -tags lispdebug (the
+// lisp-debug binary) to record coverage.
+func startCoverage(_ string) (func() error, error) {
+	return nil, errors.New("--coverage requires the lispdebug build (use the lisp-debug binary)")
+}

--- a/command/test.go
+++ b/command/test.go
@@ -1,0 +1,199 @@
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/lib/test"
+	"github.com/jig/lisp/types"
+)
+
+// discoverTestFiles returns the test files under target, which may be a
+// single file or a directory walked recursively. Both the legacy
+// *_test.mal suites and *_test.lisp files are picked up.
+func discoverTestFiles(target string) ([]string, error) {
+	info, err := os.Stat(target)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return []string{target}, nil
+	}
+	var files []string
+	err = filepath.Walk(target, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(info.Name(), "_test.mal") || strings.HasSuffix(info.Name(), "_test.lisp") {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// runTests loads every test file under target and then runs the tests
+// registered with deftest, reporting on stdout (and optionally as JSON to
+// jsonPath). A load error aborts; test failures are reported and produce
+// a non-nil error after the whole suite has run.
+func runTests(target, jsonPath string, repl_env types.EnvType) error {
+	ctx := context.Background()
+	files, err := discoverTestFiles(target)
+	if err != nil {
+		return err
+	}
+	for _, path := range files {
+		name := filepath.Base(path)
+		// Legacy *_test.mal suites read *test-params*; keep providing it.
+		testParams := fmt.Sprintf(`(def *test-params* {:test-file %q :test-absolute-path %q})`, name, path)
+		if _, err := lisp.REPL(ctx, repl_env, testParams, types.NewCursorFile(name)); err != nil {
+			return err
+		}
+		if abs, err := filepath.Abs(path); err == nil {
+			registerModule(path, abs)
+		}
+		if _, err := lisp.REPL(ctx, repl_env, `(load-file "`+path+`")`, types.NewCursorHere(path, -3, 1)); err != nil {
+			return err
+		}
+	}
+
+	reg := test.FromEnv(repl_env)
+	var results []*test.Test
+	if reg != nil {
+		results = reg.RunAll(ctx)
+	}
+
+	failedTests := 0
+	checks, failedChecks := 0, 0
+	for _, t := range results {
+		checks += len(t.Checks)
+		for _, c := range t.Checks {
+			if !c.OK {
+				failedChecks++
+			}
+		}
+		if t.OK() {
+			continue
+		}
+		failedTests++
+		fmt.Printf("--- FAIL: %s (%s)\n", t.Name, formatPos(t.Module, t.Line))
+		if t.Err != "" {
+			fmt.Printf("    error: %s\n", indent(t.Err))
+		}
+		for _, c := range t.Checks {
+			if c.OK {
+				continue
+			}
+			fmt.Printf("    %s: %s", formatPos(c.Module, c.Line), c.Form)
+			switch {
+			case c.Err != "":
+				fmt.Printf(": error: %s", indent(c.Err))
+			case c.Expected != "":
+				fmt.Printf(": expected %s, got %s", c.Expected, c.Actual)
+			default:
+				fmt.Printf(": failed")
+			}
+			if c.Message != "" {
+				fmt.Printf(" — %s", c.Message)
+			}
+			fmt.Println()
+		}
+	}
+
+	if jsonPath != "" {
+		if err := writeTestReport(jsonPath, target, results); err != nil {
+			return err
+		}
+	}
+
+	if failedTests > 0 {
+		fmt.Printf("FAIL: %d of %d tests failed (%d of %d checks)\n", failedTests, len(results), failedChecks, checks)
+		return fmt.Errorf("%d test(s) failed", failedTests)
+	}
+	fmt.Printf("PASS: %d tests, %d checks\n", len(results), checks)
+	return nil
+}
+
+func formatPos(module string, line int) string {
+	if module == "" {
+		return "?"
+	}
+	if line == 0 {
+		return module
+	}
+	return fmt.Sprintf("%s:%d", module, line)
+}
+
+// indent keeps multi-line error messages aligned under their header.
+func indent(s string) string {
+	return strings.ReplaceAll(s, "\n", "\n        ")
+}
+
+// report structures mirror the runner output for tooling (the VS Code
+// extension reads this file after a run).
+type checkReport struct {
+	Form     string `json:"form"`
+	OK       bool   `json:"ok"`
+	Module   string `json:"module,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	Error    string `json:"error,omitempty"`
+	Expected string `json:"expected,omitempty"`
+	Actual   string `json:"actual,omitempty"`
+	Message  string `json:"message,omitempty"`
+}
+
+type testReport struct {
+	Name   string        `json:"name"`
+	OK     bool          `json:"ok"`
+	Module string        `json:"module,omitempty"`
+	Line   int           `json:"line,omitempty"`
+	Error  string        `json:"error,omitempty"`
+	Checks []checkReport `json:"checks"`
+}
+
+type suiteReport struct {
+	Target  string       `json:"target"`
+	Tests   []testReport `json:"tests"`
+	Failed  int          `json:"failed"`
+	Checks  int          `json:"checks"`
+	FailedC int          `json:"failedChecks"`
+}
+
+func writeTestReport(path, target string, results []*test.Test) error {
+	rep := suiteReport{Target: target, Tests: []testReport{}}
+	for _, t := range results {
+		tr := testReport{Name: t.Name, OK: t.OK(), Module: t.Module, Line: t.Line, Error: t.Err, Checks: []checkReport{}}
+		for _, c := range t.Checks {
+			rep.Checks++
+			if !c.OK {
+				rep.FailedC++
+			}
+			tr.Checks = append(tr.Checks, checkReport{
+				Form: c.Form, OK: c.OK, Module: c.Module, Line: c.Line,
+				Error: c.Err, Expected: c.Expected, Actual: c.Actual, Message: c.Message,
+			})
+		}
+		if !tr.OK {
+			rep.Failed++
+		}
+		rep.Tests = append(rep.Tests, tr)
+	}
+	data, err := json.MarshalIndent(rep, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}

--- a/command/test_runner_test.go
+++ b/command/test_runner_test.go
@@ -1,0 +1,90 @@
+package command
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jig/lisp/lib/test/nstest"
+	"github.com/jig/lisp/types"
+)
+
+func newTestRunnerEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := newTestEnv(t)
+	if err := nstest.Load(ns); err != nil {
+		t.Fatalf("nstest.Load: %v", err)
+	}
+	return ns
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunTestsPassAndReport(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "ok_test.lisp"), `
+(deftest sums (is (= 3 (+ 1 2))))
+(deftest products (are [x y] (= x y) 4 (* 2 2) 9 (* 3 3)))
+`)
+	jsonPath := filepath.Join(dir, "report.json")
+	if err := runTests(dir, jsonPath, newTestRunnerEnv(t)); err != nil {
+		t.Fatalf("runTests: %v", err)
+	}
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rep suiteReport
+	if err := json.Unmarshal(data, &rep); err != nil {
+		t.Fatal(err)
+	}
+	if len(rep.Tests) != 2 || rep.Failed != 0 || rep.Checks != 3 {
+		t.Fatalf("unexpected report: %+v", rep)
+	}
+	if rep.Tests[0].Line == 0 || rep.Tests[0].Module == "" {
+		t.Fatalf("missing test position: %+v", rep.Tests[0])
+	}
+}
+
+func TestRunTestsFailure(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "bad_test.lisp"), `(deftest broken (is (= 1 2)))`)
+	jsonPath := filepath.Join(dir, "report.json")
+	err := runTests(dir, jsonPath, newTestRunnerEnv(t))
+	if err == nil || !strings.Contains(err.Error(), "1 test(s) failed") {
+		t.Fatalf("expected failure error, got %v", err)
+	}
+	data, err := os.ReadFile(jsonPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rep suiteReport
+	if err := json.Unmarshal(data, &rep); err != nil {
+		t.Fatal(err)
+	}
+	if rep.Failed != 1 || rep.Tests[0].Checks[0].Expected != "1" || rep.Tests[0].Checks[0].Actual != "2" {
+		t.Fatalf("unexpected report: %+v", rep)
+	}
+}
+
+func TestRunTestsSingleFileAndLoadError(t *testing.T) {
+	dir := t.TempDir()
+	single := filepath.Join(dir, "one_test.lisp")
+	writeFile(t, single, `(deftest single (is true))`)
+	if err := runTests(single, "", newTestRunnerEnv(t)); err != nil {
+		t.Fatalf("single file: %v", err)
+	}
+
+	broken := filepath.Join(dir, "broken_test.lisp")
+	writeFile(t, broken, `(this-symbol-does-not-exist)`)
+	if err := runTests(broken, "", newTestRunnerEnv(t)); err == nil {
+		t.Fatal("expected a load error")
+	}
+}

--- a/deftests/README.md
+++ b/deftests/README.md
@@ -1,0 +1,39 @@
+# deftests
+
+The `deftest` replica of the historical `tests/step*.mal` suites, run by
+`TestDeftests` (and by hand with `lisp --test deftests/` from the
+repository root — `step6_file_test.lisp` and `stepA_mal_test.lisp` load
+fixtures through paths relative to it). The originals stay untouched and
+keep running under the line-based Go harness; the two suites complement
+each other.
+
+## Conventions
+
+- Assertions compare **values**: `(is (= expected actual))`. The legacy
+  `;=>` harness compares **printed forms** instead, so printer output is
+  asserted here only where printing is the point, via
+  `(is (= "…" (pr-str …)))`.
+- Error expectations (`;/regex`) become
+  `(is (= :threw (try … (catch e :threw))))`, or a `pr-str` comparison
+  of the caught value when the message matters.
+- Cases that assert **stdout** (`prn`/`println` output) have no deftest
+  equivalent (there is no `with-out-str`) and stay in the legacy
+  harness only.
+- Multi-key hash-map / multi-element set printing has no stable order:
+  compare as values, or accept both orders with `or`.
+- `«…»` reader literals need an environment-aware reader and cannot be
+  read through `load-file`; those cases are asserted through values and
+  `pr-str`.
+- Test names and top-level helper `def`s are prefixed per file (all
+  files share one environment, and deftest re-registration replaces by
+  name).
+
+## Not replicated
+
+- `tests/step0_repl.mal` — REPL echo behaviour; also skipped by the Go
+  harness.
+- `tests/stepI_marshaling copy.mal` — depends on example marshal types
+  registered only by the Go test harness, not by the `lisp` binary.
+- Documented divergence pinned in `step1_read_print_test.lisp`: commas
+  are **not** whitespace in jig/lisp (they read as a `,` symbol), unlike
+  kanaka/mal and Clojure.

--- a/deftests/step1_read_print_test.lisp
+++ b/deftests/step1_read_print_test.lisp
@@ -1,0 +1,159 @@
+;; Replica of tests/step1_read_print.mal — read/print round trips via
+;; (pr-str (read-string src)). Note this file gives NEW coverage: the
+;; original is skipped by the Go .mal harness.
+
+(deftest read-numbers
+  (are [printed src] (= printed (pr-str (read-string src)))
+    "1"    "1"
+    "7"    "7"
+    "7"    "  7   "
+    "-123" "-123"))
+
+(deftest read-symbols
+  (are [printed src] (= printed (pr-str (read-string src)))
+    "+"       "+"
+    "abc"     "abc"
+    "abc"     "   abc   "
+    "abc5"    "abc5"
+    "abc-def" "abc-def"
+    ;; non-numbers starting with a dash
+    "-"       "-"
+    "-abc"    "-abc"
+    "->>"     "->>"))
+
+(deftest read-lists
+  (are [printed src] (= printed (pr-str (read-string src)))
+    "(+ 1 2)"       "(+ 1 2)"
+    "()"            "()"
+    "()"            "( )"
+    "(nil)"         "(nil)"
+    "((3 4))"       "((3 4))"
+    "(+ 1 (+ 2 3))" "(+ 1 (+ 2 3))"
+    "(+ 1 (+ 2 3))" "  ( +   1   (+   2 3   )   )  "
+    "(* 1 2)"       "(* 1 2)"
+    "(** 1 2)"      "(** 1 2)"
+    "(* -3 6)"      "(* -3 6)"
+    "(() ())"       "(()())"))
+
+;; DIVERGENCE from kanaka/mal and Clojure: commas are NOT whitespace in
+;; jig/lisp — they read as a `,` symbol. The original expected
+;; (1 2, 3,,,,) to read as (1 2 3); this pins the current behaviour so a
+;; future change (comma-as-whitespace, Clojure parity) shows up here.
+(deftest read-commas-are-not-whitespace
+  (is (= "(1 2 , 3)" (pr-str (read-string "(1 2, 3)")))))
+
+;; -------- Deferrable Functionality --------
+
+(deftest read-nil-true-false
+  (are [printed src] (= printed (pr-str (read-string src)))
+    "nil"   "nil"
+    "true"  "true"
+    "false" "false"))
+
+(deftest read-strings
+  (are [printed src] (= printed (pr-str (read-string src)))
+    "\"abc\""               "\"abc\""
+    "\"abc\""               "   \"abc\"   "
+    "\"abc (with parens)\"" "\"abc (with parens)\""
+    "\"abc\\\"def\""        "\"abc\\\"def\""
+    "\"\""                  "\"\""
+    "\"\\\\\""              "\"\\\\\""
+    "\"&\"" "\"&\""
+    "\"'\"" "\"'\""
+    "\"(\"" "\"(\""
+    "\")\"" "\")\""
+    "\"*\"" "\"*\""
+    "\"+\"" "\"+\""
+    "\",\"" "\",\""
+    "\"-\"" "\"-\""
+    "\"/\"" "\"/\""
+    "\":\"" "\":\""
+    "\";\"" "\";\""
+    "\"<\"" "\"<\""
+    "\"=\"" "\"=\""
+    "\">\"" "\">\""
+    "\"?\"" "\"?\""
+    "\"@\"" "\"@\""
+    "\"[\"" "\"[\""
+    "\"]\"" "\"]\""
+    "\"^\"" "\"^\""
+    "\"_\"" "\"_\""
+    "\"`\"" "\"`\""
+    "\"{\"" "\"{\""
+    "\"#{\"" "\"#{\""
+    "\"}\"" "\"}\""
+    "\"~\"" "\"~\""
+    "\"!\"" "\"!\""))
+
+(deftest read-errors
+  (are [src] (= :threw (try (read-string src) (catch e :threw)))
+    "(1 2"
+    "[1 2"
+    "\"abc"
+    "\""
+    "\"\\\""
+    "(1 \"abc"
+    "(1 \"abc\""))
+
+(deftest read-quoting-forms
+  (are [printed src] (= printed (pr-str (read-string src)))
+    "(quote 1)"                    "'1"
+    "(quote (1 2 3))"              "'(1 2 3)"
+    "(quasiquote 1)"               "`1"
+    "(quasiquote (1 2 3))"         "`(1 2 3)"
+    "(unquote 1)"                  "~1"
+    "(unquote (1 2 3))"            "~(1 2 3)"
+    "(quasiquote (1 (unquote a) 3))" "`(1 ~a 3)"
+    "(splice-unquote (1 2 3))"     "~@(1 2 3)"))
+
+(deftest read-keywords
+  (are [printed src] (= printed (pr-str (read-string src)))
+    ":kw"              ":kw"
+    "(:kw1 :kw2 :kw3)" "(:kw1 :kw2 :kw3)"))
+
+(deftest read-vectors
+  (are [printed src] (= printed (pr-str (read-string src)))
+    "[+ 1 2]"       "[+ 1 2]"
+    "[]"            "[]"
+    "[]"            "[ ]"
+    "[[3 4]]"       "[[3 4]]"
+    "[+ 1 [+ 2 3]]" "[+ 1 [+ 2 3]]"
+    "[+ 1 [+ 2 3]]" "  [ +   1   [+   2 3   ]   ]  "
+    "([])"          "([])"))
+
+(deftest read-hash-maps
+  (are [printed src] (= printed (pr-str (read-string src)))
+    "{}"                    "{}"
+    "{}"                    "{ }"
+    "{\"abc\" 1}"           "{\"abc\" 1}"
+    "{\"a\" {\"b\" 2}}"     "{\"a\" {\"b\" 2}}"
+    "{\"a\" {\"b\" {\"c\" 3}}}" "{\"a\" {\"b\" {\"c\" 3}}}"
+    "{\"a\" {\"b\" {\"cde\" 3}}}" "{  \"a\"  {\"b\"   {  \"cde\"     3   }  }}"
+    "{:a {:b {:cde 3}}}"    "{  :a  {:b   {  :cde     3   }  }}"
+    "{\"1\" 1}"             "{\"1\" 1}"
+    "({})"                  "({})")
+  ;; multi-key print order is unstable: compare as values instead
+  (is (= {"a1" 1 "a2" 2 "a3" 3} (read-string "{\"a1\" 1 \"a2\" 2 \"a3\" 3}"))))
+
+(deftest read-comments
+  (are [printed src] (= printed (pr-str (read-string src)))
+    "1" "1 ; comment after expression"
+    "1" "1; comment after expression"))
+
+(deftest read-deref-macro
+  (is (= "(deref a)" (pr-str (read-string "@a")))))
+
+;; -------- Optional Functionality --------
+
+(deftest read-metadata-macro
+  (is (= "(with-meta [1 2 3] {\"a\" 1})" (pr-str (read-string "^{\"a\" 1} [1 2 3]")))))
+
+(deftest read-string-escapes
+  (are [printed src] (= printed (pr-str (read-string src)))
+    "\"\\n\""  "\"\\n\""
+    "\"#\""    "\"#\""
+    "\"$\""    "\"$\""
+    "\"%\""    "\"%\""
+    "\".\""    "\".\""
+    "\"\\\\\"" "\"\\\\\""
+    "\"|\""    "\"|\""))

--- a/deftests/step2_eval_test.lisp
+++ b/deftests/step2_eval_test.lisp
@@ -1,0 +1,46 @@
+;; Replica of tests/step2_eval.mal in the deftest framework.
+;;
+;; Conventions used throughout deftests/: assertions compare VALUES with
+;; (is (= expected actual)) — the legacy ;=> harness compares printed
+;; forms instead, so both suites remain valuable. Error expectations
+;; (;/regex on stdout) translate to a (try … (catch e …)) pattern;
+;; pure stdout-printing cases stay in the legacy harness only.
+
+;; Testing evaluation of arithmetic operations
+(deftest eval-arithmetic
+  (is (= 3 (+ 1 2)))
+  (are [expected expr] (= expected expr)
+    11   (+ 5 (* 2 3))
+    8    (- (+ 5 (* 2 3)) 3)
+    2    (/ (- (+ 5 (* 2 3)) 3) 4)
+    1010 (/ (- (+ 515 (* 87 311)) 302) 27)
+    -18  (* -3 6)
+    -994 (/ (- (+ 515 (* -87 311)) 296) 27)))
+
+;; This should throw an error with no return value
+(deftest eval-unknown-symbol-throws
+  (is (= :threw (try (abc 1 2 3) (catch e :threw)))))
+
+;; Testing empty list
+(deftest eval-empty-list
+  (is (list? ()))
+  (is (empty? ()))
+  (is (= "()" (pr-str ()))))
+
+;; -------- Deferrable Functionality --------
+
+;; Testing evaluation within collection literals
+(deftest eval-inside-collection-literals
+  (is (= [1 2 3] [1 2 (+ 1 2)]))
+  (is (= {"a" 15} {"a" (+ 7 8)}))
+  (is (= {:a 15} {:a (+ 7 8)}))
+  (is (= 15 (get {:a (+ 7 8)} :a))))
+
+;; Check that evaluation hasn't broken empty collections
+(deftest eval-empty-collections
+  (is (vector? []))
+  (is (= 0 (count [])))
+  (is (= "[]" (pr-str [])))
+  (is (map? {}))
+  (is (= 0 (count (keys {}))))
+  (is (= "{}" (pr-str {}))))

--- a/deftests/step3_env_test.lisp
+++ b/deftests/step3_env_test.lisp
@@ -1,0 +1,54 @@
+;; Replica of tests/step3_env.mal: def, let and environment nesting.
+
+(deftest env-def
+  (def env-x 3)
+  (is (= 3 env-x))
+  (def env-x 4)
+  (is (= 4 env-x))
+  (def env-y (+ 1 7))
+  (is (= 8 env-y)))
+
+(deftest env-case-sensitive-symbols
+  (def env-mynum 111)
+  (def env-MYNUM 222)
+  (is (= 111 env-mynum))
+  (is (= 222 env-MYNUM)))
+
+(deftest env-lookup-error-aborts-def
+  (is (= :threw (try (abc 1 2 3) (catch e :threw))))
+  (def env-w 123)
+  (is (= :threw (try (def env-w (abc)) (catch e :threw))))
+  (is (= 123 env-w)))
+
+(deftest env-let
+  (is (= 9 (let (z 9) z)))
+  (is (= 9 (let (x 9) x)))
+  (def env-x2 4)
+  (is (= 4 (let (unused 9) env-x2)))
+  (is (= 6 (let (z (+ 2 3)) (+ 1 z))))
+  (is (= 12 (let (p (+ 2 3) q (+ 2 p)) (+ p q))))
+  (def env-y2 (let (z 7) z))
+  (is (= 7 env-y2))
+  ;; several body expressions: the last one wins
+  (is (= 10 (let (z 9 x 10 y 11) z y x)))
+  (is (= nil (let (z 9)))))
+
+(deftest env-outer-environment
+  (def env-a 4)
+  (is (= 9 (let (q 9) q)))
+  (is (= 4 (let (q 9) env-a)))
+  (is (= 4 (let (z 2) (let (q 9) env-a)))))
+
+;; -------- Deferrable Functionality --------
+
+(deftest env-let-vector-bindings
+  (is (= 9 (let [z 9] z)))
+  (is (= 12 (let [p (+ 2 3) q (+ 2 p)] (+ p q)))))
+
+(deftest env-vector-evaluation
+  (is (= [3 4 5 [6 7] 8] (let (a 5 b 6) [3 4 a [b 7] 8]))))
+
+;; -------- Optional Functionality --------
+
+(deftest env-let-last-assignment-wins
+  (is (= 3 (let (x 2 x 3) x))))

--- a/deftests/step4_fn_extra_test.lisp
+++ b/deftests/step4_fn_extra_test.lisp
@@ -1,0 +1,10 @@
+;; Replica of tests/step4_fn_extra.mal: arity errors must not panic.
+
+(deftest fn-arity-errors
+  (def fn-extra-1 (fn [x] nil))
+  (is (= nil (fn-extra-1 3)))
+  (is (= :threw (try (fn-extra-1) (catch e :threw))))
+  (def fn-extra-2 (fn [x y] nil))
+  (is (= :threw (try (fn-extra-2 3) (catch e :threw))))
+  (is (= :threw (try (fn-extra-2) (catch e :threw))))
+  (is (= :threw (try (fn-extra-2 1 2 3) (catch e :threw)))))

--- a/deftests/step4_if_fn_do_test.lisp
+++ b/deftests/step4_if_fn_do_test.lisp
@@ -1,0 +1,244 @@
+;; Replica of tests/step4_if_fn_do.mal: lists, if, conditionals,
+;; equality, fn/closures, do, recursion, strings, varargs, keywords and
+;; vectors. The prn/println stdout sections stay in the legacy harness.
+
+(deftest list-functions
+  (is (= () (list)))
+  (is (list? (list)))
+  (is (empty? (list)))
+  (is (= false (empty? (list 1))))
+  (is (= (quote (1 2 3)) (list 1 2 3)))
+  (is (= 3 (count (list 1 2 3))))
+  (is (= 0 (count (list))))
+  (is (= 0 (count nil)))
+  (is (= 78 (if (> (count (list 1 2 3)) 3) 89 78)))
+  (is (= 89 (if (>= (count (list 1 2 3)) 3) 89 78))))
+
+(deftest if-form
+  (are [expected expr] (= expected expr)
+    7     (if true 7 8)
+    8     (if false 7 8)
+    false (if false 7 false)
+    8     (if true (+ 1 7) (+ 1 8))
+    9     (if false (+ 1 7) (+ 1 8))
+    8     (if nil 7 8)
+    7     (if 0 7 8)
+    7     (if (list) 7 8)
+    7     (if (list 1 2 3) 7 8))
+  (is (= false (= (list) nil)))
+  (is (= true (not= (list) nil)))
+  ;; 1-way if
+  (are [expected expr] (= expected expr)
+    nil (if false (+ 1 7))
+    nil (if nil 8)
+    7   (if nil 8 7)
+    8   (if true (+ 1 7))))
+
+(deftest basic-conditionals
+  (are [expected expr] (= expected expr)
+    false (= 2 1)
+    true  (= 1 1)
+    false (= 1 2)
+    false (= 1 (+ 1 1))
+    true  (= 2 (+ 1 1))
+    false (= nil 1)
+    true  (= nil nil)
+    true  (not= 2 1)
+    false (not= 1 1)
+    true  (not= 1 2)
+    true  (not= 1 (+ 1 1))
+    false (not= 2 (+ 1 1))
+    true  (not= nil 1)
+    false (not= nil nil)
+    true  (> 2 1)
+    false (> 1 1)
+    false (> 1 2)
+    true  (>= 2 1)
+    true  (>= 1 1)
+    false (>= 1 2)
+    false (< 2 1)
+    false (< 1 1)
+    true  (< 1 2)
+    false (<= 2 1)
+    true  (<= 1 1)
+    true  (<= 1 2)))
+
+(deftest equality-of-lists
+  (are [expected expr] (= expected expr)
+    true  (= (list) (list))
+    true  (= (list) ())
+    true  (= (list 1 2) (list 1 2))
+    false (= (list 1) (list))
+    false (= (list) (list 1))
+    false (= 0 (list))
+    false (= (list) 0)
+    false (= (list nil) (list))
+    false (not= (list) (list))
+    true  (not= (list 1) (list))))
+
+(deftest user-defined-functions-and-closures
+  (is (= 7 ((fn (a b) (+ b a)) 3 4)))
+  (is (= 4 ((fn () 4))))
+  (is (= 8 ((fn (f x) (f x)) (fn (a) (+ 1 a)) 7)))
+  (is (= 12 (((fn (a) (fn (b) (+ a b))) 5) 7)))
+  (def if-gen-plus5 (fn () (fn (b) (+ 5 b))))
+  (def if-plus5 (if-gen-plus5))
+  (is (= 12 (if-plus5 7)))
+  (def if-gen-plusX (fn (x) (fn (b) (+ x b))))
+  (def if-plus7 (if-gen-plusX 7))
+  (is (= 15 (if-plus7 8))))
+
+(def if-do-a nil)
+
+(deftest do-form
+  (is (= 14 (do (def if-do-a 6) 7 (+ if-do-a 8))))
+  (is (= nil (do)))
+  ;; special forms are case-sensitive: DO is an ordinary symbol
+  (def if-DO (fn (a) 7))
+  (is (= 7 (if-DO 3))))
+
+(deftest recursive-functions
+  (def if-sumdown (fn (N) (if (> N 0) (+ N (if-sumdown (- N 1))) 0)))
+  (is (= 1 (if-sumdown 1)))
+  (is (= 3 (if-sumdown 2)))
+  (is (= 21 (if-sumdown 6)))
+  (def if-fib (fn (N) (if (= N 0) 1 (if (= N 1) 1 (+ (if-fib (- N 1)) (if-fib (- N 2)))))))
+  (is (= 1 (if-fib 1)))
+  (is (= 2 (if-fib 2)))
+  (is (= 5 (if-fib 4))))
+
+(deftest recursive-functions-in-let
+  (is (= 3 (let (f (fn () x) x 3) (f))))
+  (is (= nil (let (cst (fn (n) (if (= n 0) nil (cst (- n 1))))) (cst 1))))
+  (is (= 0 (let (f (fn (n) (if (= n 0) 0 (g (- n 1)))) g (fn (n) (f n))) (f 2)))))
+
+;; -------- Deferrable Functionality --------
+
+(deftest string-truthiness-and-equality
+  (is (= 7 (if "" 7 8)))
+  (are [expected expr] (= expected expr)
+    true  (= "" "")
+    true  (= "abc" "abc")
+    false (= "abc" "")
+    false (= "" "abc")
+    false (= "abc" "def")
+    false (= "abc" "ABC")
+    false (= (list) "")
+    false (= "" (list))
+    false (not= "" "")
+    true  (not= "abc" "def")))
+
+(deftest variable-length-arguments
+  (are [expected expr] (= expected expr)
+    3    ((fn (& more) (count more)) 1 2 3)
+    true ((fn (& more) (list? more)) 1 2 3)
+    1    ((fn (& more) (count more)) 1)
+    0    ((fn (& more) (count more)))
+    true ((fn (& more) (list? more)))
+    2    ((fn (a & more) (count more)) 1 2 3)
+    0    ((fn (a & more) (count more)) 1)
+    true ((fn (a & more) (list? more)) 1)))
+
+(deftest not-function
+  (are [expected expr] (= expected expr)
+    true  (not false)
+    true  (not nil)
+    false (not true)
+    false (not "a")
+    false (not 0)))
+
+(deftest string-quoting
+  (are [expected expr] (= expected expr)
+    ""              ""
+    "abc"           "abc"
+    "abc  def"      "abc  def"
+    "\""            "\""
+    "abc\ndef\nghi" "abc\ndef\nghi"
+    "abc\\def\\ghi" "abc\\def\\ghi"
+    "\\n"           "\\n"))
+
+(deftest pr-str-function
+  (are [expected expr] (= expected expr)
+    ""                    (pr-str)
+    "\"\""                (pr-str "")
+    "\"abc\""             (pr-str "abc")
+    "\"abc  def\" \"ghi jkl\"" (pr-str "abc  def" "ghi jkl")
+    "\"\\\"\""            (pr-str "\"")
+    "(1 2 \"abc\" \"\\\"\") \"def\"" (pr-str (list 1 2 "abc" "\"") "def")
+    "\"abc\\ndef\\nghi\"" (pr-str "abc\ndef\nghi")
+    "\"abc\\\\def\\\\ghi\"" (pr-str "abc\\def\\ghi")
+    "()"                  (pr-str (list))))
+
+(deftest str-function
+  (are [expected expr] (= expected expr)
+    ""              (str)
+    ""              (str "")
+    "abc"           (str "abc")
+    "\""            (str "\"")
+    "1abc3"         (str 1 "abc" 3)
+    "abc  defghi jkl" (str "abc  def" "ghi jkl")
+    "abc\ndef\nghi" (str "abc\ndef\nghi")
+    "abc\\def\\ghi" (str "abc\\def\\ghi")
+    "(1 2 abc \")def" (str (list 1 2 "abc" "\"") "def")
+    "()"            (str (list))))
+
+(deftest keywords-equality
+  (are [expected expr] (= expected expr)
+    true  (= :abc :abc)
+    false (= :abc :def)
+    false (= :abc ":abc")
+    true  (= (list :abc) (list :abc))
+    false (not= :abc :abc)
+    true  (not= :abc :def)
+    true  (not= :abc ":abc")
+    false (not= (list :abc) (list :abc))))
+
+(deftest vector-truthiness-and-printing
+  (is (= 7 (if [] 7 8)))
+  (are [expected expr] (= expected expr)
+    "[1 2 \"abc\" \"\\\"\"] \"def\"" (pr-str [1 2 "abc" "\""] "def")
+    "[]"              (pr-str [])
+    "[1 2 abc \"]def" (str [1 2 "abc" "\""] "def")
+    "[]"              (str [])))
+
+(deftest vector-functions-and-equality
+  (are [expected expr] (= expected expr)
+    3     (count [1 2 3])
+    false (empty? [1 2 3])
+    true  (empty? [])
+    false (list? [4 5 6])
+    true  (= [] (list))
+    true  (= [7 8] [7 8])
+    true  (= [:abc] [:abc])
+    true  (= (list 1 2) [1 2])
+    false (= (list 1) [])
+    false (= [] [1])
+    false (= 0 [])
+    false (= [] 0)
+    false (= [] "")
+    false (= "" [])
+    false (not= [] (list))
+    true  (not= (list 1) [])))
+
+(deftest vector-parameter-lists
+  (is (= 4 ((fn [] 4))))
+  (is (= 8 ((fn [f x] (f x)) (fn [a] (+ 1 a)) 7))))
+
+(deftest nested-vector-list-equality
+  (is (= [(list)] (list [])))
+  (is (= [1 2 (list 3 4 [5 6])] (list 1 2 [3 4 (list 5 6)]))))
+
+(deftest empty-and-count-on-maps
+  (is (empty? nil))
+  ;; empty? on a string is invalid
+  (is (= :threw (try (empty? "hello") (catch e :threw))))
+  (is (empty? {}))
+  (def if-hm {})
+  (is (empty? if-hm))
+  (is (= 0 (count if-hm)))
+  (def if-hm2 {:a 1})
+  (is (= false (empty? if-hm2)))
+  (is (= 1 (count if-hm2)))
+  (def if-hm3 {:a 1 :b {}})
+  (is (= false (empty? if-hm3)))
+  (is (= 2 (count if-hm3))))

--- a/deftests/step5_tco_test.lisp
+++ b/deftests/step5_tco_test.lisp
@@ -1,0 +1,11 @@
+;; Replica of tests/step5_tco.mal: tail calls run in constant stack.
+
+(deftest tco-self-recursive
+  (def tco-sum2 (fn (n acc) (if (= n 0) acc (tco-sum2 (- n 1) (+ n acc)))))
+  (is (= 55 (tco-sum2 10 0)))
+  (is (= 50005000 (tco-sum2 10000 0))))
+
+(deftest tco-mutually-recursive
+  (def tco-foo (fn (n) (if (= n 0) 0 (tco-bar (- n 1)))))
+  (def tco-bar (fn (n) (if (= n 0) 0 (tco-foo (- n 1)))))
+  (is (= 0 (tco-foo 10000))))

--- a/deftests/step6_file_test.lisp
+++ b/deftests/step6_file_test.lisp
@@ -1,0 +1,105 @@
+;; Replica of tests/step6_file.mal: read-string, slurp, load-file and
+;; atoms. File paths are relative to the repository root, like the
+;; originals: run the suite from there (TestDeftests does).
+
+(deftest do-not-broken-by-tco
+  (is (= 2 (do (do 1 2)))))
+
+(deftest read-string-basics
+  (is (= (quote (1 2 (3 4) nil)) (read-string "(1 2 (3 4) nil)")))
+  (is (= nil (read-string "nil")))
+  (is (= (quote (+ 2 3)) (read-string "(+ 2 3)")))
+  ;; a "…" string may contain a literal newline (Clojure-style)
+  (is (= "\n" (read-string "\"\n\"")))
+  (is (= 7 (read-string "7 ;; comment")))
+  (is (= 5 (eval (read-string "(+ 2 3)")))))
+
+(deftest slurp-file
+  (is (= "A line of text\n" (slurp "./tests/test.txt")))
+  ;; slurping the same file twice works
+  (is (= "A line of text\n" (slurp "./tests/test.txt"))))
+
+(deftest load-file-defs
+  (is (= "(fn (a) (do (+ 3 a)))" (pr-str (load-file "./tests/inc.mal"))))
+  (is (= 8 (inc1 7)))
+  (is (= 9 (inc2 7)))
+  (is (= 12 (inc3 9))))
+
+(deftest atoms-basics
+  (def file-a (atom 2))
+  (is (= "«atom 2»" (pr-str file-a)))
+  (is (atom? file-a))
+  (is (= false (atom? 1)))
+  (is (= 2 (deref file-a)))
+  (is (= 3 (reset! file-a 3)))
+  (is (= 3 (deref file-a)))
+  (def file-inc3 (fn (a) (+ 3 a)))
+  (is (= 6 (swap! file-a file-inc3)))
+  (is (= 6 (deref file-a)))
+  (is (= 6 (swap! file-a (fn (a) a))))
+  (is (= 12 (swap! file-a (fn (a) (* 2 a)))))
+  (is (= 120 (swap! file-a (fn (a b) (* a b)) 10)))
+  (is (= 123 (swap! file-a + 3))))
+
+(deftest atoms-and-closures
+  (def file-inc-it (fn (a) (+ 1 a)))
+  (def file-atm (atom 7))
+  (def file-f (fn () (swap! file-atm file-inc-it)))
+  (is (= 8 (file-f)))
+  (is (= 9 (file-f)))
+  ;; closures retain their own atoms
+  (def file-g (let (atm (atom 0)) (fn () (deref atm))))
+  (def file-atm2 (atom 1))
+  (is (= 0 (file-g))))
+
+;; -------- Deferrable Functionality --------
+
+(deftest load-file-large
+  (load-file "./tests/computations.mal")
+  (is (= 3 (sumdown 2)))
+  (is (= 1 (fib 2))))
+
+(deftest deref-reader-macro
+  (def file-atm3 (atom 9))
+  (is (= 9 @file-atm3)))
+
+(deftest vector-params-not-broken-by-tco
+  (def file-g2 (fn [] 78))
+  (is (= 78 (file-g2)))
+  (def file-g3 (fn [a] (+ a 78)))
+  (is (= 81 (file-g3 3))))
+
+(deftest argv-exists
+  (is (list? *ARGV*)))
+
+;; eval evaluates in the root environment, so the reference def must be
+;; top-level (a def inside a deftest body binds in the test's local env)
+(def file-a2 1)
+
+(deftest eval-defines-in-root-scope
+  (is (= 7 (let (b 12) (do (eval (read-string "(def file-aa 7)")) file-aa))))
+  ;; eval does not use local environments
+  (is (= 1 (let (file-a2 2) (eval (read-string "file-a2"))))))
+
+;; -------- Optional Functionality --------
+
+(deftest load-file-with-comments
+  (is (= "(fn (a) (do (+ 5 a)))" (pr-str (load-file "./tests/incB.mal"))))
+  (is (= 11 (inc4 7)))
+  (is (= 12 (inc5 7)))
+  (is (= {"a" 1} (load-file "./tests/incC.mal")))
+  (is (= {"a" 1} mymap)))
+
+(deftest read-string-comment-characters
+  (are [src] (= 1 (read-string src))
+    "1;!"
+    "1;\""
+    "1;#"
+    "1;$"
+    "1;%"
+    "1;'"
+    "1;\\"
+    "1;\\\\"
+    "1;\\\\\\"
+    "1;`"
+    "1; &()*+,-./:;<=>?@[]^_{|}~"))

--- a/deftests/step7_quote_test.lisp
+++ b/deftests/step7_quote_test.lisp
@@ -1,0 +1,203 @@
+;; Replica of tests/step7_quote.mal: cons, concat, quote, quasiquote,
+;; unquote, splice-unquote, vec and quasiquoteexpand.
+
+(deftest cons-function
+  (are [expected expr] (= expected expr)
+    (quote (1))       (cons 1 (list))
+    (quote (1 2))     (cons 1 (list 2))
+    (quote (1 2 3))   (cons 1 (list 2 3))
+    (quote ((1) 2 3)) (cons (list 1) (list 2 3)))
+  (def quote-a1 (list 2 3))
+  (is (= (quote (1 2 3)) (cons 1 quote-a1)))
+  ;; cons does not mutate its argument
+  (is (= (quote (2 3)) quote-a1)))
+
+(deftest concat-function
+  (are [expected expr] (= expected expr)
+    ()                    (concat)
+    (quote (1 2))         (concat (list 1 2))
+    (quote (1 2 3 4))     (concat (list 1 2) (list 3 4))
+    (quote (1 2 3 4 5 6)) (concat (list 1 2) (list 3 4) (list 5 6))
+    ()                    (concat (concat))
+    ()                    (concat (list) (list)))
+  (is (= () (concat)))
+  (is (= false (not= () (concat))))
+  (def quote-a2 (list 1 2))
+  (def quote-b2 (list 3 4))
+  (is (= (quote (1 2 3 4 5 6)) (concat quote-a2 quote-b2 (list 5 6))))
+  ;; concat does not mutate its arguments
+  (is (= (quote (1 2)) quote-a2))
+  (is (= (quote (3 4)) quote-b2)))
+
+(deftest quote-basics
+  (is (= 7 (quote 7)))
+  (is (= (list 1 2 3) (quote (1 2 3))))
+  (is (= (list 1 2 (list 3 4)) (quote (1 2 (3 4))))))
+
+(deftest quasiquote-simple
+  (are [expected expr] (= expected expr)
+    nil (quasiquote nil)
+    7   (quasiquote 7))
+  (is (= (quote a) (quasiquote a)))
+  (is (= (quote {"a" b}) (quasiquote {"a" b}))))
+
+(deftest quasiquote-lists
+  (are [expected expr] (= expected expr)
+    ()                     (quasiquote ())
+    (quote (1 2 3))        (quasiquote (1 2 3))
+    (quote (a))            (quasiquote (a))
+    (quote (1 2 (3 4)))    (quasiquote (1 2 (3 4)))
+    (quote (nil))          (quasiquote (nil))
+    (quote (1 ()))         (quasiquote (1 ()))
+    (quote (() 1))         (quasiquote (() 1))
+    (quote (1 () 2))       (quasiquote (1 () 2))
+    (quote (()))           (quasiquote (()))))
+
+(def quote-ua 8)
+(def quote-ub (quote (1 "b" "d")))
+
+(deftest unquote-basics
+  (is (= 7 (quasiquote (unquote 7))))
+  (is (= (quote quote-ua) (quasiquote quote-ua)))
+  (is (= 8 (quasiquote (unquote quote-ua))))
+  (is (= (quote (1 quote-ua 3)) (quasiquote (1 quote-ua 3))))
+  (is (= (quote (1 8 3)) (quasiquote (1 (unquote quote-ua) 3))))
+  (is (= (quote (1 quote-ub 3)) (quasiquote (1 quote-ub 3))))
+  (is (= (quote (1 (1 "b" "d") 3)) (quasiquote (1 (unquote quote-ub) 3))))
+  (is (= (quote (1 2)) (quasiquote ((unquote 1) (unquote 2)))))
+  ;; quasiquote and environments
+  (is (= 0 (let (x 0) (quasiquote (unquote x))))))
+
+(def quote-uc (quote (1 "b" "d")))
+
+(deftest splice-unquote-basics
+  (is (= (quote (1 quote-uc 3)) (quasiquote (1 quote-uc 3))))
+  (is (= (quote (1 1 "b" "d" 3)) (quasiquote (1 (splice-unquote quote-uc) 3))))
+  (is (= (quote (1 1 "b" "d")) (quasiquote (1 (splice-unquote quote-uc)))))
+  (is (= (quote (1 "b" "d" 2)) (quasiquote ((splice-unquote quote-uc) 2))))
+  (is (= (quote (1 "b" "d" 1 "b" "d")) (quasiquote ((splice-unquote quote-uc) (splice-unquote quote-uc))))))
+
+(deftest symbol-equality
+  (are [expected expr] (= expected expr)
+    true  (= (quote abc) (quote abc))
+    false (= (quote abc) (quote abcd))
+    false (= (quote abc) "abc")
+    false (= "abc" (quote abc))
+    true  (= "abc" (str (quote abc)))
+    false (= (quote abc) nil)
+    false (= nil (quote abc))))
+
+;; -------- Deferrable Functionality --------
+
+(deftest quote-reader-macro
+  (is (= 7 '7))
+  (is (= (list 1 2 3) '(1 2 3)))
+  (is (= (list 1 2 (list 3 4)) '(1 2 (3 4)))))
+
+(deftest cons-concat-with-vectors
+  (are [expected expr] (= expected expr)
+    (quote (1))       (cons 1 [])
+    (quote ([1] 2 3)) (cons [1] [2 3])
+    (quote (1 2 3))   (cons 1 [2 3])
+    (quote (1 2 3 4 5 6)) (concat [1 2] (list 3 4) [5 6])
+    (quote (1 2))     (concat [1 2])))
+
+;; -------- Optional Functionality --------
+
+(deftest quasiquote-reader-macros
+  (is (= 7 `7))
+  (is (= (quote (1 2 3)) `(1 2 3)))
+  (is (= (quote (1 2 (3 4))) `(1 2 (3 4))))
+  (is (= (quote (nil)) `(nil)))
+  (is (= 7 `~7))
+  (is (= (quote (1 8 3)) `(1 ~quote-ua 3)))
+  (is (= (quote (1 quote-ub 3)) `(1 quote-ub 3)))
+  (is (= (quote (1 (1 "b" "d") 3)) `(1 ~quote-ub 3)))
+  (is (= (quote (1 quote-uc 3)) `(1 quote-uc 3)))
+  (is (= (quote (1 1 "b" "d" 3)) `(1 ~@quote-uc 3))))
+
+(deftest vec-function
+  (are [expected expr] (= expected expr)
+    []    (vec (list))
+    [1]   (vec (list 1))
+    [1 2] (vec (list 1 2))
+    []    (vec [])
+    [1 2] (vec [1 2]))
+  ;; vec does not mutate the original list
+  (def quote-va (list 1 2))
+  (is (= [1 2] (vec quote-va)))
+  (is (= (quote (1 2)) quote-va)))
+
+(deftest quine
+  (def quote-quine (quote ((fn (q) (quasiquote ((unquote q) (quote (unquote q))))) (quote (fn (q) (quasiquote ((unquote q) (quote (unquote q)))))))))
+  (is (= quote-quine (eval quote-quine))))
+
+(deftest quasiquote-with-vectors
+  (are [expected expr] (= expected expr)
+    []   (quasiquote [])
+    [[]] (quasiquote [[]])
+    [()] (quasiquote [()])
+    (quote ([])) (quasiquote ([]))
+    (quote [1 a 3]) `[1 a 3]
+    (quote [a [] b [c] d [e f] g]) (quasiquote [a [] b [c] d [e f] g])
+    [8]           `[~quote-ua]
+    (quote [(8)]) `[(~quote-ua)]
+    (quote ([8])) `([~quote-ua])
+    (quote [a 8 a]) `[a ~quote-ua a]
+    (quote ([a 8 a])) `([a ~quote-ua a])
+    (quote [(a 8 a)]) `[(a ~quote-ua a)]
+    (quote [1 "b" "d"])     `[~@quote-uc]
+    (quote [(1 "b" "d")])   `[(~@quote-uc)]
+    (quote ([1 "b" "d"]))   `([~@quote-uc])
+    (quote [1 1 "b" "d" 3]) `[1 ~@quote-uc 3]
+    (quote ([1 1 "b" "d" 3])) `([1 ~@quote-uc 3])
+    (quote [(1 1 "b" "d" 3)]) `[(1 ~@quote-uc 3)]))
+
+(deftest misplaced-unquote
+  (is (= (quote (0 unquote)) `(0 unquote)))
+  (is (= (quote (0 splice-unquote)) `(0 splice-unquote)))
+  (is (= (quote [unquote 0]) `[unquote 0]))
+  (is (= (quote [splice-unquote 0]) `[splice-unquote 0])))
+
+(deftest quasiquoteexpand-forms
+  (are [expected expr] (= expected expr)
+    nil (quasiquoteexpand nil)
+    7   (quasiquoteexpand 7)
+    (quote (quote a))       (quasiquoteexpand a)
+    (quote (quote {"a" b})) (quasiquoteexpand {"a" b})
+    ()  (quasiquoteexpand ())
+    (quote (cons 1 (cons 2 (cons 3 ()))))  (quasiquoteexpand (1 2 3))
+    (quote (cons (quote a) ()))            (quasiquoteexpand (a))
+    (quote (cons 1 (cons 2 (cons (cons 3 (cons 4 ())) ())))) (quasiquoteexpand (1 2 (3 4)))
+    (quote (cons nil ()))                  (quasiquoteexpand (nil))
+    (quote (cons 1 (cons () ())))          (quasiquoteexpand (1 ()))
+    (quote (cons () (cons 1 ())))          (quasiquoteexpand (() 1))
+    (quote (cons 1 (cons () (cons 2 ())))) (quasiquoteexpand (1 () 2))
+    (quote (cons () ()))                   (quasiquoteexpand (()))
+    7 (quasiquoteexpand (unquote 7))
+    (quote a) (quasiquoteexpand (unquote a))
+    (quote (cons 1 (cons (quote a) (cons 3 ()))))  (quasiquoteexpand (1 a 3))
+    (quote (cons 1 (cons a (cons 3 ()))))          (quasiquoteexpand (1 (unquote a) 3))
+    (quote (cons 1 (cons (quote b) (cons 3 ())))) (quasiquoteexpand (1 b 3))
+    (quote (cons 1 (cons b (cons 3 ()))))         (quasiquoteexpand (1 (unquote b) 3))
+    (quote (cons 1 (cons 2 ())))                  (quasiquoteexpand ((unquote 1) (unquote 2)))
+    (quote (cons (quote a) (concat (b c) (cons (quote d) ())))) (quasiquoteexpand (a (splice-unquote (b c)) d))
+    (quote (cons 1 (cons (quote c) (cons 3 ())))) (quasiquoteexpand (1 c 3))
+    (quote (cons 1 (concat c (cons 3 ()))))       (quasiquoteexpand (1 (splice-unquote c) 3))
+    (quote (cons 1 (concat c ())))                (quasiquoteexpand (1 (splice-unquote c)))
+    (quote (concat c (cons 2 ())))                (quasiquoteexpand ((splice-unquote c) 2))
+    (quote (concat c (concat c ())))              (quasiquoteexpand ((splice-unquote c) (splice-unquote c)))
+    (quote (vec ()))                              (quasiquoteexpand [])
+    (quote (vec (cons (vec ()) ())))              (quasiquoteexpand [[]])
+    (quote (vec (cons () ())))                    (quasiquoteexpand [()])
+    (quote (cons (vec ()) ()))                    (quasiquoteexpand ([]))
+    (quote (vec (cons 1 (cons (quote a) (cons 3 ()))))) (quasiquoteexpand [1 a 3])))
+
+(deftest vec-on-sets
+  (is (= [] (vec #{})))
+  (is (= [:a] (vec #{:a})))
+  (is (= (set (vec #{:a :b})) #{:a :b}))
+  (is (= (set (vec #{:a :b :c :d})) #{:a :b :c :d}))
+  (is (= ["a"] (vec #{"a"})))
+  (is (= (set (vec #{"a" "b"})) #{"a" "b"}))
+  (is (= (set (vec #{"a" "b" "c" "d"})) #{"a" "b" "c" "d"})))

--- a/deftests/step8_macros_test.lisp
+++ b/deftests/step8_macros_test.lisp
@@ -1,0 +1,101 @@
+;; Replica of tests/step8_macros.mal: macro definition, macroexpand,
+;; cond, and nth/first/rest.
+
+(deftest macros-trivial
+  (defmacro macros-one (fn () 1))
+  (is (= 1 (macros-one)))
+  (defmacro macros-two (fn () 2))
+  (is (= 2 (macros-two))))
+
+(deftest macros-unless
+  (defmacro macros-unless (fn (pred a b) `(if ~pred ~b ~a)))
+  (is (= 7 (macros-unless false 7 8)))
+  (is (= 8 (macros-unless true 7 8)))
+  (defmacro macros-unless2 (fn (pred a b) (list (quote if) (list (quote not) pred) a b)))
+  (is (= 7 (macros-unless2 false 7 8)))
+  (is (= 8 (macros-unless2 true 7 8))))
+
+(deftest macros-macroexpand
+  (defmacro macros-one2 (fn () 1))
+  (is (= 1 (macroexpand (macros-one2))))
+  (defmacro macros-unless3 (fn (pred a b) `(if ~pred ~b ~a)))
+  (is (= (quote (if PRED B A)) (macroexpand (macros-unless3 PRED A B))))
+  (defmacro macros-unless4 (fn (pred a b) (list (quote if) (list (quote not) pred) a b)))
+  (is (= (quote (if (not PRED) A B)) (macroexpand (macros-unless4 PRED A B))))
+  (is (= (quote (if (not 2) 3 4)) (macroexpand (macros-unless4 2 3 4)))))
+
+(deftest macros-result-is-evaluated
+  (defmacro macros-identity (fn (x) x))
+  (is (= (quote a) (let (a 123) (macroexpand (macros-identity a)))))
+  (is (= 123 (let (a 123) (macros-identity a)))))
+
+(deftest macros-do-not-break-basics
+  (is (= () ()))
+  (is (list? ()))
+  (is (= (quote (1)) `(1))))
+
+;; -------- Deferrable Functionality --------
+
+(deftest not-is-a-function
+  (is (= false (not (= 1 1))))
+  (is (= true (not (not= 1 1))))
+  (is (= true (not (= 1 2))))
+  (is (= false (not (not= 1 2)))))
+
+(deftest nth-first-rest-lists
+  (are [expected expr] (= expected expr)
+    1   (nth (list 1) 0)
+    2   (nth (list 1 2) 1)
+    nil (nth (list 1 2 nil) 2)
+    nil (first (list))
+    6   (first (list 6))
+    7   (first (list 7 8 9))
+    ()  (rest (list))
+    ()  (rest (list 6))
+    (quote (8 9)) (rest (list 7 8 9)))
+  ;; nth out of range throws and aborts the def
+  (def macros-x "x")
+  (is (= :threw (try (def macros-x (nth (list 1 2) 2)) (catch e :threw))))
+  (is (= "x" macros-x)))
+
+(deftest cond-macro
+  (is (= nil (macroexpand (cond))))
+  (is (= nil (cond)))
+  (is (= (quote (if X Y (cond))) (macroexpand (cond X Y))))
+  (are [expected expr] (= expected expr)
+    7   (cond true 7)
+    nil (cond false 7)
+    7   (cond true 7 true 8)
+    8   (cond false 7 true 8)
+    9   (cond false 7 false 8 "else" 9)
+    8   (cond false 7 (= 2 2) 8 "else" 9)
+    nil (cond false 7 false 8 false 9))
+  (is (= (quote (if X Y (cond Z T))) (macroexpand (cond X Y Z T))))
+  (is (= "yes" (let (x (cond false "no" true "yes")) x)))
+  (is (= "yes" (let [x (cond false "no" true "yes")] x))))
+
+(deftest nth-first-rest-vectors
+  (are [expected expr] (= expected expr)
+    1   (nth [1] 0)
+    2   (nth [1 2] 1)
+    nil (nth [1 2 nil] 2)
+    nil (first [])
+    nil (first nil)
+    10  (first [10])
+    10  (first [10 11 12])
+    ()  (rest [])
+    ()  (rest nil)
+    ()  (rest [10])
+    (quote (11 12)) (rest [10 11 12])
+    (quote (11 12)) (rest (cons 10 [11 12])))
+  (def macros-x2 "x")
+  (is (= :threw (try (def macros-x2 (nth [1 2] 2)) (catch e :threw))))
+  (is (= "x" macros-x2)))
+
+;; ------- Optional Functionality --------------
+
+(deftest macros-use-closures
+  (def macros-closure-x 2)
+  (defmacro macros-a (fn [] macros-closure-x))
+  (is (= 2 (macros-a)))
+  (is (= 2 (let (macros-closure-x 3) (macros-a)))))

--- a/deftests/step9_gocompat_test.lisp
+++ b/deftests/step9_gocompat_test.lisp
@@ -1,0 +1,62 @@
+;; Replica of tests/step9_gocompat.mal: go errors, wrapping, panic and
+;; type?. The «go-error …» literal expectations become value/pr-str
+;; checks (the literals themselves need an environment-aware reader).
+
+(deftest gocompat-catch-values
+  (is (= "sample" (try (throw "sample") (catch err err))))
+  (is (= "string" (try (throw "sample") (catch err (type? err)))))
+  (is (= {:a 1} (try (throw {:a 1}) (catch err err)))))
+
+(deftest gocompat-wrapped-errors
+  (def gocompat-thrower (fn [] (throw (go-error "wrapped %w" (go-error "sample")))))
+  (is (= :threw (try (gocompat-thrower) (catch err :threw))))
+  (is (= "«go-error \"wrapped sample\"»" (pr-str (try (gocompat-thrower) (catch err err)))))
+  (is (= "«go-error \"wrapped sample\"»" (try (gocompat-thrower) (catch err (str err)))))
+  (is (= "go-error" (type? (try (gocompat-thrower) (catch err err)))))
+  (is (= :threw (try (throw 9) (catch err :threw)))))
+
+(deftest gocompat-go-error-construction
+  (is (= "«go-error \"simple\"»" (pr-str (go-error "simple"))))
+  (is (= "«go-error \"simple wrapped\"»" (pr-str (go-error "simple %s" (go-error "wrapped")))))
+  (is (= "«go-error \"simple wrapped\"»" (pr-str (go-error "simple %w" (go-error "wrapped")))))
+  ;; %w wraps (unwrap-error recovers the cause), %s does not
+  (def gocompat-compo-err (go-error "simple %w" (go-error "wrapped")))
+  (is (= "«go-error \"wrapped\"»" (pr-str (unwrap-error gocompat-compo-err))))
+  (def gocompat-non-compo-err (go-error "simple %s" (go-error "wrapped")))
+  (is (= nil (unwrap-error gocompat-non-compo-err))))
+
+(deftest gocompat-throw-go-errors
+  (def gocompat-compo-err2 (go-error "simple %w" (go-error "wrapped")))
+  (is (= "«go-error \"simple wrapped\"»" (pr-str (try (throw gocompat-compo-err2) (catch err err)))))
+  (is (= "«go-error \"simple wrapped\"»" (try (throw gocompat-compo-err2) (catch err (str err)))))
+  (is (= "«go-error \"wrapped\"»" (pr-str (try (throw gocompat-compo-err2) (catch err (unwrap-error err)))))))
+
+(deftest gocompat-panic
+  (is (= "simple" (try (panic "simple") (catch e e))))
+  (is (= "«go-error \"github.com/jig/lisp/lib/core[panic]: simple\"»" (pr-str (try (panic (go-error "simple")) (catch e e)))))
+  (is (= "«go-error \"simple\"»" (pr-str (unwrap-error (try (panic (go-error "simple")) (catch e e))))))
+  (is (= 3 (try (panic 3) (catch e e)))))
+
+(deftest gocompat-type-predicate
+  (are [expected expr] (= expected expr)
+    "nil"         (type? nil)
+    "boolean"     (type? false)
+    "keyword"     (type? :idx)
+    "integer"     (type? 3)
+    "string"      (type? "hello 世界!")
+    "atom"        (type? (atom 3))
+    "future-call" (type? (future 3))
+    "integer"     (type? (try (throw 3) (catch e e)))
+    "list"        (type? (quote (1 2 3)))
+    "hash-map"    (type? {:a 1 :b 2 :c 3})
+    "vector"      (type? [0 1 :c []])
+    "set"         (type? #{:a :b})
+    "integer"     (type? (try (panic 3) (catch e e)))
+    "go-error"    (type? (go-error "pum"))
+    "go-error"    (type? (go-error "pum %s" (go-error "pum!")))
+    "go-error"    (type? (go-error "pum %w" (go-error "pum!")))
+    "function"    (type? (fn [] 0))
+    "go-function" (type? type?)
+    "string"      (type? (try (panic "simple") (catch err err))))
+  (def gocompat-zero 0)
+  (is (= "symbol" (type? (quote gocompat-zero)))))

--- a/deftests/step9_try_test.lisp
+++ b/deftests/step9_try_test.lisp
@@ -1,0 +1,218 @@
+;; Replica of tests/step9_try.mal: try/catch/finally, apply, map,
+;; predicates, hash-maps and the issue-#87 regressions. Cases asserting
+;; prn output stay in the legacy harness.
+
+(deftest try-catch-basics
+  (is (= 123 (try 123 (catch e 456))))
+  (is (= :caught (try abc (catch exc :caught))))
+  (is (= :caught (try (abc 1 2) (catch exc :caught))))
+  ;; errors from core builtins can be caught
+  (is (= :caught (try (nth () 1) (catch exc :caught))))
+  (is (= 7 (try (throw "my exception") (catch exc (do (str "exc:" exc) 7))))))
+
+(deftest try-handlers-restore
+  (is (= "c2" (try (do (try "t1" (catch e "c1")) (throw "e1")) (catch e "c2"))))
+  (is (= "c2" (try (try (throw "e1") (catch e (throw "e2"))) (catch e "c2")))))
+
+(deftest throw-is-a-function
+  (is (= "my err" (try (map throw (list "my err")) (catch exc exc)))))
+
+(deftest type-predicates
+  (are [expected expr] (= expected expr)
+    true  (symbol? (quote abc))
+    false (symbol? "abc")
+    true  (nil? nil)
+    false (nil? true)
+    true  (true? true)
+    false (true? false)
+    false (true? true?)
+    true  (false? false)
+    false (false? true)))
+
+(deftest apply-function
+  (are [expected expr] (= expected expr)
+    5    (apply + (list 2 3))
+    9    (apply + 4 (list 5))
+    ()   (apply list (list))
+    true (apply symbol? (list (quote two)))
+    5    (apply (fn (a b) (+ a b)) (list 2 3))
+    9    (apply (fn (a b) (+ a b)) 4 (list 5))
+    9    (apply + 4 [5])
+    ()   (apply list [])
+    5    (apply (fn (a b) (+ a b)) [2 3])
+    9    (apply (fn (a b) (+ a b)) 4 [5])))
+
+(deftest map-function
+  (def try-nums (list 1 2 3))
+  (def try-double (fn (a) (* 2 a)))
+  (is (= 6 (try-double 3)))
+  (is (= (quote (2 4 6)) (map try-double try-nums)))
+  (is (= (quote (false true false)) (map (fn (x) (symbol? x)) (list 1 (quote two) "three"))))
+  (is (= () (map str ())))
+  (is (= (quote (2 4 6)) (map (fn (a) (* 2 a)) [1 2 3])))
+  (is (= (quote (true true)) (map (fn [& args] (list? args)) [1 2]))))
+
+;; -------- Deferrable Functionality --------
+
+(deftest symbol-keyword-constructors
+  (are [expected expr] (= expected expr)
+    false (symbol? :abc)
+    true  (symbol? (quote abc))
+    true  (symbol? (symbol "abc"))
+    true  (keyword? :abc)
+    false (keyword? (quote abc))
+    false (keyword? "abc")
+    false (keyword? "")
+    true  (keyword? (keyword "abc")))
+  (is (= (quote abc) (symbol "abc")))
+  (is (= :abc (keyword "abc"))))
+
+(deftest sequential-predicate
+  (are [expected expr] (= expected expr)
+    true  (sequential? (list 1 2 3))
+    true  (sequential? [15])
+    false (sequential? sequential?)
+    false (sequential? nil)
+    false (sequential? "abc")))
+
+(deftest vector-constructors
+  (are [expected expr] (= expected expr)
+    true  (vector? [10 11])
+    false (vector? (quote (12 13)))
+    [3 4 5] (vector 3 4 5)
+    true  (= [] (vector))
+    true  (map? {})
+    false (map? (quote ()))
+    false (map? [])
+    false (map? (quote abc))
+    false (map? :abc)))
+
+(deftest hash-map-basics
+  (is (= {"a" 1} (hash-map "a" 1)))
+  (is (= {"a" 1} {"a" 1}))
+  (is (= {"a" 1} (assoc {} "a" 1)))
+  (is (= 1 (get (assoc (assoc {"a" 1} "b" 2) "c" 3) "a")))
+  (def try-hm1 (hash-map))
+  (is (= {} try-hm1))
+  (is (map? try-hm1))
+  (is (= false (map? 1)))
+  (is (= false (map? "abc")))
+  (is (= nil (get nil "a")))
+  (is (= nil (get try-hm1 "a")))
+  (is (= false (contains? try-hm1 "a")))
+  (def try-hm2 (assoc try-hm1 "a" 1))
+  (is (= {"a" 1} try-hm2))
+  ;; the original map is unchanged
+  (is (= nil (get try-hm1 "a")))
+  (is (= false (contains? try-hm1 "a")))
+  (is (= 1 (get try-hm2 "a")))
+  (is (contains? try-hm2 "a")))
+
+(deftest hash-map-keys-vals
+  (def try-hm1b (hash-map))
+  (def try-hm2b (assoc try-hm1b "a" 1))
+  (is (= () (keys try-hm1b)))
+  (is (= (quote ("a")) (keys try-hm2b)))
+  (is (= (quote ("1")) (keys {"1" 1})))
+  (is (= () (vals try-hm1b)))
+  (is (= (quote (1)) (vals try-hm2b)))
+  (is (= 3 (count (keys (assoc try-hm2b "b" 2 "c" 3))))))
+
+(deftest hash-map-keyword-keys
+  (is (= 123 (get {:abc 123} :abc)))
+  (is (contains? {:abc 123} :abc))
+  (is (= false (contains? {:abcd 123} :abc)))
+  (is (= {:bcd 234} (assoc {} :bcd 234)))
+  (is (keyword? (nth (keys {:abc 123 :def 456}) 0)))
+  (is (keyword? (nth (vals {"a" :abc "b" :def}) 0))))
+
+(deftest hash-map-assoc-updates
+  (def try-hm4 (assoc {:a 1 :b 2} :a 3 :c 1))
+  (are [expected key] (= expected (get try-hm4 key))
+    3 :a
+    2 :b
+    1 :c))
+
+(deftest hash-map-nil-values
+  (is (contains? {:abc nil} :abc))
+  (is (= {:bcd nil} (assoc {} :bcd nil))))
+
+(deftest str-pr-str-on-maps
+  (is (= "A{:abc val}Z" (str "A" {:abc "val"} "Z")))
+  (is (= "true.false.nil.:keyw.symb" (str true "." false "." nil "." :keyw "." (quote symb))))
+  (is (= "\"A\" {:abc \"val\"} \"Z\"" (pr-str "A" {:abc "val"} "Z")))
+  (is (= "true \".\" false \".\" nil \".\" :keyw \".\" symb" (pr-str true "." false "." nil "." :keyw "." (quote symb))))
+  ;; multi-key print order is unstable: accept either
+  (def try-s (str {:abc "val1" :def "val2"}))
+  (is (or (= try-s "{:abc val1 :def val2}") (= try-s "{:def val2 :abc val1}")))
+  (def try-p (pr-str {:abc "val1" :def "val2"}))
+  (is (or (= try-p "{:abc \"val1\" :def \"val2\"}") (= try-p "{:def \"val2\" :abc \"val1\"}"))))
+
+(deftest apply-with-mal-list-args
+  (is (= true (apply (fn (& more) (list? more)) [1 2 3])))
+  (is (= true (apply (fn (& more) (list? more)) [])))
+  (is (= true (apply (fn (a & more) (list? more)) [1]))))
+
+;; -------- Optional Functionality --------
+
+(deftest throw-non-strings
+  (is (= {:msg "err2"} (try (throw {:msg "err2"}) (catch e e))))
+  (is (= 7 (try (throw (list 1 2 3)) (catch exc (do (str "err:" exc) 7)))))
+  ;; try without catch propagates
+  (is (= :threw (try (try xyz) (catch e :threw)))))
+
+(deftest hash-map-dissoc
+  (def try-hm3 (assoc (assoc (hash-map) "a" 1) "b" 2))
+  (is (= 2 (count (keys try-hm3))))
+  (is (= 2 (count (vals try-hm3))))
+  (is (= {"b" 2} (dissoc try-hm3 "a")))
+  (is (= {} (dissoc try-hm3 "a" "b")))
+  (is (= {} (dissoc try-hm3 "a" "b" "c")))
+  (is (= 2 (count (keys try-hm3))))
+  (is (= {:fgh 456} (dissoc {:cde 345 :fgh 456} :cde)))
+  (is (= {:fgh 456} (dissoc {:cde nil :fgh 456} :cde))))
+
+(deftest hash-map-equality
+  (are [expected expr] (= expected expr)
+    true  (= {} {})
+    true  (= {} (hash-map))
+    true  (= {:a 11 :b 22} (hash-map :b 22 :a 11))
+    false (= {:a 12 :b 22} (hash-map :b 22 :a 11))
+    false (= {:c 11 :b 22} (hash-map :b 22 :a 11))
+    true  (= {:a 11 :b [22 33]} (hash-map :b [22 33] :a 11))
+    true  (= {:a 11 :b {:c 33}} (hash-map :b {:c 33} :a 11))
+    false (= {:a 11 :b 22} (hash-map :b 23 :a 11))
+    false (= {:a 11 :b 22} (hash-map :a 11))
+    true  (= {:a [11 22]} {:a (list 11 22)})
+    false (= {:a 11 :b 22} (list :a 11 :b 22))
+    false (= {} [])
+    false (= [] {})))
+
+(deftest try-does-not-require-do
+  (is (= 7 (try 1 2 (let [x 3] x) (throw "my exception") (catch exc 4 (let [x 5] x) 6 7))))
+  (is (= true (try 1 2 3 true))))
+
+(deftest try-catch-finally
+  (def try-fin (atom false))
+  (is (= 123 (try 123 (catch e 456) (finally (reset! try-fin true)))))
+  (is (= 1 (try (let [x 1] x) (finally (reset! try-fin false)))))
+  (is (= 2 (try (let [x 1] x) (let [x 2] x) (finally (reset! try-fin true)))))
+  ;; finally cannot throw errors
+  (is (= 2 (try (let [x 1] x) (let [x 2] x) (finally (throw "poum!"))))))
+
+(deftest rethrow-from-catch
+  (is (= :outer (try (try (throw 2) (catch err (throw 3))) (catch e :outer))))
+  (is (= 3 (try (try (throw 2) (catch err (throw 3))) (catch err err))))
+  (is (= :caught (try (/ 0 0) (catch e :caught))))
+  (is (= 2 (try (throw 1) (catch e (+ e 1)))))
+  (is (= "err:2" (try (throw 2) (catch e (str "err:" e))))))
+
+;; The catch result is a value, not code (issue #87)
+(deftest catch-result-not-reevaluated
+  (is (= {:v (quote (+ 1 2))} (try (throw "x") (catch e {:v (quote (+ 1 2))}))))
+  (is (= (quote (str "hi")) (try (throw "x") (catch e (quote (str "hi"))))))
+  (is (= "boom" (get (try (throw "boom") (catch e {:op (quote (throw "boom")) :error (str e)})) :error)))
+  (is (= (quote (throw "boom")) (get (try (throw "boom") (catch e {:op (quote (throw "boom")) :error (str e)})) :op))))
+
+(deftest recur-from-catch-tail
+  (is (= 3 (loop [i 0] (try (if (< i 3) (throw "again") i) (catch e (recur (inc i))))))))

--- a/deftests/stepA_mal_test.lisp
+++ b/deftests/stepA_mal_test.lisp
@@ -1,0 +1,159 @@
+;; Replica of tests/stepA_mal.mal: host-language, atoms as envs,
+;; metadata, predicates, conj, seq and time-ms.
+
+(deftest host-language
+  (is (= false (= "something bogus" *host-language*))))
+
+(deftest hash-map-evaluation-and-atoms
+  (def malA-e (atom {"+" +}))
+  (swap! malA-e assoc "-" -)
+  (is (= 15 ((get @malA-e "+") 7 8)))
+  (is (= 3 ((get @malA-e "-") 11 8)))
+  (swap! malA-e assoc "foo" (list))
+  (is (= () (get @malA-e "foo")))
+  (swap! malA-e assoc "bar" (quote (1 2 3)))
+  (is (= (quote (1 2 3)) (get @malA-e "bar"))))
+
+(deftest optional-functions-present
+  (is (= nil (do (list time-ms string? number? seq conj meta with-meta fn?) nil)))
+  (is (= (quote (false false false)) (map symbol? (quote (nil false true))))))
+
+;; -------- Optional Functionality --------
+
+(deftest metadata-on-functions
+  (is (= nil (meta (fn (a) a))))
+  (is (= {"b" 1} (meta (with-meta (fn (a) a) {"b" 1}))))
+  (is (= "abc" (meta (with-meta (fn (a) a) "abc"))))
+  (def malA-l-wm (with-meta (fn (a) a) {"b" 2}))
+  (is (= {"b" 2} (meta malA-l-wm)))
+  (is (= {"new_meta" 123} (meta (with-meta malA-l-wm {"new_meta" 123}))))
+  (is (= {"b" 2} (meta malA-l-wm)))
+  (def malA-f-wm2 ^{"abc" 1} (fn [a] (+ 1 a)))
+  (is (= {"abc" 1} (meta malA-f-wm2)))
+  ;; meta of native functions is nil (not an error)
+  (is (= nil (meta +))))
+
+(deftest closures-and-metadata-coexist
+  (def malA-gen-plusX (fn (x) (with-meta (fn (b) (+ x b)) {"meta" 1})))
+  (def malA-plus7 (malA-gen-plusX 7))
+  (def malA-plus8 (malA-gen-plusX 8))
+  (is (= 15 (malA-plus7 8)))
+  (is (= {"meta" 1} (meta malA-plus7)))
+  (is (= {"meta" 1} (meta malA-plus8)))
+  (is (= {"meta" 2} (meta (with-meta malA-plus7 {"meta" 2}))))
+  (is (= {"meta" 1} (meta malA-plus8))))
+
+(deftest string-number-predicates
+  (are [expected expr] (= expected expr)
+    true  (string? "")
+    false (string? (quote abc))
+    true  (string? "abc")
+    false (string? :abc)
+    false (string? (keyword "abc"))
+    false (string? 234)
+    false (string? nil)
+    true  (number? 123)
+    true  (number? -1)
+    false (number? nil)
+    false (number? false)
+    false (number? "123")))
+
+(deftest fn-macro-predicates
+  (def malA-add1 (fn (x) (+ x 1)))
+  (are [expected expr] (= expected expr)
+    true  (fn? +)
+    true  (fn? malA-add1)
+    false (fn? cond)
+    false (fn? "+")
+    false (fn? :+)
+    true  (fn? ^{"ismacro" true} (fn () 0))
+    true  (macro? cond)
+    false (macro? +)
+    false (macro? malA-add1)
+    false (macro? "+")
+    false (macro? :+)
+    false (macro? {})))
+
+(deftest conj-function
+  (are [expected expr] (= expected expr)
+    (quote (1))       (conj (list) 1)
+    (quote (2 1))     (conj (list 1) 2)
+    (quote (4 2 3))   (conj (list 2 3) 4)
+    (quote (6 5 4 2 3)) (conj (list 2 3) 4 5 6)
+    (quote ((2 3) 1)) (conj (list 1) (list 2 3))
+    [1]         (conj [] 1)
+    [1 2]       (conj [1] 2)
+    [2 3 4]     (conj [2 3] 4)
+    [2 3 4 5 6] (conj [2 3] 4 5 6)
+    [1 [2 3]]   (conj [1] [2 3])
+    {}          (conj {})
+    nil         (conj)
+    {:a 1}      (conj {} :a 1))
+  (are [expected key] (= expected (get (conj {} :a 1 :b 2) key))
+    1   :a
+    2   :b
+    nil :c)
+  (are [expected key] (= expected (get (conj {:a 1} :b 2) key))
+    1   :a
+    2   :b
+    nil :c)
+  (is (= #{} (conj #{})))
+  (is (= #{:a} (conj #{} :a)))
+  (are [expected key] (= expected (get (conj #{} :a :b) key))
+    :a  :a
+    :b  :b
+    nil :c)
+  (are [expected key] (= expected (get (conj #{:a} :b) key))
+    :a  :a
+    :b  :b
+    nil :c))
+
+(deftest seq-function
+  (are [expected expr] (= expected expr)
+    (quote ("a" "b" "c")) (seq "abc")
+    (quote (2 3 4))       (seq (quote (2 3 4)))
+    (quote (2 3 4))       (seq [2 3 4])
+    nil (seq "")
+    nil (seq (quote ()))
+    nil (seq [])
+    nil (seq nil))
+  (is (= "this is a test" (apply str (seq "this is a test")))))
+
+(deftest metadata-on-collections
+  (is (= nil (meta [1 2 3])))
+  (is (= [1 2 3] (with-meta [1 2 3] {"a" 1})))
+  (is (= {"a" 1} (meta (with-meta [1 2 3] {"a" 1}))))
+  (is (vector? (with-meta [1 2 3] {"a" 1})))
+  (is (= "abc" (meta (with-meta [1 2 3] "abc"))))
+  (is (= [] (with-meta [] "abc")))
+  (is (= {"a" 1} (meta (with-meta (list 1 2 3) {"a" 1}))))
+  (is (list? (with-meta (list 1 2 3) {"a" 1})))
+  (is (= () (with-meta (list) {"a" 1})))
+  (is (empty? (with-meta (list) {"a" 1})))
+  (is (= {"a" 1} (meta (with-meta {"abc" 123} {"a" 1}))))
+  (is (map? (with-meta {"abc" 123} {"a" 1})))
+  (is (= {} (with-meta {} {"a" 1})))
+  (def malA-l-wm2 (with-meta [4 5 6] {"b" 2}))
+  (is (= [4 5 6] malA-l-wm2))
+  (is (= {"b" 2} (meta malA-l-wm2)))
+  (is (= {"new_meta" 123} (meta (with-meta malA-l-wm2 {"new_meta" 123}))))
+  (is (= {"b" 2} (meta malA-l-wm2))))
+
+(deftest metadata-on-builtins
+  (is (= nil (meta +)))
+  (def malA-f-wm3 ^{"def" 2} +)
+  (is (= {"def" 2} (meta malA-f-wm3)))
+  (is (= nil (meta +))))
+
+(deftest time-ms-advances
+  (load-file "./tests/computations.mal")
+  (def malA-start-time (time-ms))
+  (is (= false (= malA-start-time 0)))
+  (is (= 500500 (sumdown 1000)))
+  (is (> (time-ms) malA-start-time)))
+
+(deftest defmacro-does-not-mutate-function
+  (def malA-f (fn [x] (number? x)))
+  (defmacro malA-m malA-f)
+  (is (= true (malA-f (+ 1 1))))
+  (is (= false (malA-m (+ 1 1)))))

--- a/deftests/stepC_JSON_test.lisp
+++ b/deftests/stepC_JSON_test.lisp
@@ -1,0 +1,43 @@
+;; Replica of tests/stepC_JSON.mal: range, base64 round-trip, ¬…¬ raw
+;; strings and str. The prn/println sections assert stdout and stay in
+;; the legacy harness only.
+
+(deftest range-basics
+  (are [expected expr] (= expected expr)
+    [0]         (range 0 1)
+    []          (range 0 0)
+    [0 1 2 3]   (range 0 4)
+    []          (range 0 -1)
+    [-10]       (range -10 -9)
+    [10]        (range 10 11)))
+
+(deftest base64-round-trip
+  (is (= "Hello World" (binary2str (unbase64 (base64 (str2binary "Hello World"))))))
+  (is (= "안녕 하세요" (binary2str (unbase64 (base64 (str2binary "안녕 하세요")))))))
+
+(deftest raw-strings
+  (is (= "Hello" ¬Hello¬))
+  (is (= "\"Hello\"" ¬"Hello"¬))
+  ;; a doubled ¬ escapes a literal ¬
+  (is (= "¬" ¬¬¬¬))
+  (is (= "¬" "¬")))
+
+(deftest str-with-raw-strings
+  (are [expected expr] (= expected expr)
+    ""                  (str)
+    ""                  (str ¬¬)
+    "abc"               (str ¬abc¬)
+    "¬"                 (str ¬¬¬¬)
+    "¬"                 (str "¬")
+    "1abc3"             (str 1 ¬abc¬ 3)
+    "abc  defghi jkl"   (str ¬abc  def¬ ¬ghi jkl¬)
+    "(1 2 abc \")def"   (str (list 1 2 ¬abc¬ ¬"¬) ¬def¬)
+    "(1 2 abc ¬)def"    (str (list 1 2 ¬abc¬ ¬¬¬¬) ¬def¬))
+  ;; raw strings keep backslashes verbatim
+  (is (= "abc\\ndef\\nghi" (str ¬abc\ndef\nghi¬)))
+  (is (= "abc\\\\def\\\\ghi" (str ¬abc\\def\\ghi¬))))
+
+(deftest json-shaped-strings-print-raw
+  ;; strings that look like JSON print with ¬…¬, others with quotes
+  (is (= "¬{\"hello\"}¬" (pr-str "{\"hello\"}")))
+  (is (= "\"{hello}\"" (pr-str "{hello}"))))

--- a/deftests/stepD_casterror_test.lisp
+++ b/deftests/stepD_casterror_test.lisp
@@ -1,0 +1,20 @@
+;; Replica of tests/stepD_casterror.mal: numeric errors are catchable and
+;; carry their message; go-error literals round-trip.
+
+(deftest casterror-division-by-zero
+  (is (= :threw (try (/ 0 0) (catch e :threw))))
+  (is (= :threw (try (/ 1 0) (catch e :threw))))
+  (is (= "«go-error \"division by zero\"»" (pr-str (try (/ 1 0) (catch e e)))))
+  ;; try without catch still propagates
+  (is (= :threw (try (try (/ 1 0)) (catch e :threw)))))
+
+(deftest casterror-non-number
+  (is (= :threw (try (+ 1 :hello) (catch e :threw))))
+  (is (= :threw (try (+ 1 "hello") (catch e :threw)))))
+
+;; The original's «go-error "simple error"» literal cases are omitted:
+;; «…» reader literals need an environment to resolve their constructor,
+;; and load-file's read-string deliberately runs without one (reading a
+;; string must not execute constructor code).
+(deftest casterror-go-error-value
+  (is (= "go-error" (type? (try (/ 1 0) (catch e e))))))

--- a/deftests/stepE_merge_assert_test.lisp
+++ b/deftests/stepE_merge_assert_test.lisp
@@ -1,0 +1,57 @@
+;; Replica of tests/stepE_merge_assert.mal: merge, assert and rename-keys.
+
+(deftest merge-basics
+  (are [expected expr] (= expected expr)
+    {}      (merge {} {})
+    {:a 1}  (merge {:a 1} {})
+    {:a 1}  (merge {:a 1} {:a 1})
+    ;; second takes precedence
+    {:a 111} (merge {:a 1} {:a 111})
+    {:a 1}   (merge {} {:a 1}))
+  (is (= 111 (get (merge {:a 1 :b 2} {:a 111}) :a)))
+  (is (= 1 (get (merge {:x 1 :y 2} {:y 3 :z 4}) :x)))
+  (is (= 3 (get (merge {:x 1 :y 2} {:y 3 :z 4}) :y)))
+  (is (= 4 (get (merge {:x 1 :y 2} {:y 3 :z 4}) :z))))
+
+(deftest merge-nil-maps
+  (is (= {:a 1} (merge nil {:a 1})))
+  (is (= {:a 1} (merge {:a 1} nil)))
+  (is (= nil (merge nil nil))))
+
+(deftest merge-defs
+  (def merge-m1 {:a 1})
+  (def merge-m2 {:a 2})
+  (is (= {:a 2} (merge merge-m1 merge-m2)))
+  (is (= {:m1 {:a 2}} (merge {:m1 merge-m1} {:m1 merge-m2}))))
+
+(deftest assert-basics
+  (is (= :threw (try (assert) (catch e :threw))))
+  ;; only nil and false fail an assert
+  (are [expr] (= nil expr)
+    (assert true)
+    (assert 0)
+    (assert 1)
+    (assert [1 2 3])
+    (assert ())
+    (assert {}))
+  (is (= :threw (try (assert nil) (catch e :threw))))
+  (is (= :threw (try (assert false) (catch e :threw)))))
+
+(deftest assert-with-message
+  (is (= nil (assert true "boom!")))
+  ;; a string message is thrown wrapped as a go-error; other values raw
+  (is (= "«go-error \"boom!\"»" (pr-str (try (assert nil "boom!") (catch e e)))))
+  (is (= "«go-error \"boom!\"»" (pr-str (try (assert false "boom!") (catch e e)))))
+  (is (= 3 (try (assert nil 3) (catch e e))))
+  (is (= [3] (try (assert nil [3]) (catch e e))))
+  (is (= (quote (3)) (try (assert nil (quote (3))) (catch e e))))
+  (is (= {:3 3} (try (assert nil {:3 3}) (catch e e))))
+  (is (= (quote assert) (try (assert nil (quote assert)) (catch e e)))))
+
+(deftest rename-keys-basics
+  (are [expected expr] (= expected expr)
+    {}         (rename-keys {} {})
+    {:a 1}     (rename-keys {:a 1} {})
+    {"mimi" 1} (rename-keys {:a 1} {:a "mimi"}))
+  (is (= 1 (get (rename-keys {:a 1 :b 3} {:a "mimi"}) "mimi")))
+  (is (= 3 (get (rename-keys {:a 1 :b 3} {:a "mimi"}) :b))))

--- a/deftests/stepF_set_test.lisp
+++ b/deftests/stepF_set_test.lisp
@@ -1,0 +1,125 @@
+;; Replica of tests/stepF_set.mal: set literals, assoc/dissoc/get on
+;; sets, equality, metadata and hash-set.
+
+(deftest sets-are-not-sequential
+  (is (= false (sequential? #{})))
+  (is (= false (sequential? #{:a :b :c}))))
+
+(deftest set-construction
+  (are [expected expr] (= expected expr)
+    #{"a"} (set ["a"])
+    #{"a"} (set (quote ("a")))
+    #{}    (set nil)
+    #{"a"} #{"a"}
+    #{"a"} (assoc #{} "a"))
+  (is (= "a" (get (assoc (assoc #{"a"} "b") "c") "a"))))
+
+(deftest set-predicates-and-get
+  (def set-s1 (set (quote ())))
+  (is (set? #{}))
+  (is (set? set-s1))
+  (is (= false (set? 1)))
+  (is (= false (set? "abc")))
+  (is (= nil (get nil "a")))
+  (is (= nil (get set-s1 "a")))
+  (is (= false (contains? set-s1 "a")))
+  (def set-s2 (assoc set-s1 "a"))
+  ;; the original set is unchanged
+  (is (= nil (get set-s1 "a")))
+  (is (= false (contains? set-s1 "a")))
+  (is (= "a" (get set-s2 "a")))
+  (is (contains? set-s2 "a")))
+
+(deftest set-seq-and-count
+  (def set-s1b (set ()))
+  (def set-s2b (assoc set-s1b "a"))
+  (is (= () (seq set-s1b)))
+  (is (= (quote ("a")) (seq set-s2b)))
+  (is (= (quote ("1")) (seq #{"1"})))
+  (is (= 3 (count (seq (assoc set-s2b "b" "c")))))
+  (is (= 3 (count (assoc set-s2b "b" "c")))))
+
+(deftest set-keyword-keys
+  (is (= :abc (get #{:abc} :abc)))
+  (is (contains? #{:abc} :abc))
+  (is (= false (contains? #{:abcd} :abc)))
+  (is (= #{:bcd} (assoc #{} :bcd)))
+  (is (keyword? (nth (seq #{:abc :def}) 0))))
+
+(deftest set-assoc-updates
+  (def set-s4 (assoc #{:a :b} :a :c))
+  (are [expected key] (= expected (get set-s4 key))
+    :a  :a
+    :b  :b
+    :c  :c
+    nil :d))
+
+(deftest set-str-and-pr-str
+  (is (= "A#{:abc}Z" (str "A" #{:abc} "Z")))
+  (is (= "true.false.nil.:keyw.symb" (str true "." false "." nil "." :keyw "." (quote symb))))
+  (is (= "\"A\" #{:abc} \"Z\"" (pr-str "A" #{:abc} "Z")))
+  (is (= "true \".\" false \".\" nil \".\" :keyw \".\" symb" (pr-str true "." false "." nil "." :keyw "." (quote symb))))
+  ;; multi-element set print order is unstable: accept either
+  (def set-s (str #{:abc :def}))
+  (is (or (= set-s "#{:abc :def}") (= set-s "#{:def :abc}")))
+  (def set-p (pr-str #{:abc :def}))
+  (is (or (= set-p "#{:abc :def}") (= set-p "#{:def :abc}"))))
+
+(deftest set-dissoc
+  (def set-s3 (assoc (assoc #{} "a") "b"))
+  (is (= 2 (count (seq set-s3))))
+  (is (= 2 (count set-s3)))
+  (is (= #{"b"} (dissoc set-s3 "a")))
+  (is (= #{} (dissoc set-s3 "a" "b")))
+  (is (= #{} (dissoc set-s3 "a" "b" "c")))
+  ;; the original set is unchanged
+  (is (= 2 (count (seq set-s3))))
+  (is (= 2 (count set-s3)))
+  (is (= #{:fgh} (dissoc #{:cde :fgh} :cde))))
+
+(deftest set-empty-predicate
+  (is (empty? #{}))
+  (is (= false (empty? #{"aa"}))))
+
+(deftest set-equality
+  (are [expected expr] (= expected expr)
+    true  (= #{} #{})
+    true  (= #{} (set (quote ())))
+    true  (= #{} (set []))
+    true  (= #{:a :b} (set [:b :a]))
+    true  (= #{:a :b} (set [:a :b]))
+    false (= #{:a :c} (set [:a :b]))
+    false (= #{:b :c} (set [:a :b]))
+    true  (= #{:b :a} (set [:a :b]))
+    false (= #{:b} (set [:a]))
+    true  (= #{:a :b "c" "d"} (set [:a "c" :b "d"]))
+    false (= #{:a :b} (set [:a]))
+    false (= #{} [])
+    false (= [] #{})
+    false (= #{} ())
+    false (= () #{})
+    false (= #{} {})
+    false (= {} #{})))
+
+(deftest set-metadata
+  (is (= #{"a"} (meta (with-meta #{"abc"} #{"a"}))))
+  (is (set? (with-meta #{"abc"} #{"a"})))
+  (is (= #{} (with-meta #{} #{"a"})))
+  (def set-l-wm (with-meta [4 5 6] #{"b"}))
+  (is (= [4 5 6] set-l-wm))
+  (is (= #{"b"} (meta set-l-wm)))
+  (is (= #{"new_meta"} (meta (with-meta set-l-wm #{"new_meta"}))))
+  (is (= #{"b"} (meta set-l-wm))))
+
+(deftest set-metadata-on-builtins
+  (is (= nil (meta +)))
+  (def set-f-wm3 ^#{"def"} +)
+  (is (= #{"def"} (meta set-f-wm3)))
+  (is (= nil (meta +))))
+
+(deftest hash-set-construction
+  (are [expected key] (= expected (contains? (hash-set :a :b :c) key))
+    true  :a
+    true  :b
+    true  :c
+    false :z))

--- a/deftests/stepG_infunctions_test.lisp
+++ b/deftests/stepG_infunctions_test.lisp
@@ -1,0 +1,77 @@
+;; Replica of tests/stepG_infunctions.mal: assoc, assoc-in, get-in,
+;; update and update-in over maps and vectors.
+
+(deftest assoc-vectors
+  (is (= [0 1 100 3] (assoc [0 1 2 3] 2 100)))
+  (is (= [0 1 "hello" 3] (assoc [0 1 2 3] 2 "hello"))))
+
+(deftest assoc-in-basics
+  (is (= {:a "hello"} (assoc-in {} [:a] "hello")))
+  (is (= "hello" (get (assoc-in {:a 1 :b {:c 2}} [:a] "hello") :a)))
+  (is (= "hello" (get (assoc-in {:a 1 :b {:c 2}} [:b] "hello") :b)))
+  (is (= {:c 2} (get (assoc-in {:a 1 :b {:c 2}} [:a] "hello") :b)))
+  (is (= 1 (get (assoc-in {:a 1 :b {:c 2}} [:b] "hello") :a)))
+  (is (= [0 1 2] (assoc-in [0 1 2] [] "hello")))
+  (is (= [0 1 ["hello"] 3] (assoc-in [0 1 [2] 3] [2 0] "hello")))
+  (is (= [0 1 {:a "hello"} 3] (assoc-in [0 1 {:a 10} 3] [2 :a] "hello"))))
+
+(deftest get-in-maps
+  (def infn-m {:a 1 :b {:c 2}})
+  (are [expected expr] (= expected expr)
+    1   (get-in {:a 1} [:a])
+    2   (get-in {:a 1 :b {:c 2}} [:b :c])
+    nil (get-in {:a 1 :b {:c 2}} [:b :d])
+    2   (get-in infn-m [:b :c])
+    nil (get-in infn-m [:b :d]))
+  (is (= 1 (get (get-in infn-m []) :a)))
+  (is (= {:c 2} (get (get-in infn-m []) :b))))
+
+(deftest get-in-vectors
+  (are [expected expr] (= expected expr)
+    12            (get-in [10 11 12 13] [2])
+    201           (get-in [10 11 [200 201 202] 13] [2 1])
+    [200 201 202] (get-in [10 11 [200 201 202] 13] [2])
+    [10 11 [200 201 202] 13] (get-in [10 11 [200 201 202] 13] [])))
+
+(deftest update-maps-and-vectors
+  (def infn-m2 {:a 1 :b {:c 2}})
+  (is (= 22 (get (update infn-m2 :a (fn [_] 22)) :a)))
+  (is (= 33 (get (update infn-m2 :x (fn [_] 33)) :x)))
+  (def infn-v [0 1 [22 33] 3])
+  (is (= 1111 (get (update infn-v 1 (fn [_] 1111)) 1)))
+  (is (= 5555 (get (update infn-v 2 (fn [_] 5555)) 2))))
+
+(deftest update-in-maps
+  (def infn-m3 {:a 1 :b {:c 2}})
+  (def infn-mu (update-in infn-m3 [:b :c] (fn [x] (+ 1000 x))))
+  (is (= 1002 (get-in infn-mu [:b :c])))
+  (is (= 1 (get-in infn-mu [:a])))
+  (is (= {:c 1002} (get-in infn-mu [:b])))
+  ;; an empty path applies the fn to nil and leaves the map unchanged
+  (is (= 2 (get-in (update-in infn-m3 [] (fn [x] (+ x 2000))) [:b :c])))
+  ;; the fn receives nil for missing paths
+  (is (= 200 (get-in (update-in infn-m3 [:x] (fn [x] (if x 100 200))) [:x])))
+  (is (= 300 (get-in (update-in infn-m3 [:x :y] (fn [x] (if x 100 300))) [:x :y])))
+  (is (= 400 (get-in (update-in infn-m3 [:x :y :z] (fn [x] (if x 100 400))) [:x :y :z]))))
+
+(deftest update-in-vectors
+  (def infn-v2 [0 1 [22 33] 3])
+  (def infn-vu2 (update-in infn-v2 [2 1] (fn [x] (+ 1000 x))))
+  (is (= [22 1033] (get infn-vu2 2)))
+  (is (= 1033 (get-in infn-vu2 [2 1])))
+  (is (= 0 (get-in infn-vu2 [0]))))
+
+(deftest assoc-in-positions
+  (def infn-m4 {:a 1 :b {:c 2}})
+  (are [expected path value] (= expected (get-in (assoc-in infn-m4 path value) path))
+    11 [:b :c]    11
+    12 [:b]       12
+    13 [:a]       13
+    14 [:x]       14
+    18 [:x :y]    18
+    19 [:x :y :z] 19))
+
+(deftest get-in-mixed-index
+  (is (= 20 (get-in {:a [10 20]} [:a 1])))
+  (is (= 20 (get-in {:a (quote (10 20))} [:a 1])))
+  (is (= "hello" (get-in {:a (quote (10 [30 40 {:b "hello"} 60]))} [:a 1 2 :b]))))

--- a/deftests/stepH_strings_test.lisp
+++ b/deftests/stepH_strings_test.lisp
@@ -1,0 +1,29 @@
+;; Replica of tests/stepH_strings.mal: split, subs, starts-with?, ends-with?.
+
+(deftest string-split
+  (are [expected expr] (= expected expr)
+    ["abc" "abc"]                 (split "abc-abc" "-")
+    ["abc-abc"]                   (split "abc-abc" " ")
+    ["abc" "abc" "abc" "0" "s"]   (split "abc-abc-abc-0-s" "-")
+    ["a" "b" "c" "-" "a" "b" "c"] (split "abc-abc" "")
+    [""]                          (split "" "-")
+    ["abc abc" "abc"]             (split "abc abc-abc" "-")
+    ["abc" "abc-abc"]             (split "abc abc-abc" " ")
+    ["" "c" "c-" "c"]             (split "abcabc-abc" "ab"))
+  ;; compatible with first
+  (is (= "abc" (first (split "abc-abc" "-")))))
+
+(deftest string-subs
+  ;; counted in Unicode code points
+  (are [expected expr] (= expected expr)
+    "el"  (subs "hello" 1 3)
+    "llo" (subs "hello" 2)
+    "él"  (subs "héllo" 1 3)
+    ""    (subs "hello" 0 0)
+    ""    (subs "hello" 5)))
+
+(deftest string-prefix-suffix
+  (is (starts-with? "--foo" "--"))
+  (is (= false (starts-with? "-f" "--")))
+  (is (ends-with? "file.txt" ".txt"))
+  (is (= false (ends-with? "file.txt" ".md"))))

--- a/deftests/stepJ_future_test.lisp
+++ b/deftests/stepJ_future_test.lisp
@@ -1,0 +1,47 @@
+;; Replica of tests/stepJ_future.mal: futures, deref and cancellation.
+
+(deftest future-deref
+  (is (= 2 (deref (future (+ 1 1)))))
+  (is (= 2 @(future (+ 1 1))))
+  (is (= 2 (deref (future (do (sleep 10) (+ 1 1))))))
+  (def future-async-sum (future (do (sleep 10) (+ 1 1))))
+  (is (= 2 @future-async-sum)))
+
+(deftest future-simultaneous-and-predicates
+  (def future-sum1 (future (do (sleep 10) (+ 1 1))))
+  (def future-sum2 (future (do (sleep 10) (+ 2 2))))
+  (is (future? future-sum1))
+  (is (future? future-sum2))
+  (is (= false (future? 2)))
+  (is (= 2 @future-sum1))
+  (is (= 4 (deref future-sum2)))
+  (is (future-done? future-sum1))
+  (is (future-done? future-sum2))
+  (is (= false (future-cancelled? future-sum1)))
+  (is (= false (future-cancelled? future-sum2)))
+  ;; cancelling a completed future reports false
+  (is (= false (future-cancel future-sum1)))
+  (is (= false (future-cancel future-sum2))))
+
+(deftest future-cancellation
+  (def future-slow (future (do (sleep 5000) (+ 1 1))))
+  (is (= true (future-cancel future-slow)))
+  (is (future-cancelled? future-slow)))
+
+(deftest future-error-propagates-on-deref
+  (is (= :threw (try @(future (/ 1 0)) (catch e :threw))))
+  (def future-bad (future (/ 1 0)))
+  (is (= false (future-cancelled? future-bad)))
+  (sleep 10)
+  (is (future-done? future-bad))
+  (is (= :threw (try @future-bad (catch e :threw))))
+  (is (= false (future-cancelled? future-bad)))
+  (is (future-done? future-bad)))
+
+(deftest future-captures-environment
+  (def future-a 2)
+  (def future-b 3)
+  (is (= 5 @(future (+ future-a future-b))))
+  (def future-fa (future 2))
+  (def future-fb (future 3))
+  (is (= 5 @(future (+ @future-fa @future-fb)))))

--- a/deftests/stepK_numbers_test.lisp
+++ b/deftests/stepK_numbers_test.lisp
@@ -1,0 +1,118 @@
+;; Replica of tests/stepK_numbers.mal: number literals, radix big ints,
+;; floats and the variadic arithmetic. Literal-to-print expectations
+;; (;=>) become pr-str comparisons; read errors go through read-string.
+
+(deftest numbers-decimal-ints
+  (are [expected expr] (= expected expr)
+    -1    -1
+    -1000 -1000
+    -1000 -1_000
+    1000  1_0_0_0
+    0     0
+    1     1
+    9     9
+    42    42
+    1234567890 1234567890))
+
+(deftest numbers-leading-zero-octal-rejected
+  (is (= :threw (try (read-string "042") (catch e :threw))))
+  (is (= :threw (try (read-string "00") (catch e :threw)))))
+
+(deftest numbers-radix-literals-are-big-ints
+  ;; radix literals print back as 0x… padded to whole octets
+  (are [printed literal] (= printed (pr-str literal))
+    "0xCAFECAFE" 0xCAFE_CAFE
+    "0xCAFECAFE" 0xCA_FE_CA_FE
+    "0x00"       0x0
+    "0x01"       0x1
+    "0x0F"       0xf
+    "0x42"       0x42
+    "0x0123456789ABCDEF" 0x123456789abcDEF
+    "0x0F"       0o17
+    "0x05"       0b101
+    ;; beyond the machine word without overflow
+    "0xFFFFFFFFFFFFFFFFFFFF" 0xFFFF_FFFF_FFFF_FFFF_FFFF
+    ;; signed radix literals round-trip too
+    "-0x01"      -0x01
+    "-0xCAFECAFE" -0xCAFE_CAFE)
+  ;; numeric equality, not pointer identity; distinct from machine ints
+  (is (= 0x0A 0x0A))
+  (is (= false (= 0x0A 10)))
+  (is (= -0x01 -0x01)))
+
+(deftest numbers-floats-print
+  (are [printed literal] (= printed (pr-str literal))
+    "3.1416"       3.1416
+    "0"            0.
+    "1"            1.
+    "42"           42.
+    "1.234568e+09" 01234567890.
+    "0"            .0
+    "0.1"          .1
+    "0.42"         .42
+    "0.012345679"  .0123456789
+    "0"            0.0
+    "1"            1.0
+    "42"           42.0
+    "0"            0e0
+    "1"            1e0
+    "42"           42e0
+    "0"            0E0
+    "42"           42E0
+    "0"            0e+10
+    "1e-10"        1e-10
+    "4.2e+11"      42e+10
+    "0.12345679"   01234567890e-10
+    "1e-10"        1E-10
+    "4.2e+11"      42E+10))
+
+(deftest numbers-variadic-arithmetic
+  (are [expected expr] (= expected expr)
+    0  (+)
+    5  (+ 5)
+    3  (+ 1 1 1)
+    15 (+ 1 2 3 4 5)
+    1  (*)
+    24 (* 2 3 4)
+    -10 (- 10)
+    7  (- 10 1 2)
+    2  (/ 12 2 3)
+    3  (/ 7 2)
+    0  (/ 2)
+    1  (/ 1))
+  (is (= :threw (try (/ 0) (catch e :threw))))
+  (is (= :threw (try (/ 1 0) (catch e :threw)))))
+
+(deftest numbers-float-tower
+  ;; a float makes the result float: compare against float literals
+  ;; ((= 4 4.0) is false — machine ints and floats are distinct types)
+  (are [expected expr] (= expected expr)
+    4.0 (+ 1.5 2.5)
+    1.5 (+ 1 0.5)
+    3.0 (* 2 1.5)
+    0.5 (- 1 0.25 0.25))
+  (is (= false (= 4 4.0))))
+
+(deftest numbers-bigint-arithmetic
+  (are [printed expr] (= printed (pr-str expr))
+    "0x03"   (+ 0x01 0x02)
+    "0x02"   (+ 0x01 1)
+    "-0x01"  (- 0x01 2)
+    "-0xFF"  (- 0xFF)
+    "0x0100" (* 0x10 0x10)
+    "0x05"   (/ 0x10 0x03)
+    "0x0FFFFFFFFFFFFFFFF0" (* 0xFFFF_FFFF_FFFF_FFFF 0x10))
+  ;; big ints and floats do not mix
+  (is (= :threw (try (+ 0x01 1.5) (catch e :threw)))))
+
+(deftest numbers-ordering-chains
+  (are [expected expr] (= expected expr)
+    true  (< 1 2 3)
+    false (< 1 3 2)
+    true  (< 5)
+    true  (<= 1 1 2)
+    true  (> 3 2 1)
+    true  (>= 3 3 1)
+    true  (< 1 1.5 2)
+    true  (< 0x01 0x02)
+    true  (< 0x01 2)))

--- a/deftests/stepL_envvar_test.lisp
+++ b/deftests/stepL_envvar_test.lisp
@@ -1,0 +1,13 @@
+;; Replica of tests/stepL_envvar.mal: environment variables.
+;; The original's PWD-basename check is omitted: it depends on the
+;; working directory the runner happens to be invoked from.
+
+(deftest envvar-set-get-unset
+  (is (= nil (setenv "DEFTEST_VAR1" "hello")))
+  (is (= nil (setenv "DEFTEST_VAR2" "")))
+  (is (= "hello" (getenv "DEFTEST_VAR1")))
+  (is (= "" (getenv "DEFTEST_VAR2")))
+  (is (= nil (getenv "DEFTEST_VAR3")))
+  (is (= nil (unsetenv "DEFTEST_VAR1")))
+  (is (= nil (getenv "DEFTEST_VAR1")))
+  (unsetenv "DEFTEST_VAR2"))

--- a/deftests/stepM_take_drop_test.lisp
+++ b/deftests/stepM_take_drop_test.lisp
@@ -1,0 +1,46 @@
+;; Replica of tests/stepM_take_drop.mal: take, drop, take-last,
+;; drop-last and subvec.
+
+(deftest take-basics
+  (are [expected expr] (= expected expr)
+    (quote (1 2 3)) (take 3 (quote (1 2 3 4 5 6)))
+    (quote (1 2 3)) (take 3 [1 2 3 4 5 6])
+    (quote (1 2))   (take 3 [1 2])
+    ()              (take 1 [])
+    ()              (take 1 nil)
+    ()              (take 0 [1])
+    ()              (take -1 [1])))
+
+(deftest drop-basics
+  (are [expected expr] (= expected expr)
+    (quote (1 2 3 4)) (drop -1 [1 2 3 4])
+    (quote (1 2 3 4)) (drop 0 [1 2 3 4])
+    (quote (3 4))     (drop 2 [1 2 3 4])
+    ()                (drop 5 [1 2 3 4]))
+  ;; similar to subvec but with seqs
+  (is (= (quote (6 7 8)) (take 3 (drop 5 (range 1 11))))))
+
+(deftest take-last-basics
+  (are [expected expr] (= expected expr)
+    (quote (3 4)) (take-last 2 [1 2 3 4])
+    (quote (4))   (take-last 2 [4])
+    nil           (take-last 2 [])
+    nil           (take-last 2 nil)
+    nil           (take-last 0 [1])
+    nil           (take-last -1 [1])))
+
+(deftest drop-last-basics
+  ;; default n=1 is unsupported
+  (is (= :threw (try (drop-last [1 2 3 4]) (catch e :threw))))
+  (are [expected expr] (= expected expr)
+    (quote (1 2 3 4)) (drop-last -1 [1 2 3 4])
+    (quote (1 2 3 4)) (drop-last 0 [1 2 3 4])
+    ()                (drop-last 5 [1 2 3 4])
+    (quote (1 2))     (drop-last 2 [1 2 3 4])
+    (quote (1 2))     (drop-last 2 (quote (1 2 3 4))))
+  ;; unsupported with hash-maps
+  (is (= :threw (try (drop-last 2 {:a 1 :b 2 :c 3 :d 4}) (catch e :threw)))))
+
+(deftest subvec-basics
+  (is (= [3 4 5 6 7] (subvec [1 2 3 4 5 6 7] 2)))
+  (is (= [3 4] (subvec [1 2 3 4 5 6 7] 2 4))))

--- a/deftests/stepN_defn_test.lisp
+++ b/deftests/stepN_defn_test.lisp
@@ -1,0 +1,28 @@
+;; Replica of tests/stepN_defn.mal: defn, when and partial.
+
+(deftest defn-macroexpansion
+  (is (= (quote (def defn-name (fn args b))) (macroexpand (defn defn-name args b))))
+  ;; the printed form of the resulting function keeps the implicit do
+  (is (= "(fn [& s] (do (apply str s)))" (pr-str (defn defn-super-str [& s] (apply str s))))))
+
+(deftest defn-bodies-and-varargs
+  (defn defn-f [x] 1 2 x)
+  (is (= 3 (defn-f 3)))
+  (defn defn-super-str2 [& s] (apply str s))
+  (is (= "helloworld" (str "hello" "world")))
+  (is (= "helloworld" (defn-super-str2 "hello" "world"))))
+
+(deftest when-macro
+  (is (= (quote (if condition (do a b))) (macroexpand (when condition a b))))
+  (is (= nil (when false (nth () 0) a)))
+  (is (= 2 (when true 3 2))))
+
+(deftest partial-application
+  (are [expected expr] (= expected expr)
+    3       ((partial +) 1 2)
+    3       ((partial + 1) 2)
+    3       ((partial + 1 2))
+    true    ((partial not) false)
+    true    ((partial not false))
+    3       ((partial (fn [x y] (+ x y)) 1) 2)
+    "1234"  ((partial str 1 2) 3 4)))

--- a/deftests/stepO_loop_recur_test.lisp
+++ b/deftests/stepO_loop_recur_test.lisp
@@ -1,0 +1,87 @@
+;; Replica of tests/stepO_loop_recur.mal: loop/recur, fn-recur and
+;; their errors. The issue-#87 catch-result cases live in
+;; step9_try_test.lisp.
+
+(deftest loop-without-recur-is-let
+  (are [expected expr] (= expected expr)
+    7  (loop [] 7)
+    11 (loop [a 11] a)
+    7  (loop [a 3 b 4] (+ a b))
+    ;; bindings evaluate sequentially, like let
+    8  (loop [a 2 b (* a 3)] (+ a b))
+    ;; list-style binding form is also accepted
+    30 (loop (a 5 b 6) (* a b))
+    ;; the loop body is an implicit do
+    3  (loop [i 0] 1 2 3)))
+
+(def loop-shadowed 99)
+
+(deftest loop-bindings-shadow
+  (is (= 1 (loop [loop-shadowed 1] loop-shadowed)))
+  (is (= 99 loop-shadowed))
+  (is (= 2 (let [x 1] (loop [x 2] x)))))
+
+(deftest recur-basics
+  ;; countdown and accumulation
+  (is (= 15 (loop [i 5 acc 0] (if (= i 0) acc (recur (- i 1) (+ acc i))))))
+  ;; recur rebinds all bindings positionally
+  (is (= 13 (loop [a 0 b 10] (if (= a 3) b (recur (inc a) (inc b))))))
+  ;; recur is TCO: deep iteration runs in constant stack
+  (is (= 100000 (loop [i 0] (if (< i 100000) (recur (inc i)) i)))))
+
+(deftest recur-nested-loops
+  ;; recur binds to the nearest enclosing loop
+  (is (= 6 (loop [i 0 total 0]
+             (if (= i 3)
+               total
+               (recur (inc i) (+ total (loop [j 0 s 0] (if (= j 2) s (recur (inc j) (+ s 1))))))))))
+  ;; a loop may compute another loop's initial binding
+  (is (= [0 1 2] (loop [v (loop [j 0 acc []] (if (< j 3) (recur (inc j) (conj acc j)) acc))] v))))
+
+(deftest loop-inside-function
+  (defn loop-sum-to [n] (loop [i 0 acc 0] (if (> i n) acc (recur (inc i) (+ acc i)))))
+  (is (= 10 (loop-sum-to 4)))
+  (is (= 5050 (loop-sum-to 100))))
+
+(deftest recur-errors
+  ;; recur arity must match the loop bindings
+  (is (= :threw (try (loop [i 0] (if (< i 1) (recur 1 2) i)) (catch e :threw))))
+  ;; recur outside any loop or function is an error
+  (is (= :threw (try (eval (read-string "(recur 1)")) (catch e :threw)))))
+
+(deftest fn-recur
+  (defn loop-count-up [x] (if (> x 3) x (recur (inc x))))
+  (is (= 4 (loop-count-up 0)))
+  (is (= 10 (loop-count-up 10)))
+  ;; anonymous function
+  (is (= 15 ((fn [i acc] (if (= i 0) acc (recur (- i 1) (+ acc i)))) 5 0)))
+  ;; constant stack
+  (defn loop-spin [i] (if (< i 100000) (recur (inc i)) i))
+  (is (= 100000 (loop-spin 0)))
+  ;; a tail call moves the recursion point to the called function
+  (defn loop-pong [x] (if (> x 2) :pong-done (recur (+ x 1))))
+  (defn loop-ping [x] (loop-pong x))
+  (is (= :pong-done (loop-ping 0))))
+
+(deftest fn-recur-nearest-point
+  ;; a loop inside a fn wins as the nearest recursion point
+  (defn loop-sum-below [n] (loop [i 0 acc 0] (if (< i n) (recur (inc i) (+ acc i)) acc)))
+  (is (= 6 (loop-sum-below 4)))
+  ;; a function called from a loop body recurs to itself
+  (defn loop-count-up2 [x] (if (> x 3) x (recur (inc x))))
+  (is (= 4 (loop [i 0] (if (< i 2) (recur (inc i)) (loop-count-up2 0))))))
+
+(deftest fn-recur-through-go-paths
+  (defn loop-count-up3 [x] (if (> x 3) x (recur (inc x))))
+  (is (= 4 (apply loop-count-up3 [0])))
+  (is (= (quote (4 10)) (map loop-count-up3 [0 10])))
+  (def loop-counter (atom 0))
+  (is (= 5 (swap! loop-counter (fn [v] (if (< v 5) (recur (inc v)) v))))))
+
+(deftest fn-recur-from-try-tail
+  (defn loop-retry [x] (try (if (< x 3) (recur (inc x)) x) (catch e :nope)))
+  (is (= 3 (loop-retry 0))))
+
+(deftest fn-recur-arity
+  (defn loop-bad-arity [x] (if false x (recur 1 2)))
+  (is (= :threw (try (loop-bad-arity 0) (catch e :threw)))))

--- a/deftests/stepP_metatest_test.lisp
+++ b/deftests/stepP_metatest_test.lisp
@@ -1,0 +1,4 @@
+;; Replica of tests/stepP_metatest.mal: a thrown value is caught as-is.
+
+(deftest throw-string-caught
+  (is (= "hello" (try (throw "hello") (catch e e)))))

--- a/deftests_test.go
+++ b/deftests_test.go
@@ -1,0 +1,97 @@
+package lisp_test
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/concurrent"
+	"github.com/jig/lisp/lib/concurrent/nsconcurrent"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/coreextended/nscoreextended"
+	"github.com/jig/lisp/lib/system"
+	"github.com/jig/lisp/lib/test"
+	"github.com/jig/lisp/lib/test/nstest"
+	"github.com/jig/lisp/types"
+)
+
+// TestDeftests runs the deftest suite under deftests/ — the deftest
+// replica of the .mal step files (see deftests/README.md) — mirroring
+// what `lisp --test deftests/` does. Relative paths inside the suite
+// (e.g. ./tests/test.txt) resolve against the repository root, which is
+// the working directory of this test.
+func TestDeftests(t *testing.T) {
+	ns := env.NewEnv()
+	for _, load := range []func(types.EnvType) error{
+		nscore.Load,
+		nscore.LoadInput,
+		nscore.LoadNullArgs,
+		nsconcurrent.Load,
+		nscoreextended.Load,
+		nstest.Load,
+	} {
+		if err := load(ns); err != nil {
+			t.Fatalf("library load: %v", err)
+		}
+	}
+	system.Load(ns)
+	concurrent.Load(ns)
+
+	files, err := filepath.Glob("deftests/*_test.lisp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no deftest files found under deftests/")
+	}
+	sort.Strings(files)
+
+	ctx := context.Background()
+	for _, path := range files {
+		if _, err := lisp.REPL(ctx, ns, `(load-file "`+path+`")`, types.NewCursorHere(path, -3, 1)); err != nil {
+			t.Fatalf("loading %s: %v", path, err)
+		}
+	}
+
+	reg := test.FromEnv(ns)
+	if reg == nil {
+		t.Fatal("no test registry in environment")
+	}
+	results := reg.RunAll(ctx)
+	if len(results) == 0 {
+		t.Fatal("no tests registered")
+	}
+	tests, checks := 0, 0
+	for _, res := range results {
+		tests++
+		checks += len(res.Checks)
+		if res.OK() {
+			continue
+		}
+		var b strings.Builder
+		if res.Err != "" {
+			b.WriteString("\n    error: " + res.Err)
+		}
+		for _, c := range res.Checks {
+			if c.OK {
+				continue
+			}
+			b.WriteString("\n    " + c.Module + ":" + strconv.Itoa(c.Line) + ": " + c.Form)
+			switch {
+			case c.Err != "":
+				b.WriteString(": error: " + c.Err)
+			case c.Expected != "":
+				b.WriteString(": expected " + c.Expected + ", got " + c.Actual)
+			default:
+				b.WriteString(": failed")
+			}
+		}
+		t.Errorf("FAIL: %s (%s:%d)%s", res.Name, res.Module, res.Line, b.String())
+	}
+	t.Logf("deftests: %d tests, %d checks", tests, checks)
+}

--- a/docgen/libraries.go
+++ b/docgen/libraries.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jig/lisp/lib/require/nsrequire"
 	"github.com/jig/lisp/lib/sql/nssql"
 	"github.com/jig/lisp/lib/system/nssystem"
+	"github.com/jig/lisp/lib/test/nstest"
 	"github.com/jig/lisp/types"
 )
 
@@ -41,6 +42,7 @@ func standardLibraries() []library {
 		{"sql", nssql.Load},
 		{"cli", nscli.Load},
 		{"integrity", nsintegrity.Load},
+		{"test", nstest.Load},
 	}
 }
 

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -21,6 +21,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	spew "github.com/davecgh/go-spew/spew"
@@ -101,6 +102,7 @@ func Load(env EnvType) {
 	call.Call(env, binary2str)
 	call.Call(env, json_encode)
 	call.Call(env, sleep)
+	call.Call(env, gensym)
 	call.Call(env, time_ms)
 	call.Call(env, time_ns)
 	call.Call(env, time_format)
@@ -530,6 +532,17 @@ func spit(fileName, contents string, opts ...MalType) error {
 		return werr
 	}
 	return cerr
+}
+
+// gensymCounter feeds gensym; a Go atomic (rather than a lisp atom in
+// the header) so the macro-writing primitive is available with only
+// core loaded, before the concurrent library provides atoms.
+var gensymCounter atomic.Int64
+
+// gensym returns a fresh, hopefully-unique symbol (see "Plugging the
+// Leaks", http://www.gigamonkeys.com/book/macros-defining-your-own.html).
+func gensym() (Symbol, error) {
+	return Symbol{Val: fmt.Sprintf("G__%d", gensymCounter.Add(1))}, nil
 }
 
 // Number functions

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -92,6 +92,7 @@ var coreDocs = []struct{ name, arglist, doc string }{
 	{"println", "[& args]", "Prints its arguments (unquoted) separated by spaces, then a newline."},
 	{"prn", "[& args]", "Prints its arguments (readable) separated by spaces, then a newline."},
 	{"sleep", "[ms]", "Sleeps for ms milliseconds."},
+	{"gensym", "[]", "Returns a fresh, hopefully-unique symbol like G__N (for writing hygienic macros)."},
 
 	// Predicates
 	{"nil?", "[x]", "Whether x is nil."},

--- a/lib/core/header-basic.lisp
+++ b/lib/core/header-basic.lisp
@@ -32,4 +32,47 @@
                     (hash-map :doc ~(first fdecl))))
             `(def ~name
                 (fn ~(first fdecl) ~@(rest fdecl)))))
-        {:doc "Defines a named function (defn name [params] body…); an optional docstring may follow name."})))
+        {:doc "Defines a named function (defn name [params] body…); an optional docstring may follow name."}))
+
+    ;; Fundamental helpers and control-flow macros, promoted from
+    ;; coreextended so every library header can rely on them with only
+    ;; core loaded (their Clojure counterparts live in clojure.core).
+
+    (defn inc
+        "Returns x + 1."
+        [x]
+        (+ x 1))
+
+    (defn dec
+        "Returns x - 1."
+        [x]
+        (- x 1))
+
+    (defmacro when
+        (with-meta
+            (fn [condition & body]
+                `(if ~condition (do ~@body)))
+            {:doc "Evaluates body in an implicit do when condition is truthy; otherwise nil."}))
+
+    ;; "x1 x2 .. xn" is rewritten so each argument is evaluated at most
+    ;; once and evaluation stops at the first nil/false.
+    (defmacro and
+        (with-meta
+            (fn [& xs]
+                (cond (empty? xs)      true
+                      (= 1 (count xs)) (first xs)
+                      true             (let (condvar (gensym))
+                                        `(let (~condvar ~(first xs))
+                                            (if ~condvar (and ~@(rest xs)) ~condvar)))))
+            {:doc "Evaluates its arguments in order, returning the first falsey one, or the last (true with none)."}))
+
+    ;; "x1 x2 .. xn" is rewritten as nested ifs so each argument is
+    ;; evaluated at most once; without arguments, returns nil.
+    (defmacro or
+        (with-meta
+            (fn [& xs]
+                (if (< (count xs) 2)
+                    (first xs)
+                    (let [r (gensym)]
+                        `(let (~r ~(first xs)) (if ~r ~r (or ~@(rest xs)))))))
+            {:doc "Evaluates its arguments in order, returning the first truthy one, or nil."})))

--- a/lib/core/header-load-file.lisp
+++ b/lib/core/header-load-file.lisp
@@ -8,3 +8,7 @@
             (str
                 ";; $MODULE " file-path "\n"
                 "(do " (slurp file-path) "\n)"))))
+
+;; load-file-once is registered in Go by nscore.LoadInput: its seen-set
+;; needs mutable state, and atoms live in the concurrent library, which
+;; is not available at core-load time.

--- a/lib/core/nscore/nscore.go
+++ b/lib/core/nscore/nscore.go
@@ -2,8 +2,10 @@ package nscore
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/lib/call"
@@ -48,6 +50,31 @@ func LoadInput(env EnvType) error {
 	if _, err := lisp.REPL(context.Background(), env, core.HeaderLoadFile(), NewCursorFile(_package_)); err != nil {
 		return err
 	}
+
+	// load-file-once needs mutable state for its seen-set; a Go closure
+	// keeps it available with only core loaded (atoms belong to the
+	// concurrent library).
+	var mu sync.Mutex
+	seen := map[string]bool{}
+	env.Set(Symbol{Val: "load-file-once"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
+		if len(a) != 1 {
+			return nil, fmt.Errorf("load-file-once: wrong number of arguments (%d instead of 1)", len(a))
+		}
+		path, ok := a[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("load-file-once: file-path must be a string (was of type %T)", a[0])
+		}
+		mu.Lock()
+		already := seen[path]
+		seen[path] = true
+		mu.Unlock()
+		if already {
+			return nil, nil
+		}
+		return lisp.EVAL(ctx, NewList(nil, Symbol{Val: "load-file"}, path), env)
+	}})
+	call.Doc(env, "load-file-once", "[file-path]", "Like load-file, but never loads the same path twice.")
+
 	return nil
 }
 

--- a/lib/coreextended/header-coreextended.lisp
+++ b/lib/coreextended/header-coreextended.lisp
@@ -1,16 +1,10 @@
 (do
 ;;; Trivial
   ;; Trivial but convenient functions.
-
-  (defn inc
-    "Returns a + 1 (integer successor)."
-    [a]
-    (+ a 1))
-
-  (defn dec
-    "Returns a - 1 (integer predecessor)."
-    [a]
-    (- a 1))
+  ;; NOTE: inc, dec, gensym — and the when/and/or macros and
+  ;; load-file-once below — moved to the core headers (header-basic,
+  ;; header-load-file) so every library header can rely on them with
+  ;; only core loaded.
 
   (defn zero?
     "Whether n equals 0."
@@ -21,15 +15,6 @@
     "Returns its argument unchanged."
     [x]
     x)
-
-  ;; Generate a hopefully unique symbol. See section "Plugging the Leaks"
-  ;; of http://www.gigamonkeys.com/book/macros-defining-your-own.html
-  (def gensym
-    (with-meta
-      (let [counter (atom 0)]
-        (fn []
-          (symbol (str "G__" (swap! counter inc)))))
-      {:doc "Returns a fresh, hopefully-unique symbol like G__N."}))
 
 ;;; Benchmark
   ;; An alternative approach, to complement perf.mal
@@ -103,15 +88,6 @@
     [f & args]
     (fn [& more-args]
       (apply f (concat args more-args))))
-
-;;; Control Flow Macros
-  ;; Convenient control flow macros.
-
-  (defmacro when
-    (with-meta
-      (fn [condition & body]
-        `(if ~condition (do ~@body)))
-      {:doc "Evaluates body in an implicit do when condition is truthy; otherwise nil."}))
 
 ;;; Threading
   ;; Composition of partially applied functions.
@@ -357,19 +333,6 @@
   ;; Iteration on evaluations interpreted as boolean values.
 
   ;; "(or x1 x2 .. xn x)"
-  ;; is almost rewritten as
-  ;; "(if x1 x1 (if x2 x2 (.. (if xn xn x))))"
-  ;; except that each argument is evaluated at most once.
-  ;; Without arguments, returns "nil".
-  (defmacro or
-    (with-meta
-      (fn [& xs]
-        (if (< (count xs) 2)
-          (first xs)
-          (let [r (gensym)]
-            `(let (~r ~(first xs)) (if ~r ~r (or ~@(rest xs)))))))
-      {:doc "Evaluates its arguments in order, returning the first truthy one, or nil."}))
-
   (defn every?
     "Whether (pred x) is truthy for every x in xs."
     [pred xs]
@@ -390,20 +353,6 @@
       nil
       (or (pred (first xs))
           (some pred (rest xs)))))
-
-  ;; "x1 x2 .. xn x" is rewritten so each argument is evaluated at most
-  ;; once and evaluation stops at the first nil/false.
-  ;; Without arguments, returns "true".
-  (defmacro and
-    (with-meta
-      (fn [& xs]
-        ;; Arguments and the result are interpreted as boolean values.
-        (cond (empty? xs)      true
-              (= 1 (count xs)) (first xs)
-              true             (let (condvar (gensym))
-                                `(let (~condvar ~(first xs))
-                                  (if ~condvar (and ~@(rest xs)) ~condvar)))))
-      {:doc "Evaluates its arguments in order, returning the first falsey one, or the last (true with none)."}))
 
 ;;; Arithmetic
   ;; Integer division helpers, absolute value and min/max. Integer `/`
@@ -497,20 +446,4 @@
     [to from]
     (reduce conj to from))
 
-;;; Load File Once
-  ;; This file is normally loaded with "load-file", so it needs a
-  ;; different mechanism to neutralize multiple inclusions of
-  ;; itself. Moreover, the file list should never be reset.
-  (def load-file-once
-    (with-meta
-      (try
-        load-file-once
-      (catch _
-        (let [seen (atom {"../lib/load-file-once.mal" nil})]
-          (fn [filename]
-            (if (not (contains? @seen filename))
-              (do
-                (swap! seen assoc filename nil)
-                (load-file filename)))))))
-      {:doc "Like load-file, but never loads the same path twice."}))
 )

--- a/lib/test/header-test.lisp
+++ b/lib/test/header-test.lisp
@@ -1,0 +1,29 @@
+;; $MODULE header-test
+
+;; deftest/is/are macros, expanding into the test/* builtins
+(do
+    (defmacro deftest
+        (with-meta
+            (fn [name & body]
+                `(test/register! (quote ~name) (fn [] ~@body)))
+            {:doc "Registers body as the test named name; run with the --test runner or (test/run-tests!)."}))
+
+    (defmacro is
+        (with-meta
+            (fn [form & msg]
+                ;; only core builtins here: coreextended (and, …) may not be loaded
+                (let [eq2 (if (list? form)
+                              (if (= (first form) (quote =))
+                                  (= 3 (count form))
+                                  false)
+                              false)]
+                    (if eq2
+                        `(test/check-eq! (quote ~form) (fn [] ~(nth form 1)) (fn [] ~(nth form 2)) ~@msg)
+                        `(test/check! (quote ~form) (fn [] ~form) ~@msg))))
+            {:doc "Asserts form is truthy; inside deftest it records the outcome, outside it throws on failure. (is (= expected actual)) reports both values."}))
+
+    (defmacro are
+        (with-meta
+            (fn [argv expr & rows]
+                (test/expand-are argv expr rows))
+            {:doc "Template assertion: substitutes each row of values for argv in expr and asserts every instance, e.g. (are [x y] (= x y) 2 (+ 1 1) 4 (* 2 2))."})))

--- a/lib/test/nstest/nstest.go
+++ b/lib/test/nstest/nstest.go
@@ -1,0 +1,28 @@
+package nstest
+
+import (
+	"context"
+	"reflect"
+	"strings"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/lib/test"
+	"github.com/jig/lisp/types"
+)
+
+type Here struct{}
+
+var (
+	__package_fullpath__ = strings.Split(reflect.TypeFor[Here]().PkgPath(), "/")
+	_package_            = "$" + __package_fullpath__[len(__package_fullpath__)-1]
+)
+
+func Load(env types.EnvType) error {
+	if err := test.Load(env); err != nil {
+		return err
+	}
+	if _, err := lisp.REPL(context.Background(), env, test.HeaderTest(), types.NewCursorFile(_package_)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/lib/test/test.go
+++ b/lib/test/test.go
@@ -1,0 +1,371 @@
+// Package test implements the deftest/is/are unit-testing library.
+//
+// The lisp-facing surface lives in header-test.lisp (deftest, is, are
+// macros); this file provides the Go builtins they expand into and the
+// registry the CLI test runner consumes. A Registry is created per
+// environment by Load and stored under test/*registry*, so embedders and
+// the command-line runner can retrieve it with FromEnv.
+package test
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"sync"
+
+	"github.com/jig/lisp/lib/call"
+	"github.com/jig/lisp/lisperror"
+	"github.com/jig/lisp/printer"
+	. "github.com/jig/lisp/types"
+)
+
+//go:embed header-test.lisp
+var headerTest string
+
+// HeaderTest returns the lisp source of the deftest/is/are macros.
+func HeaderTest() string { return headerTest }
+
+// registrySymbol is the environment binding under which Load stores the
+// per-environment Registry.
+const registrySymbol = "test/*registry*"
+
+// Check is the outcome of a single is/are assertion.
+type Check struct {
+	Form     string // source form, printed
+	OK       bool
+	Err      string // evaluation error, if any
+	Expected string // printed expected value ((is (= expected actual)) only)
+	Actual   string // printed actual value
+	Message  string // optional user message
+	Module   string
+	Line     int
+}
+
+// Test is one deftest with its accumulated checks.
+type Test struct {
+	Name   string
+	Module string
+	Line   int
+	Fn     MalType // the zero-argument test function
+	Err    string  // error escaping the test body, if any
+	Checks []Check
+}
+
+// OK reports whether the test ran without an escaped error and every
+// check passed.
+func (t *Test) OK() bool {
+	if t.Err != "" {
+		return false
+	}
+	for _, c := range t.Checks {
+		if !c.OK {
+			return false
+		}
+	}
+	return true
+}
+
+// Registry accumulates deftest registrations and, while running, the
+// checks they record.
+type Registry struct {
+	mu      sync.Mutex
+	tests   []*Test
+	current *Test
+}
+
+// FromEnv returns the Registry stored in env by Load, or nil.
+func FromEnv(env EnvType) *Registry {
+	v, err := env.Get(Symbol{Val: registrySymbol})
+	if err != nil {
+		return nil
+	}
+	reg, _ := v.(*Registry)
+	return reg
+}
+
+// Tests returns the registered tests, in registration order.
+func (r *Registry) Tests() []*Test {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]*Test, len(r.tests))
+	copy(out, r.tests)
+	return out
+}
+
+func (r *Registry) register(name string, fn MalType, module string, line int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t := &Test{Name: name, Fn: fn, Module: module, Line: line}
+	// Re-registering a name replaces the previous test, so reloading a
+	// file in a live session stays idempotent.
+	for i, prev := range r.tests {
+		if prev.Name == name {
+			r.tests[i] = t
+			return
+		}
+	}
+	r.tests = append(r.tests, t)
+}
+
+func (r *Registry) record(c Check) (inTest bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.current == nil {
+		return false
+	}
+	r.current.Checks = append(r.current.Checks, c)
+	return true
+}
+
+// RunAll executes every registered test sequentially and returns them
+// with their results.
+func (r *Registry) RunAll(ctx context.Context) []*Test {
+	for _, t := range r.Tests() {
+		r.mu.Lock()
+		t.Err = ""
+		t.Checks = nil
+		r.current = t
+		r.mu.Unlock()
+		if _, err := Apply(ctx, t.Fn, nil); err != nil {
+			t.Err = err.Error()
+		}
+		r.mu.Lock()
+		r.current = nil
+		r.mu.Unlock()
+	}
+	return r.Tests()
+}
+
+// testsAsData converts results to lisp data for test/run-tests!.
+func testsAsData(tests []*Test) MalType {
+	out := make([]MalType, 0, len(tests))
+	for _, t := range tests {
+		checks := make([]MalType, 0, len(t.Checks))
+		for _, c := range t.Checks {
+			m := map[string]MalType{
+				NewKeyword("form"): c.Form,
+				NewKeyword("ok"):   c.OK,
+			}
+			if c.Err != "" {
+				m[NewKeyword("error")] = c.Err
+			}
+			if !c.OK && c.Expected != "" {
+				m[NewKeyword("expected")] = c.Expected
+				m[NewKeyword("actual")] = c.Actual
+			}
+			if c.Message != "" {
+				m[NewKeyword("message")] = c.Message
+			}
+			checks = append(checks, HashMap{Val: m})
+		}
+		m := map[string]MalType{
+			NewKeyword("name"):   t.Name,
+			NewKeyword("ok"):     t.OK(),
+			NewKeyword("checks"): Vector{Val: checks},
+		}
+		if t.Err != "" {
+			m[NewKeyword("error")] = t.Err
+		}
+		out = append(out, HashMap{Val: m})
+	}
+	return Vector{Val: out}
+}
+
+func position(form MalType) (module string, line int) {
+	var cur *Position
+	switch f := form.(type) {
+	case List:
+		cur = f.Cursor
+	case Vector:
+		cur = f.Cursor
+	case Symbol:
+		cur = f.Cursor
+	case MalFunc:
+		cur = f.Cursor
+	}
+	if cur == nil {
+		return "", 0
+	}
+	if cur.Module != nil {
+		module = *cur.Module
+	}
+	return module, cur.BeginRow
+}
+
+func truthy(v MalType) bool { return v != nil && v != false }
+
+func firstMessage(msg []MalType) string {
+	if len(msg) == 0 {
+		return ""
+	}
+	if s, ok := msg[0].(string); ok {
+		return s
+	}
+	return printer.Pr_str(msg[0], true)
+}
+
+// Load registers the test builtins and macros on env.
+func Load(env EnvType) error {
+	reg := &Registry{}
+	env.Set(Symbol{Val: registrySymbol}, reg)
+
+	register := func(name MalType, fn MalType) (MalType, error) {
+		var testName string
+		switch n := name.(type) {
+		case Symbol:
+			testName = n.Val
+		case string:
+			testName = n
+		default:
+			return nil, fmt.Errorf("deftest: name must be a symbol (was of type %T)", name)
+		}
+		module, line := position(name)
+		if module == "" && line == 0 {
+			module, line = position(fn)
+		}
+		reg.register(testName, fn, module, line)
+		return Symbol{Val: testName}, nil
+	}
+	call.CallOverrideFN(env, "test/register!", register)
+	call.Doc(env, "test/register!", "[name fn]", "Registers fn as the test named name; deftest expands to this.")
+
+	check := func(ctx context.Context, form MalType, thunk MalType, msg ...MalType) (MalType, error) {
+		module, line := position(form)
+		c := Check{Form: printer.Pr_str(form, true), Message: firstMessage(msg), Module: module, Line: line}
+		val, err := Apply(ctx, thunk, nil)
+		if err != nil {
+			c.Err = err.Error()
+		}
+		c.OK = err == nil && truthy(val)
+		if reg.record(c) {
+			return c.OK, nil
+		}
+		// Outside deftest an is failure throws, so plain scripts and the
+		// legacy *_test.mal suites fail loudly.
+		if !c.OK {
+			if err != nil {
+				return nil, err
+			}
+			return nil, lisperror.NewLispError(fmt.Errorf("assertion failed: %s", c.Form), form)
+		}
+		return val, nil
+	}
+	call.CallOverrideFN(env, "test/check!", check)
+	call.Doc(env, "test/check!", "[form thunk & msg]", "Records form's outcome in the running test; (is …) expands to this.")
+
+	checkEq := func(ctx context.Context, form MalType, expected MalType, actual MalType, msg ...MalType) (MalType, error) {
+		module, line := position(form)
+		c := Check{Form: printer.Pr_str(form, true), Message: firstMessage(msg), Module: module, Line: line}
+		expVal, expErr := Apply(ctx, expected, nil)
+		actVal, actErr := Apply(ctx, actual, nil)
+		switch {
+		case expErr != nil:
+			c.Err = expErr.Error()
+		case actErr != nil:
+			c.Err = actErr.Error()
+		default:
+			c.OK = Equal_Q(expVal, actVal)
+			if !c.OK {
+				c.Expected = printer.Pr_str(expVal, true)
+				c.Actual = printer.Pr_str(actVal, true)
+			}
+		}
+		if reg.record(c) {
+			return c.OK, nil
+		}
+		if !c.OK {
+			if c.Err != "" {
+				if expErr != nil {
+					return nil, expErr
+				}
+				return nil, actErr
+			}
+			return nil, lisperror.NewLispError(fmt.Errorf("assertion failed: %s: expected %s, got %s", c.Form, c.Expected, c.Actual), form)
+		}
+		return true, nil
+	}
+	call.CallOverrideFN(env, "test/check-eq!", checkEq)
+	call.Doc(env, "test/check-eq!", "[form expected-thunk actual-thunk & msg]", "Records an equality check with expected/actual reporting; (is (= a b)) expands to this.")
+
+	runTests := func(ctx context.Context) (MalType, error) {
+		return testsAsData(reg.RunAll(ctx)), nil
+	}
+	call.CallOverrideFN(env, "test/run-tests!", runTests)
+	call.Doc(env, "test/run-tests!", "[]", "Runs every registered test and returns the results as data.")
+
+	expandAre := func(argv MalType, expr MalType, rows MalType) (MalType, error) {
+		return ExpandAre(argv, expr, rows)
+	}
+	call.CallOverrideFN(env, "test/expand-are", expandAre)
+	call.Doc(env, "test/expand-are", "[argv expr rows]", "Macro helper: expands an (are …) template into a do of is forms.")
+
+	return nil
+}
+
+// ExpandAre expands an (are argv expr & rows) template: rows are consumed
+// in chunks of (count argv), each chunk substituted for the argv symbols
+// in expr, and every instance wrapped in (is …).
+func ExpandAre(argv MalType, expr MalType, rows MalType) (MalType, error) {
+	symsRaw, err := GetSlice(argv)
+	if err != nil {
+		return nil, fmt.Errorf("are: first argument must be a binding vector")
+	}
+	syms := make([]string, len(symsRaw))
+	for i, s := range symsRaw {
+		sym, ok := s.(Symbol)
+		if !ok {
+			return nil, fmt.Errorf("are: binding vector must hold symbols (got %T)", s)
+		}
+		syms[i] = sym.Val
+	}
+	if len(syms) == 0 {
+		return nil, fmt.Errorf("are: binding vector cannot be empty")
+	}
+	vals, err := GetSlice(rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(vals)%len(syms) != 0 {
+		return nil, fmt.Errorf("are: %d values do not fill rows of %d", len(vals), len(syms))
+	}
+	forms := []MalType{Symbol{Val: "do"}}
+	for i := 0; i < len(vals); i += len(syms) {
+		subst := map[string]MalType{}
+		for j, name := range syms {
+			subst[name] = vals[i+j]
+		}
+		forms = append(forms, List{Val: []MalType{Symbol{Val: "is"}, substitute(expr, subst)}})
+	}
+	return List{Val: forms}, nil
+}
+
+// substitute returns expr with every symbol found in subst replaced.
+func substitute(expr MalType, subst map[string]MalType) MalType {
+	switch e := expr.(type) {
+	case Symbol:
+		if v, ok := subst[e.Val]; ok {
+			return v
+		}
+		return e
+	case List:
+		out := make([]MalType, len(e.Val))
+		for i, c := range e.Val {
+			out[i] = substitute(c, subst)
+		}
+		return List{Val: out, Cursor: e.Cursor}
+	case Vector:
+		out := make([]MalType, len(e.Val))
+		for i, c := range e.Val {
+			out[i] = substitute(c, subst)
+		}
+		return Vector{Val: out, Cursor: e.Cursor}
+	case HashMap:
+		out := make(map[string]MalType, len(e.Val))
+		for k, v := range e.Val {
+			out[k] = substitute(v, subst)
+		}
+		return HashMap{Val: out, Cursor: e.Cursor}
+	default:
+		return expr
+	}
+}

--- a/lib/test/test_test.go
+++ b/lib/test/test_test.go
@@ -1,0 +1,109 @@
+package test_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/test"
+	"github.com/jig/lisp/lib/test/nstest"
+	"github.com/jig/lisp/printer"
+	"github.com/jig/lisp/types"
+)
+
+func newEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	if err := nscore.Load(ns); err != nil {
+		t.Fatalf("load core: %v", err)
+	}
+	if err := nstest.Load(ns); err != nil {
+		t.Fatalf("load test: %v", err)
+	}
+	return ns
+}
+
+func run(t *testing.T, ns types.EnvType, src string) types.MalType {
+	t.Helper()
+	ast, err := lisp.READ(src, types.NewCursorFile(t.Name()), ns)
+	if err != nil {
+		t.Fatalf("read %q: %v", src, err)
+	}
+	res, err := lisp.EVAL(context.Background(), ast, ns)
+	if err != nil {
+		t.Fatalf("eval %q: %v", src, err)
+	}
+	return res
+}
+
+func TestDeftestIsAre(t *testing.T) {
+	ns := newEnv(t)
+	run(t, ns, `(deftest passing (is (= 3 (+ 1 2))) (are [x y] (= x y) 2 2 4 4))`)
+	run(t, ns, `(deftest failing (is (= 5 (+ 1 2)) "should be five") (is nil))`)
+	run(t, ns, `(deftest erroring (is (= 1 (undefined-symbol))))`)
+
+	reg := test.FromEnv(ns)
+	if reg == nil {
+		t.Fatal("no registry in env")
+	}
+	results := reg.RunAll(context.Background())
+	if len(results) != 3 {
+		t.Fatalf("expected 3 tests, got %d", len(results))
+	}
+
+	passing, failing, erroring := results[0], results[1], results[2]
+	if !passing.OK() || len(passing.Checks) != 3 {
+		t.Fatalf("passing: OK=%v checks=%d", passing.OK(), len(passing.Checks))
+	}
+	if failing.OK() || len(failing.Checks) != 2 {
+		t.Fatalf("failing: OK=%v checks=%d", failing.OK(), len(failing.Checks))
+	}
+	if c := failing.Checks[0]; c.Expected != "5" || c.Actual != "3" || c.Message != "should be five" {
+		t.Fatalf("failing check 0: %+v", c)
+	}
+	if erroring.OK() || erroring.Checks[0].Err == "" {
+		t.Fatalf("erroring: OK=%v err=%q", erroring.OK(), erroring.Checks[0].Err)
+	}
+}
+
+func TestReRegisterReplaces(t *testing.T) {
+	ns := newEnv(t)
+	run(t, ns, `(deftest same (is true))`)
+	run(t, ns, `(deftest same (is true) (is true))`)
+	reg := test.FromEnv(ns)
+	results := reg.RunAll(context.Background())
+	if len(results) != 1 {
+		t.Fatalf("expected re-registration to replace, got %d tests", len(results))
+	}
+	if len(results[0].Checks) != 2 {
+		t.Fatalf("expected the second registration to win, got %d checks", len(results[0].Checks))
+	}
+}
+
+func TestIsOutsideDeftestThrows(t *testing.T) {
+	ns := newEnv(t)
+	if v := run(t, ns, `(is (= 2 (+ 1 1)))`); v != true {
+		t.Fatalf("passing is outside deftest: got %v", printer.Pr_str(v, true))
+	}
+	ast, err := lisp.READ(`(is (= 1 2))`, types.NewCursorFile(t.Name()), ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = lisp.EVAL(context.Background(), ast, ns)
+	if err == nil || !strings.Contains(err.Error(), "assertion failed") {
+		t.Fatalf("failing is outside deftest should throw, got %v", err)
+	}
+}
+
+func TestRunTestsFromLisp(t *testing.T) {
+	ns := newEnv(t)
+	run(t, ns, `(deftest one (is true))`)
+	res := run(t, ns, `(test/run-tests!)`)
+	printed := printer.Pr_str(res, true)
+	if !strings.Contains(printed, `:name "one"`) || !strings.Contains(printed, ":ok true") {
+		t.Fatalf("unexpected run-tests! output: %s", printed)
+	}
+}

--- a/tools/vscode-lisp/README.md
+++ b/tools/vscode-lisp/README.md
@@ -22,6 +22,14 @@ interpreter.
 - Document formatting (a gofmt-style canonical layout, comments
   preserved) via the language server. Enabled on save by default for
   lisp files, or run **Format Document** (`⇧⌥F`) manually.
+- Testing panel integration: `(deftest …)` tests in `*_test.lisp` /
+  `*_test.mal` files appear in the Test Explorer with run buttons and
+  inline failure messages (expected/actual diffs from `(is (= … …))`).
+  The **Coverage** run profile executes the suite under
+  `--coverage` and feeds VS Code's native test coverage view, painting
+  covered/uncovered lisp lines in the editor gutter — Go-style. Both
+  profiles spawn the `lisp-debug` binary (`lisp.testRunner.command`
+  overrides which one).
 - A pastel-green parenthesis `()` icon for the `lisp` language. Under a
   typical file icon theme (Seti, Material, …) this shows on editor tabs
   but not in the Explorer, because those themes already claim `.lisp`.

--- a/tools/vscode-lisp/package-lock.json
+++ b/tools/vscode-lisp/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "vscode-lisp",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-lisp",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "SEE LICENSE IN ../../LICENCE",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "@types/vscode": "^1.85.0",
+        "@types/vscode": "^1.88.0",
         "typescript": "^5.4.0"
       },
       "engines": {
-        "vscode": "^1.85.0"
+        "vscode": "^1.88.0"
       }
     },
     "node_modules/@types/node": {

--- a/tools/vscode-lisp/package.json
+++ b/tools/vscode-lisp/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-lisp",
   "displayName": "jig/lisp",
   "description": "Language support and debugger for the jig/lisp interpreter",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "publisher": "jig",
   "icon": "./icons/icon.png",
   "license": "SEE LICENSE IN ../../LICENCE",
@@ -11,7 +11,7 @@
     "url": "https://github.com/jig/lisp"
   },
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.88.0"
   },
   "categories": [
     "Programming Languages",
@@ -19,9 +19,11 @@
   ],
   "main": "./out/extension.js",
   "activationEvents": [
-    "onDebugResolve:lisp",
     "onDebugDynamicConfigurations:lisp",
-    "onLanguage:lisp"
+    "onDebugResolve:lisp",
+    "onLanguage:lisp",
+    "workspaceContains:**/*_test.lisp",
+    "workspaceContains:**/*_test.mal"
   ],
   "contributes": {
     "languages": [
@@ -158,6 +160,11 @@
           },
           "default": [],
           "description": "Include directories for require module resolution in the editor (equivalent to the interpreter's -i/--include)."
+        },
+        "lisp.testRunner.command": {
+          "type": "string",
+          "default": "",
+          "description": "Binary used by the Testing panel to run lisp tests (defaults to lisp.debugAdapter.command; needs a lispdebug build for coverage)."
         }
       }
     },
@@ -176,7 +183,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "^1.88.0",
     "typescript": "^5.4.0"
   },
   "dependencies": {

--- a/tools/vscode-lisp/src/extension.ts
+++ b/tools/vscode-lisp/src/extension.ts
@@ -4,6 +4,7 @@ import {
   LanguageClientOptions,
   ServerOptions,
 } from "vscode-languageclient/node";
+import { activateTesting } from "./tests";
 
 let client: LanguageClient | undefined;
 
@@ -27,6 +28,8 @@ export function activate(context: vscode.ExtensionContext): void {
       new LispDebugConfigurationProvider(),
     ),
   );
+
+  activateTesting(context);
 
   const cfg = vscode.workspace.getConfiguration("lisp");
   if (cfg.get<boolean>("languageServer.enabled", true)) {

--- a/tools/vscode-lisp/src/tests.ts
+++ b/tools/vscode-lisp/src/tests.ts
@@ -1,0 +1,336 @@
+import * as vscode from "vscode";
+import { execFile, ChildProcess } from "child_process";
+import * as path from "path";
+import * as os from "os";
+import * as fs from "fs";
+
+/**
+ * Test integration: discovers (deftest …) forms in *_test.lisp / *_test.mal
+ * files, runs them through the CLI runner (`lisp-debug --test FILE
+ * --test-json REPORT`), and — for the Coverage profile — collects an lcov
+ * report (`--coverage`) surfaced through VS Code's native test coverage
+ * API (gutters, Test Coverage view).
+ */
+
+const DEFTEST_RE = /\(deftest\s+([^\s()[\]{}"']+)/g;
+const TEST_GLOB = "**/*_test.{lisp,mal}";
+
+interface CheckReport {
+  form: string;
+  ok: boolean;
+  module?: string;
+  line?: number;
+  error?: string;
+  expected?: string;
+  actual?: string;
+  message?: string;
+}
+
+interface TestReport {
+  name: string;
+  ok: boolean;
+  module?: string;
+  line?: number;
+  error?: string;
+  checks: CheckReport[];
+}
+
+interface SuiteReport {
+  tests: TestReport[];
+}
+
+export function activateTesting(context: vscode.ExtensionContext): void {
+  const ctrl = vscode.tests.createTestController("jigLispTests", "jig/lisp tests");
+  context.subscriptions.push(ctrl);
+
+  // Detailed per-line coverage is stashed here when a run produces it;
+  // loadDetailedCoverage hands it back to VS Code lazily.
+  const coverageDetails = new WeakMap<vscode.FileCoverage, vscode.StatementCoverage[]>();
+
+  async function parseTestFile(uri: vscode.Uri): Promise<void> {
+    let text: string;
+    try {
+      text = new TextDecoder().decode(await vscode.workspace.fs.readFile(uri));
+    } catch {
+      ctrl.items.delete(uri.toString());
+      return;
+    }
+    const fileItem =
+      ctrl.items.get(uri.toString()) ??
+      ctrl.createTestItem(uri.toString(), path.basename(uri.fsPath), uri);
+    fileItem.canResolveChildren = false;
+    const children: vscode.TestItem[] = [];
+    const lines = text.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+      DEFTEST_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = DEFTEST_RE.exec(lines[i])) !== null) {
+        const item = ctrl.createTestItem(`${uri.toString()}#${m[1]}`, m[1], uri);
+        item.range = new vscode.Range(i, 0, i, lines[i].length);
+        children.push(item);
+      }
+    }
+    if (children.length === 0) {
+      ctrl.items.delete(uri.toString());
+      return;
+    }
+    fileItem.children.replace(children);
+    ctrl.items.add(fileItem);
+  }
+
+  async function discoverAll(): Promise<void> {
+    const uris = await vscode.workspace.findFiles(TEST_GLOB);
+    await Promise.all(uris.map(parseTestFile));
+  }
+
+  ctrl.resolveHandler = async (item) => {
+    if (!item) {
+      await discoverAll();
+    }
+  };
+
+  const watcher = vscode.workspace.createFileSystemWatcher(TEST_GLOB);
+  context.subscriptions.push(watcher);
+  watcher.onDidCreate(parseTestFile);
+  watcher.onDidChange(parseTestFile);
+  watcher.onDidDelete((uri) => ctrl.items.delete(uri.toString()));
+
+  async function runHandler(
+    request: vscode.TestRunRequest,
+    token: vscode.CancellationToken,
+    withCoverage: boolean,
+  ): Promise<void> {
+    const run = ctrl.createTestRun(request);
+    const fileItems = new Map<string, { file: vscode.TestItem; tests?: Set<string> }>();
+
+    const addFile = (file: vscode.TestItem, test?: vscode.TestItem) => {
+      let entry = fileItems.get(file.id);
+      if (!entry) {
+        entry = { file, tests: test ? new Set() : undefined };
+        fileItems.set(file.id, entry);
+      }
+      if (test && entry.tests) {
+        entry.tests.add(test.label);
+      } else if (!test) {
+        entry.tests = undefined; // whole file requested
+      }
+    };
+    if (request.include) {
+      for (const item of request.include) {
+        if (item.parent) {
+          addFile(item.parent, item);
+        } else {
+          addFile(item);
+        }
+      }
+    } else {
+      await discoverAll();
+      ctrl.items.forEach((item) => addFile(item));
+    }
+
+    const cfg = vscode.workspace.getConfiguration("lisp");
+    const command = cfg.get<string>("testRunner.command") ||
+      cfg.get<string>("debugAdapter.command", "lisp-debug");
+
+    for (const { file, tests } of fileItems.values()) {
+      if (token.isCancellationRequested) {
+        break;
+      }
+      const uri = file.uri;
+      if (!uri) {
+        continue;
+      }
+      const tmpBase = path.join(os.tmpdir(), `lisp-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+      const reportPath = `${tmpBase}.json`;
+      const lcovPath = `${tmpBase}.lcov`;
+      const args = ["--test", uri.fsPath, "--test-json", reportPath];
+      if (withCoverage) {
+        args.push("--coverage", lcovPath);
+      }
+      file.children.forEach((t) => {
+        if (!tests || tests.has(t.label)) {
+          run.enqueued(t);
+        }
+      });
+      const { stdout, stderr } = await execRunner(command, args, path.dirname(uri.fsPath), token);
+      if (stdout) {
+        run.appendOutput(stdout.replace(/\n/g, "\r\n"));
+      }
+      if (stderr) {
+        run.appendOutput(stderr.replace(/\n/g, "\r\n"));
+      }
+
+      let report: SuiteReport | undefined;
+      try {
+        report = JSON.parse(fs.readFileSync(reportPath, "utf8")) as SuiteReport;
+      } catch {
+        // No report: the runner failed before running tests (load error,
+        // missing binary…) — mark everything errored with the output.
+        file.children.forEach((t) => {
+          if (!tests || tests.has(t.label)) {
+            run.errored(t, new vscode.TestMessage(stderr || stdout || "test runner produced no report"));
+          }
+        });
+      } finally {
+        fs.rmSync(reportPath, { force: true });
+      }
+
+      if (report) {
+        const byName = new Map(report.tests.map((t) => [t.name, t]));
+        file.children.forEach((t) => {
+          if (tests && !tests.has(t.label)) {
+            return;
+          }
+          const res = byName.get(t.label);
+          if (!res) {
+            run.skipped(t);
+            return;
+          }
+          run.started(t);
+          if (res.ok) {
+            run.passed(t);
+            return;
+          }
+          const messages: vscode.TestMessage[] = [];
+          if (res.error) {
+            messages.push(new vscode.TestMessage(res.error));
+          }
+          for (const c of res.checks) {
+            if (c.ok) {
+              continue;
+            }
+            let msg: vscode.TestMessage;
+            if (c.expected !== undefined && c.actual !== undefined && !c.error) {
+              msg = vscode.TestMessage.diff(
+                c.message ? `${c.form} — ${c.message}` : c.form,
+                c.expected,
+                c.actual,
+              );
+            } else {
+              const text = c.error ? `${c.form}: ${c.error}` : `${c.form}: failed`;
+              msg = new vscode.TestMessage(c.message ? `${text} — ${c.message}` : text);
+            }
+            const loc = checkLocation(uri, c);
+            if (loc) {
+              msg.location = loc;
+            }
+            messages.push(msg);
+          }
+          run.failed(t, messages);
+        });
+      }
+
+      if (withCoverage) {
+        try {
+          for (const fc of parseLcov(lcovPath, coverageDetails)) {
+            run.addCoverage(fc);
+          }
+        } catch {
+          // no coverage output (e.g. release binary): ignore
+        } finally {
+          fs.rmSync(lcovPath, { force: true });
+        }
+      }
+    }
+    run.end();
+  }
+
+  ctrl.createRunProfile(
+    "Run",
+    vscode.TestRunProfileKind.Run,
+    (req, token) => runHandler(req, token, false),
+    true,
+  );
+  const covProfile = ctrl.createRunProfile(
+    "Coverage",
+    vscode.TestRunProfileKind.Coverage,
+    (req, token) => runHandler(req, token, true),
+    false,
+  );
+  covProfile.loadDetailedCoverage = async (_run, fileCoverage) =>
+    coverageDetails.get(fileCoverage as vscode.FileCoverage) ?? [];
+}
+
+/** Resolve a check's module/line to a VS Code location, if possible. */
+function checkLocation(testUri: vscode.Uri, c: CheckReport): vscode.Location | undefined {
+  if (!c.line || c.line <= 0) {
+    return undefined;
+  }
+  let file = c.module;
+  if (!file) {
+    return undefined;
+  }
+  if (!path.isAbsolute(file)) {
+    file = path.join(path.dirname(testUri.fsPath), file);
+  }
+  const pos = new vscode.Position(c.line - 1, 0);
+  return new vscode.Location(vscode.Uri.file(file), pos);
+}
+
+/** Run the CLI test runner; resolves with its output even on non-zero exit
+ * (test failures exit 1 by design). */
+function execRunner(
+  command: string,
+  args: string[],
+  cwd: string,
+  token: vscode.CancellationToken,
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    let child: ChildProcess | undefined;
+    const done = (stdout: string, stderr: string) => resolve({ stdout, stderr });
+    child = execFile(command, args, { cwd }, (error, stdout, stderr) => {
+      if (error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+        done("", `cannot run '${command}': not found on PATH`);
+        return;
+      }
+      done(stdout ?? "", stderr ?? "");
+    });
+    token.onCancellationRequested(() => child?.kill());
+  });
+}
+
+/** Parse an lcov tracefile into FileCoverage objects, stashing per-line
+ * detail for loadDetailedCoverage. */
+function parseLcov(
+  lcovPath: string,
+  details: WeakMap<vscode.FileCoverage, vscode.StatementCoverage[]>,
+): vscode.FileCoverage[] {
+  const text = fs.readFileSync(lcovPath, "utf8");
+  const out: vscode.FileCoverage[] = [];
+  let file: string | undefined;
+  let statements: vscode.StatementCoverage[] = [];
+  const flush = () => {
+    if (!file) {
+      return;
+    }
+    const covered = statements.filter((s) => (s.executed as number) > 0).length;
+    const fc = new vscode.FileCoverage(
+      vscode.Uri.file(file),
+      new vscode.TestCoverageCount(covered, statements.length),
+    );
+    details.set(fc, statements);
+    out.push(fc);
+    file = undefined;
+    statements = [];
+  };
+  for (const line of text.split("\n")) {
+    if (line.startsWith("SF:")) {
+      flush();
+      file = line.slice(3).trim();
+    } else if (line.startsWith("DA:")) {
+      const [lineNo, count] = line.slice(3).split(",").map(Number);
+      if (Number.isFinite(lineNo) && lineNo > 0) {
+        statements.push(
+          new vscode.StatementCoverage(
+            Number.isFinite(count) ? count : 0,
+            new vscode.Position(lineNo - 1, 0),
+          ),
+        );
+      }
+    } else if (line.startsWith("end_of_record")) {
+      flush();
+    }
+  }
+  flush();
+  return out;
+}


### PR DESCRIPTION
Implements the full testing-and-coverage pipeline discussed: a Clojure-style test framework for lisp code, a CLI runner, per-line coverage via the `lispdebug` eval hook, and VS Code integration with the native Test Coverage API.

## 1. `test` library — `deftest` / `is` / `are`

```clojure
(deftest double-works
  (is (= 4 (double 2)))                 ; expected/actual reporting on failure
  (are [in out] (= out (double in))
    0 0
    5 10))
```

- Macros in `lib/test/header-test.lisp`; Go builtins carry the registry (per environment, `test.FromEnv`). `are` substitutes symbols in Go so the `(= …)` special case survives the template.
- A failing `is` **outside** `deftest` throws — plain scripts and legacy `*_test.mal` suites keep failing loudly.
- `(test/run-tests!)` runs the suite from lisp and returns results as data.

## 2. CLI runner

- `--test DIR|FILE` discovers `*_test.lisp` + legacy `*_test.mal` (the `*test-params*` contract is preserved), loads, runs, prints Go-style failures with `file:line`, exits non-zero on failure.
- `--test-json FILE` writes a machine report (consumed by the extension).

## 3. Coverage (lispdebug builds)

`--coverage FILE` installs an `EvalHook` that counts evaluated forms per source line (chaining to any previously installed hook) and writes **lcov** on completion. The denominator comes from statically parsing each executed file; test files are excluded (as Go excludes `_test.go`) and pseudo-modules (REPL, `-e`, `$…` headers) are skipped. Release builds reject the flag with a clear error. Known limitation (documented): literal atoms carry no source position, so a line holding only a literal is not counted as coverable.

## 4. VS Code extension 0.9.0

- **Testing panel**: `(deftest …)` discovery with per-test run buttons; failures as inline messages with expected/actual **diffs** and check locations.
- **Coverage profile**: runs under `--coverage` and feeds VS Code's **native coverage API** (engine bump to `^1.88.0`) — covered/uncovered lisp lines in the gutter and the Test Coverage view, Go-style.
- `lisp.testRunner.command` setting (defaults to `lisp.debugAdapter.command`).

## Verification

- New tests: `lib/test/test_test.go` (framework semantics incl. re-registration and outside-deftest throw), `command/test_runner_test.go` (runner, JSON report, load errors), `command/coverage_debug_test.go` (lcov content: hit/unhit lines, test-file exclusion; `lispdebug`-tagged).
- `gofmt`/`go vet` clean (plain + `lispdebug`); full suite green (plain + `lispdebug`); `-race` green on root, lib/test and command (both modes); docgen sync guard passes; `LANGUAGE.md` regenerated; extension compiles under `@types/vscode` 1.118.
- Exercised end-to-end: demo suite with passing/failing tests → correct exit codes, JSON report and lcov (unhit line reported as `DA:…,0`, test file excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)