### PR TITLE
feat: Read_program (no more (do …) wrapper hacks) and shebang scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,16 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   suites (200+ tests, 1300 value-based checks), run by `TestDeftests`
   and by `lisp --test deftests/`; the originals stay untouched under
   the line-based harness
+- shebang scripts: a leading `#!/usr/bin/env lisp` line reads as a
+  comment (the two bytes become `;;` in place, so positions stay
+  exact), `lisp --fmt` preserves it verbatim, and the VS Code
+  extension (0.9.1) recognises extensionless files by their first line
+- `read-program` builtin and `reader.Read_program`: read a whole file
+  — any number of top-level forms — into one `(do …)` AST with
+  positions matching the source exactly. `load-file`, script
+  execution, the LSP analyser and the coverage universe now build on
+  it, retiring the textual `"(do …)"` wrapping, the `;; $MODULE`
+  prefix line and every row-shift correction that came with them
 - commas are whitespace, as in Clojure and kanaka/mal: `(1 2, 3)`
   reads as `(1 2 3)` (previously a comma silently read as a `,`
   symbol; the formatter already treated commas as whitespace)

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -236,6 +236,7 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `println` | `[& args]` | Prints its arguments (unquoted) separated by spaces, then a newline. |
 | `prn` | `[& args]` | Prints its arguments (readable) separated by spaces, then a newline. |
 | `range` | `[start end]` | Vector of integers from start to end-1. |
+| `read-program` | `[src module]` | Reads every form in src as one (do …) AST with positions attributed to module; load-file builds on it. |
 | `read-string` | `[string]` | Reads the first lisp form from string. |
 | `rename-keys` | `[map keymap]` | Copy of map with keys renamed according to keymap. |
 | `rest` | `[coll]` | All but the first element of coll, as a list. |

--- a/README.md
+++ b/README.md
@@ -353,6 +353,22 @@ Use <kbd>Ctrl</kbd> + <kbd>D</kbd> to exit Lisp REPL.
 lisp helloworld.lisp
 ```
 
+Scripts can also be directly executable: a leading shebang line reads
+as a comment (positions in error messages are unaffected, and
+`lisp --fmt` preserves it verbatim). Use the portable `env` form:
+
+```bash
+cat > hello <<'EOF'
+#!/usr/bin/env lisp
+(println "hello" (first *ARGV*))
+EOF
+chmod +x hello
+./hello world
+```
+
+In VS Code, extensionless files with a lisp shebang are recognised by
+their first line and get highlighting, LSP and the debugger as usual.
+
 ### Execute inline expression
 
 ```bash

