### PR TITLE
feat(core): add an exit builtin for process status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,10 @@ identifiers or bit patterns keep working and now survive any width.
 
 Non-breaking, for context (see `git log v0.2.24..` for the full list):
 
+- `exit` builtin: `(exit)` / `(exit status)` ends the process with the
+  given status (`0` by default), like Clojure's `System/exit`. It stops
+  before the interpreter echoes a script's final value, so a program run
+  as a file can set a real exit code without printing a trailing result
 - `loop`/`recur` special forms; `into`, and `conj` accepting `[k v]`
   pairs / maps
 - `recur` in a function's tail position (Clojure semantics): the

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -285,6 +285,7 @@ Reading and writing files and stdin.
 
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
+| `exit` | `([] [status])` | Terminates the process with status (an integer, 0 when omitted). Does not return. |
 | `load-file` | `[file-path]` | Reads and evaluates the lisp file at file-path in the current environment; returns the value of its last form. |
 | `load-file-once` | `[file-path]` | Like load-file, but never loads the same path twice. |
 | `readline` | `[prompt]` | Prints prompt and reads a line from input. |

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -298,6 +298,7 @@ func LoadInput(env EnvType) {
 	call.Call(env, slurp)
 	call.Call(env, spit, 2, 4)
 	call.Call(env, readLine)
+	call.Call(env, exit, 0, 1)
 
 	loadInputDocs(env)
 }
@@ -538,6 +539,26 @@ func spit(fileName, contents string, opts ...MalType) error {
 		return werr
 	}
 	return cerr
+}
+
+// osExit is the process-exit hook, indirected so tests can observe the
+// requested status instead of terminating the test binary.
+var osExit = os.Exit
+
+// exit terminates the process with the given status code (0 when omitted),
+// like Clojure's System/exit. It does not return; stdout is unbuffered (fmt
+// writes straight to os.Stdout), so any preceding output is not lost.
+func exit(args ...MalType) (MalType, error) {
+	code := 0
+	if len(args) == 1 {
+		n, ok := args[0].(int)
+		if !ok {
+			return nil, fmt.Errorf("exit: status must be an integer, got %T", args[0])
+		}
+		code = n
+	}
+	osExit(code)
+	return nil, nil
 }
 
 // gensymCounter feeds gensym; a Go atomic (rather than a lisp atom in

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -30,6 +30,7 @@ var inputDocs = []struct{ name, arglist, doc string }{
 	{"slurp", "[filename]", "Reads a file and returns its contents as a string."},
 	{"spit", "[filename s & opts]", "Writes string s to a file, creating or truncating it; with :append true, appends instead."},
 	{"readline", "[prompt]", "Prints prompt and reads a line from input."},
+	{"exit", "([] [status])", "Terminates the process with status (an integer, 0 when omitted). Does not return."},
 }
 
 var coreDocs = []struct{ name, arglist, doc string }{

--- a/lib/core/exit_test.go
+++ b/lib/core/exit_test.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+	"testing"
+)
+
+// TestExit checks the exit builtin through the osExit indirection, so the
+// test observes the requested status instead of terminating the test binary.
+func TestExit(t *testing.T) {
+	orig := osExit
+	defer func() { osExit = orig }()
+
+	var got int
+	called := false
+	osExit = func(code int) { got, called = code, true }
+
+	// (exit 3) requests status 3
+	if _, err := exit(3); err != nil {
+		t.Fatalf("exit(3): unexpected error %v", err)
+	}
+	if !called || got != 3 {
+		t.Fatalf("exit(3): called=%v got=%d, want status 3", called, got)
+	}
+
+	// (exit) defaults to status 0
+	called, got = false, -1
+	if _, err := exit(); err != nil {
+		t.Fatalf("exit(): unexpected error %v", err)
+	}
+	if !called || got != 0 {
+		t.Fatalf("exit(): called=%v got=%d, want status 0", called, got)
+	}
+
+	// (exit "x") is a type error and must not terminate
+	called = false
+	if _, err := exit("x"); err == nil {
+		t.Fatal(`exit("x"): expected an error for a non-integer status`)
+	}
+	if called {
+		t.Fatal(`exit("x"): must not terminate on a bad argument`)
+	}
+}


### PR DESCRIPTION
## What

Adds an `exit` core builtin:

- `(exit)` terminates with status `0`
- `(exit status)` terminates with the given integer status
- a non-integer status is a normal lisp error (does not terminate)

Like Clojure's `System/exit`. Registered by `LoadInput` next to `slurp`/`spit`, documented in `LANGUAGE.md` (regenerated) and `CHANGELOG.md`.

## Why

When a script is **run as a file**, the interpreter echoes the value of its last form (`fmt.Println(result)` in `command`). Shebang command scripts that end with `(main *ARGV*)` therefore:

1. print a spurious trailing `0`/`nil`, and
2. cannot set a real process exit code — a `main` returning `1` on error still exits `0`.

`(exit (main *ARGV*))` fixes both: it stops before the echo and sets the status. Scripts that do **not** call `exit` keep the existing echo behaviour (e.g. a generator whose output is its final map).

## Notes

- `stdout` is unbuffered (`fmt` writes straight to `os.Stdout`), so output printed before `exit` is not lost — verified end to end (`(println "hola") (exit 2)` prints `hola`, exits `2`).
- `os.Exit` is indirected through a package-level `osExit` var so the unit test can observe the requested status instead of terminating the test binary.

## Tests

- `TestExit` (new): status `3`, default `0`, and the non-integer error path.
- `docgen` drift test and `TestCoreBuiltinsAllDocumented` pass (doc added).
- `go test ./...`, `go vet`, `gofmt` clean.
