### PR TITLE
feat(vscode-lisp): file-level Run/Run-All test CodeLens (Go parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,9 +163,10 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   suites (200+ tests, 1300 value-based checks), run by `TestDeftests`
   and by `lisp --test deftests/`; the originals stay untouched under
   the line-based harness
-- Debug Test: the VS Code extension (0.9.2) gains a **Debug** run
-  profile and Go-style **Run Test | Debug Test** CodeLens above each
-  `deftest`. Debugging launches a DAP session that loads the file and
+- Debug Test: the VS Code extension (0.9.3) gains a **Debug** run
+  profile and Go-style CodeLens — **Run Test | Debug Test** above each
+  `deftest`, plus **Run File Tests | Run All Tests** at the top of any
+  file that has tests. Debugging launches a DAP session that loads the file and
   runs just that test (new `test/run-test!` builtin + `--run-test`
   flag), so breakpoints in the test body are hit. The debugger no
   longer stops when a `(fn …)` closure is merely created (only when its

--- a/tools/vscode-lisp/README.md
+++ b/tools/vscode-lisp/README.md
@@ -22,6 +22,9 @@ interpreter.
 - Document formatting (a gofmt-style canonical layout, comments
   preserved) via the language server. Enabled on save by default for
   lisp files, or run **Format Document** (`⇧⌥F`) manually.
+- Go-style CodeLens: **Run Test | Debug Test** above each `(deftest …)`,
+  and **Run File Tests | Run All Tests** at the top of any file with
+  tests.
 - Testing panel integration: `(deftest …)` tests in `*_test.lisp` /
   `*_test.mal` files appear in the Test Explorer with run buttons and
   inline failure messages (expected/actual diffs from `(is (= … …))`).

--- a/tools/vscode-lisp/package-lock.json
+++ b/tools/vscode-lisp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-lisp",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-lisp",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "SEE LICENSE IN ../../LICENCE",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/tools/vscode-lisp/package.json
+++ b/tools/vscode-lisp/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-lisp",
   "displayName": "jig/lisp",
   "description": "Language support and debugger for the jig/lisp interpreter",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "publisher": "jig",
   "icon": "./icons/icon.png",
   "license": "SEE LICENSE IN ../../LICENCE",

--- a/tools/vscode-lisp/src/tests.ts
+++ b/tools/vscode-lisp/src/tests.ts
@@ -343,16 +343,30 @@ export function activateTesting(context: vscode.ExtensionContext): void {
         await debugHandler(new vscode.TestRunRequest([item]), new vscode.CancellationTokenSource().token);
       }
     }),
+    vscode.commands.registerCommand("lisp.test.runFile", async (uri: vscode.Uri) => {
+      await parseTestFile(uri);
+      const fileItem = ctrl.items.get(uri.toString());
+      if (fileItem) {
+        await runHandler(new vscode.TestRunRequest([fileItem]), new vscode.CancellationTokenSource().token, false);
+      }
+    }),
+    vscode.commands.registerCommand("lisp.test.runAll", async () => {
+      await runHandler(new vscode.TestRunRequest(), new vscode.CancellationTokenSource().token, false);
+    }),
     vscode.languages.registerCodeLensProvider(
       { language: "lisp" },
       {
         provideCodeLenses(document): vscode.CodeLens[] {
           const lenses: vscode.CodeLens[] = [];
           const lines = document.getText().split("\n");
+          let firstDeftest = -1;
           for (let i = 0; i < lines.length; i++) {
             DEFTEST_RE.lastIndex = 0;
             let m: RegExpExecArray | null;
             while ((m = DEFTEST_RE.exec(lines[i])) !== null) {
+              if (firstDeftest < 0) {
+                firstDeftest = i;
+              }
               const range = new vscode.Range(i, 0, i, lines[i].length);
               const name = m[1];
               lenses.push(
@@ -360,6 +374,14 @@ export function activateTesting(context: vscode.ExtensionContext): void {
                 new vscode.CodeLens(range, { title: "$(debug-alt) Debug Test", command: "lisp.test.debug", arguments: [document.uri, name] }),
               );
             }
+          }
+          // Go-style file-level lenses at the very top of any file with tests.
+          if (firstDeftest >= 0) {
+            const top = new vscode.Range(0, 0, 0, 0);
+            lenses.unshift(
+              new vscode.CodeLens(top, { title: "$(run-all) Run File Tests", command: "lisp.test.runFile", arguments: [document.uri] }),
+              new vscode.CodeLens(top, { title: "$(run-all) Run All Tests", command: "lisp.test.runAll", arguments: [] }),
+            );
           }
           return lenses;
         },


### PR DESCRIPTION
Completes the Go-style CodeLens: two file-level links at the very top of any file that has tests —

- **▶ Run File Tests** — runs every `deftest` in the current file.
- **▶ Run All Tests** — runs the whole discovered suite (Go's "package tests").

alongside the existing per-test **Run Test | Debug Test** lenses. New commands `lisp.test.runFile` / `lisp.test.runAll` route through the same run handler; extension bumped to 0.9.3. Extension-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)