--- a/command/coverage_debug.go
+++ b/command/coverage_debug.go
@@ -61,17 +61,15 @@ func coverableLines(path string) (map[int]bool, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Files hold many top-level forms; wrap in (do …) like the LSP does
-	// and shift rows back by the extra first line.
-	ast, err := reader.Read_str("(do\n"+string(src)+"\n)", types.NewCursorFile(path), nil)
+	ast, err := reader.Read_program(string(src), types.NewCursorFile(path), nil)
 	if err != nil {
 		return nil, err
 	}
 	lines := map[int]bool{}
 	var walk func(form types.MalType)
 	mark := func(cur *types.Position) {
-		if cur != nil && cur.BeginRow > 1 {
-			lines[cur.BeginRow-1] = true
+		if cur != nil && cur.BeginRow > 0 {
+			lines[cur.BeginRow] = true
 		}
 	}
 	walk = func(form types.MalType) {

--- a/command/preamble.go
+++ b/command/preamble.go
@@ -95,8 +95,7 @@ func runScript(ctx context.Context, env types.EnvType, fileName string, preamble
 		return nil, err
 	}
 
-	src := ";; $MODULE " + fileName + "\n(do " + content + "\n)"
-	ast, err := reader.Read_str(src, nil, &types.HashMap{Val: values}, env)
+	ast, err := reader.Read_program(content, types.NewCursorFile(fileName), &types.HashMap{Val: values}, env)
 	if err != nil {
 		return nil, err
 	}

--- a/deftests/shebang_test.lisp
+++ b/deftests/shebang_test.lisp
@@ -1,0 +1,11 @@
+#!/usr/bin/env lisp
+;; This file is itself a shebang script: loading it through the test
+;; runner proves load-file treats the #! line as a comment.
+
+(deftest shebang-is-a-comment
+  (is (= 7 (read-string "#!/usr/bin/env lisp\n7"))))
+
+(deftest read-program-builtin
+  (is (= "(do 1 2 3)" (pr-str (read-program "1 2 3" "inline"))))
+  (is (= 3 (eval (read-program "(def shebang-x 1)\n(+ shebang-x 2)" "inline"))))
+  (is (= nil (read-program ";; only a comment" "inline"))))

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -23,6 +23,11 @@ func TestSource(t *testing.T) {
 			want: "(+ 1 2 3)\n",
 		},
 		{
+			name: "shebang preserved verbatim",
+			in:   "#!/usr/bin/env lisp\n(println   1)\n",
+			want: "#!/usr/bin/env lisp\n(println 1)\n",
+		},
+		{
 			name: "vector aligns to first element",
 			in:   "(let [a 1\n   b 2]\n  a)\n",
 			want: "(let [a 1\n      b 2]\n  a)\n",

--- a/format/lex.go
+++ b/format/lex.go
@@ -37,6 +37,17 @@ func lex(src string) ([]token, error) {
 		nl = 0
 	}
 
+	// A leading shebang is a comment token, kept verbatim so formatting
+	// preserves it byte for byte.
+	if strings.HasPrefix(src, "#!") {
+		j := strings.IndexByte(src, '\n')
+		if j < 0 {
+			j = n
+		}
+		emit(tComment, strings.TrimRight(src[:j], " \t\r"))
+		i = j
+	}
+
 	for i < n {
 		c := src[i]
 		switch {

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -86,6 +86,12 @@ func Load(env EnvType) {
 	})
 	call.Call(env, sPew)
 	call.CallOverrideFN(env, "read-string", func(a MalType) (MalType, error) { return reader.Read_str(a.(string), nil, nil) })
+	// read-program reads a whole file's worth of forms into one (do …)
+	// AST with positions attributed to module; like read-string it runs
+	// without an environment («…» constructors are not resolved).
+	call.CallOverrideFN(env, "read-program", func(src, module string) (MalType, error) {
+		return reader.Read_program(src, NewCursorFile(module), nil)
+	})
 	call.CallOverrideFN(env, "set", func(a MalType) (Set, error) { return NewSet(a) })
 	call.Call(env, keys)
 	call.Call(env, vals)

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -130,6 +130,7 @@ var coreDocs = []struct{ name, arglist, doc string }{
 	{"set", "[coll]", "Creates a set from the elements of coll."},
 
 	// Time & version
+	{"read-program", "[src module]", "Reads every form in src as one (do …) AST with positions attributed to module; load-file builds on it."},
 	{"time-ms", "[]", "Current time in milliseconds since the epoch."},
 	{"time-ns", "[]", "Current time in nanoseconds since the epoch."},
 	{"time-format", "[ms]", "Formats epoch milliseconds (as of time-ms) as an RFC 3339 UTC timestamp with millisecond precision."},

--- a/lib/core/header-load-file.lisp
+++ b/lib/core/header-load-file.lisp
@@ -3,11 +3,7 @@
 (defn load-file
     "Reads and evaluates the lisp file at file-path in the current environment; returns the value of its last form."
     [file-path]
-    (eval
-        (read-string
-            (str
-                ";; $MODULE " file-path "\n"
-                "(do " (slurp file-path) "\n)"))))
+    (eval (read-program (slurp file-path) file-path)))
 
 ;; load-file-once is registered in Go by nscore.LoadInput: its seen-set
 ;; needs mutable state, and atoms live in the concurrent library, which

--- a/lsp/analyse.go
+++ b/lsp/analyse.go
@@ -67,12 +67,9 @@ type analysis struct {
 	preambles []preambleDef   // in-file placeholder defaults
 }
 
-// analyseDocument parses content with the interpreter's reader and
-// extracts diagnostics and top-level definitions.
-//
-// The reader parses a single form, so the document is wrapped in
-// `(do\n…\n)`; the extra leading line shifts every row by one, which is
-// undone by walking the AST once. This reuses the real reader — the
+// analyseDocument parses content with the interpreter's reader
+// (Read_program: every top-level form, positions matching the document
+// exactly) and extracts diagnostics and top-level definitions — the
 // same positions, the same errors the interpreter itself would report.
 // emptyPlaceholders lets the reader accept `$NAME` preamble
 // placeholders in analysed documents: their values are only known at
@@ -94,13 +91,11 @@ func analyseDocument(name, content string) *analysis {
 			a.preambles = append(a.preambles, preambleDef{name: m[1], expr: m[2], line: i})
 		}
 	}
-	wrapped := "(do\n" + content + "\n)"
-	ast, err := reader.Read_str(wrapped, types.NewCursorFile(name), emptyPlaceholders)
+	ast, err := reader.Read_program(content, types.NewCursorFile(name), emptyPlaceholders)
 	if err != nil {
 		a.diagnostics = append(a.diagnostics, diagnosticFromError(err))
 		return a
 	}
-	shiftRows(ast, -1, map[*types.Position]bool{})
 	wrapper, ok := ast.(types.List)
 	if !ok || len(wrapper.Val) == 0 {
 		return a
@@ -644,8 +639,7 @@ func (b *semBuilder) ref(sym types.Symbol) {
 }
 
 // diagnosticFromError converts a reader error into an LSP diagnostic.
-// Rows are shifted by -1 to undo the `(do\n` wrapper line; LSP positions
-// are zero-based while the reader's are one-based.
+// LSP positions are zero-based while the reader's are one-based.
 func diagnosticFromError(err error) Diagnostic {
 	d := Diagnostic{
 		Severity: severityError,
@@ -655,10 +649,9 @@ func diagnosticFromError(err error) Diagnostic {
 	var pos *types.Position
 	if lispErr, ok := err.(lisperror.LispError); ok {
 		pos = lispErr.Position()
-		// The wrapped LispError message embeds "<module>:<row>:", with the
-		// row offset by the `(do\n` wrapper line. The diagnostic range
-		// already carries the (corrected) position, so surface only the
-		// bare underlying message.
+		// The wrapped LispError message embeds "<module>:<row>:"; the
+		// diagnostic range already carries the position, so surface only
+		// the bare underlying message.
 		if inner, ok := lispErr.ErrorValue().(error); ok {
 			d.Message = inner.Error()
 		}
@@ -667,7 +660,7 @@ func diagnosticFromError(err error) Diagnostic {
 		d.Range = Range{Start: Position{0, 0}, End: Position{0, 1}}
 		return d
 	}
-	startLine := pos.BeginRow - 2 // -1 wrapper line, -1 zero-based
+	startLine := pos.BeginRow - 1 // zero-based
 	if startLine < 0 {
 		startLine = 0
 	}
@@ -675,7 +668,7 @@ func diagnosticFromError(err error) Diagnostic {
 	if startChar < 0 {
 		startChar = 0
 	}
-	endLine := pos.Row - 2
+	endLine := pos.Row - 1
 	endChar := pos.Col
 	if endLine < startLine || (endLine == startLine && endChar <= startChar) {
 		endLine = startLine
@@ -734,43 +727,6 @@ func definitionOf(form types.MalType) (definition, bool) {
 		}
 	}
 	return d, true
-}
-
-// shiftRows walks the AST adjusting every cursor's rows by delta. seen
-// guards against adjusting a shared *Position twice.
-func shiftRows(ast types.MalType, delta int, seen map[*types.Position]bool) {
-	switch n := ast.(type) {
-	case types.List:
-		shiftPos(n.Cursor, delta, seen)
-		for _, c := range n.Val {
-			shiftRows(c, delta, seen)
-		}
-	case types.Vector:
-		shiftPos(n.Cursor, delta, seen)
-		for _, c := range n.Val {
-			shiftRows(c, delta, seen)
-		}
-	case types.HashMap:
-		shiftPos(n.Cursor, delta, seen)
-		for _, v := range n.Val {
-			shiftRows(v, delta, seen)
-		}
-	case types.Set:
-		shiftPos(n.Cursor, delta, seen)
-	case types.Symbol:
-		shiftPos(n.Cursor, delta, seen)
-	}
-}
-
-func shiftPos(p *types.Position, delta int, seen map[*types.Position]bool) {
-	if p == nil || seen[p] {
-		return
-	}
-	seen[p] = true
-	p.BeginRow += delta
-	if p.Row > 0 {
-		p.Row += delta
-	}
 }
 
 // rangeOf converts a reader position (one-based) to an LSP range

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -43,6 +43,11 @@ func (tr *tokenReader) peek() *Token {
 }
 
 func tokenize(sourceCode string, cursor *Position) ([]Token, error) {
+	// A leading shebang (#!/usr/bin/env lisp) reads as a comment: the two
+	// bytes are replaced in place so every position stays exact.
+	if strings.HasPrefix(sourceCode, "#!") {
+		sourceCode = ";;" + sourceCode[2:]
+	}
 	result := make([]Token, 0, 1)
 
 	var s scanner.Scanner
@@ -409,4 +414,37 @@ func Read_str(str string, cursor *Position, placeholderValues *HashMap, ns ...En
 		return nil, lisperror.NewLispError(errors.New("not all tokens where parsed"), tokenReader.tokens[tokenReader.position-1])
 	}
 	return res, nil
+}
+
+// Read_program reads a whole compilation unit — any number of top-level
+// forms — and returns them wrapped in a single (do …) form built
+// directly as AST, so every position matches the source exactly: no
+// textual "(do " wrapping, no `;; $MODULE` prefix line, no row
+// shifting. A source with no forms (empty, or only comments) reads as
+// nil.
+func Read_program(str string, cursor *Position, placeholderValues *HashMap, ns ...EnvType) (MalType, error) {
+	if cursor == nil {
+		cursor = NewAnonymousCursorHere(1, 1)
+	}
+	tokens, err := tokenize(str, cursor)
+	if err != nil {
+		return nil, err
+	}
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+	rdr := tokenReader{tokens: tokens, position: 0}
+	var nsv EnvType
+	if len(ns) != 0 {
+		nsv = ns[0]
+	}
+	forms := []MalType{Symbol{Val: "do"}}
+	for rdr.position < len(rdr.tokens) {
+		form, err := read_form(&rdr, placeholderValues, nsv)
+		if err != nil {
+			return nil, err
+		}
+		forms = append(forms, form)
+	}
+	return List{Val: forms, Cursor: tokens[0].Cursor.Copy()}, nil
 }

--- a/reader/reader_test.go
+++ b/reader/reader_test.go
@@ -197,6 +197,67 @@ func TestCommasAreWhitespace(t *testing.T) {
 	}
 }
 
+// TestShebang checks that a leading #! line reads as a comment without
+// disturbing positions, and that #! anywhere else stays an error.
+func TestShebang(t *testing.T) {
+	ast, err := reader.Read_str("#!/usr/bin/env lisp\n7", types.NewCursorFile(t.Name()), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ast != 7 {
+		t.Fatalf("got %v, want 7", ast)
+	}
+	if _, err := reader.Read_str("7\n#!/usr/bin/env lisp", types.NewCursorFile(t.Name()), nil); err == nil {
+		t.Fatal("a mid-file #! must remain an error")
+	}
+}
+
+// TestReadProgram checks the multi-form reader: every top-level form in
+// one synthesized (do …), exact positions, nil for an empty program.
+func TestReadProgram(t *testing.T) {
+	ast, err := reader.Read_program("(def a 1)\n(def b 2)\nb", types.NewCursorFile(t.Name()), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prog, ok := ast.(types.List)
+	if !ok || len(prog.Val) != 4 {
+		t.Fatalf("expected (do f1 f2 f3), got %s", printer.Pr_str(ast, true))
+	}
+	if head, ok := prog.Val[0].(types.Symbol); !ok || head.Val != "do" {
+		t.Fatalf("expected do head, got %s", printer.Pr_str(prog.Val[0], true))
+	}
+	// positions match the source exactly: (def b 2) starts on row 2
+	second, ok := prog.Val[2].(types.List)
+	if !ok || second.Cursor == nil || second.Cursor.BeginRow != 2 {
+		t.Fatalf("expected second form on row 2, got %+v", second.Cursor)
+	}
+
+	// empty programs (blank or comment-only) read as nil
+	for _, src := range []string{"", "   \n", ";; only a comment\n", "#!/usr/bin/env lisp\n"} {
+		ast, err := reader.Read_program(src, types.NewCursorFile(t.Name()), nil)
+		if err != nil {
+			t.Fatalf("%q: %v", src, err)
+		}
+		if ast != nil {
+			t.Fatalf("%q: expected nil, got %s", src, printer.Pr_str(ast, true))
+		}
+	}
+
+	// a single form still comes wrapped, for a uniform shape
+	ast, err = reader.Read_program("42", types.NewCursorFile(t.Name()), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := printer.Pr_str(ast, true); got != "(do 42)" {
+		t.Fatalf("got %s, want (do 42)", got)
+	}
+
+	// malformed input errors
+	if _, err := reader.Read_program("(1 2", types.NewCursorFile(t.Name()), nil); err == nil {
+		t.Fatal("expected an error for an unbalanced form")
+	}
+}
+
 // TestMultilineString checks that a "…" literal may span physical lines
 // (Clojure-style): the literal newline is kept verbatim in the string value,
 // and an unterminated literal still errors at EOF.

--- a/tools/vscode-lisp/package-lock.json
+++ b/tools/vscode-lisp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-lisp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-lisp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "SEE LICENSE IN ../../LICENCE",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/tools/vscode-lisp/package.json
+++ b/tools/vscode-lisp/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-lisp",
   "displayName": "jig/lisp",
   "description": "Language support and debugger for the jig/lisp interpreter",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "publisher": "jig",
   "icon": "./icons/icon.png",
   "license": "SEE LICENSE IN ../../LICENCE",
@@ -41,7 +41,8 @@
         "icon": {
           "light": "./icons/lisp.svg",
           "dark": "./icons/lisp.svg"
-        }
+        },
+        "firstLine": "^#!.*\\blisp(-debug)?\\b"
       }
     ],
     "iconThemes": [


### PR DESCRIPTION
The two loading questions, solved together — the shebang only works end-to-end once the wrapper is gone, so they share a PR.

## 1. `Read_program`: the elegant fix for the `(do …)` wrapper

The reader gains **`Read_program`**: it reads a whole compilation unit (any number of top-level forms) and returns one `(do …)` form **built directly as AST** — positions match the source exactly *by construction*. An empty/comment-only source reads as `nil`.

Retired with it, all four accumulated position hacks:
- the textual `"(do " + content + ")"` wrapping (load-file, runScript, LSP, coverage);
- the `;; $MODULE` prefix line + `rowShift` compensation in the load paths (the `Read_str` mechanism itself stays, for the library headers that carry it);
- the LSP's `shiftRows` AST walk and the `-2` diagnostics offsets;
- the coverage universe's `-1`.

`load-file` becomes two calls: `(eval (read-program (slurp file-path) file-path))` — the new **`read-program` builtin** reads a source string into a positioned AST (like `read-string`, it runs without an environment, so `«…»` constructors are not resolved). Fixes an old subtlety too: line 1 of a loaded file no longer had a 4-column shift from the `(do ` prefix.

**Verified non-breaking**: the whole suite (plain + `lispdebug`, including the DAP/LSP position tests) passes untouched, and the coverage lcov output is **byte-identical** before and after the rewiring.

## 2. Shebang scripts

- A **leading** `#!` line reads as a comment: the two bytes become `;;` in place, so every position stays exact. A mid-file `#!` remains an error.
- The formatter lexes a leading shebang as a **verbatim** comment: `lisp --fmt` preserves it byte for byte.
- End to end: `chmod +x` + `#!/usr/bin/env lisp` runs the script through PATH (the portable `env` form is the one documented in the README).
- `deftests/shebang_test.lisp` is itself a shebang script, so the test runner proves the load path continuously.

## 3. VS Code (0.9.1)

`firstLine: ^#!.*\blisp(-debug)?\b` on the language contribution: extensionless scripts are recognised by their shebang and get highlighting, LSP and debugger as usual (everything keys on the language id).

## Verification

`gofmt`/`go vet` clean (plain + `lispdebug`); full suite green in both modes; `-race` on reader/command/lsp green; `TestShebang`, `TestReadProgram`, formatter round-trip and the live shebang deftest added; exercised end to end (executable script, error positions on line 2, preamble path, lcov parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)