### PR TITLE
feat(core): read-password — read stdin with echo disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,11 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   `«recur»` sentinel as a value
 - multi-line `"…"` strings (Clojure-style): a literal newline is kept
   verbatim; `¬…¬` remains for JSON and other escape-heavy content
+- `read-password` — reads a line from stdin with terminal echo
+  disabled (via `golang.org/x/term`), for passwords and secrets; the
+  prompt goes to stderr, and non-terminal input (pipes, tests) falls
+  back to a plain line read. Returns nil on end of input, like
+  `readline`
 - `test` library — Clojure-style unit testing for lisp code: `deftest`,
   `is` (with expected/actual reporting for `(is (= …))`), `are`
   templates and `test/run-tests!`. The CLI runner grew with it:

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -294,6 +294,7 @@ Reading and writing files and stdin.
 | `exit` | `([] [status])` | Terminates the process with status (an integer, 0 when omitted). Does not return. |
 | `load-file` | `[file-path]` | Reads and evaluates the lisp file at file-path in the current environment; returns the value of its last form. |
 | `load-file-once` | `[file-path]` | Like load-file, but never loads the same path twice. |
+| `read-password` | `[prompt]` | Prints prompt (to stderr) and reads a line with terminal echo disabled; falls back to a plain read when input is not a terminal. Returns nil on end of input. |
 | `readline` | `[prompt]` | Prints prompt and reads a line from input. |
 | `slurp` | `[filename]` | Reads a file and returns its contents as a string. |
 | `spit` | `[filename s & opts]` | Writes string s to a file, creating or truncating it; with :append true, appends instead. |

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,8 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
+	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,10 @@ golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
 golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
 golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -24,6 +24,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/term"
+
 	spew "github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
 	"github.com/jig/lisp/lib/call"
@@ -298,6 +300,7 @@ func LoadInput(env EnvType) {
 	call.Call(env, slurp)
 	call.Call(env, spit, 2, 4)
 	call.Call(env, readLine)
+	call.CallOverrideFN(env, "read-password", readPassword)
 	call.Call(env, exit, 0, 1)
 
 	loadInputDocs(env)
@@ -1759,6 +1762,32 @@ func readLine(prompt string) (MalType, error) {
 		stdinScanner = bufio.NewScanner(os.Stdin)
 	})
 	fmt.Print(prompt)
+	if !stdinScanner.Scan() {
+		return nil, nil
+	}
+	return stdinScanner.Text(), nil
+}
+
+// readPassword prints prompt and reads one line from stdin with terminal
+// echo disabled, returning the text without the trailing newline (nil on
+// EOF/error, like readLine). When stdin is not a terminal (piped input,
+// tests, CI) there is no echo to suppress, so it falls back to a normal
+// line read. The prompt goes to stderr so capturing stdout (e.g.
+// `pw=$(lisp get-secret.lisp)`) does not swallow it.
+func readPassword(prompt string) (MalType, error) {
+	fd := int(os.Stdin.Fd())
+	fmt.Fprint(os.Stderr, prompt)
+	if term.IsTerminal(fd) {
+		b, err := term.ReadPassword(fd)
+		fmt.Fprintln(os.Stderr) // the user's Enter was not echoed
+		if err != nil {
+			return nil, nil
+		}
+		return string(b), nil
+	}
+	stdinScannerOnce.Do(func() {
+		stdinScanner = bufio.NewScanner(os.Stdin)
+	})
 	if !stdinScanner.Scan() {
 		return nil, nil
 	}

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -30,6 +30,7 @@ var inputDocs = []struct{ name, arglist, doc string }{
 	{"slurp", "[filename]", "Reads a file and returns its contents as a string."},
 	{"spit", "[filename s & opts]", "Writes string s to a file, creating or truncating it; with :append true, appends instead."},
 	{"readline", "[prompt]", "Prints prompt and reads a line from input."},
+	{"read-password", "[prompt]", "Prints prompt (to stderr) and reads a line with terminal echo disabled; falls back to a plain read when input is not a terminal. Returns nil on end of input."},
 	{"exit", "([] [status])", "Terminates the process with status (an integer, 0 when omitted). Does not return."},
 }
 

--- a/lib/core/readpassword_test.go
+++ b/lib/core/readpassword_test.go
@@ -1,0 +1,61 @@
+package core
+
+import (
+	"os"
+	"sync"
+	"testing"
+)
+
+// withStdin runs fn with os.Stdin fed from content and the shared
+// line-scanner reset, so the read-* builtins observe exactly this input.
+func withStdin(t *testing.T, content string, fn func()) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	_ = w.Close()
+	orig := os.Stdin
+	os.Stdin = r
+	// Reset the shared scanner to fresh state (a sync.Once cannot be
+	// copied, so restore by re-zeroing rather than saving the old value —
+	// no other test relies on prior scanner state).
+	stdinScanner = nil
+	stdinScannerOnce = sync.Once{}
+	t.Cleanup(func() {
+		os.Stdin = orig
+		stdinScanner = nil
+		stdinScannerOnce = sync.Once{}
+		_ = r.Close()
+	})
+	fn()
+}
+
+// TestReadPasswordPipedFallback covers the non-terminal path: with stdin
+// piped there is no echo to suppress, so it reads a line like readline.
+// (The echo-off terminal path needs a pty and is exercised manually.)
+func TestReadPasswordPipedFallback(t *testing.T) {
+	withStdin(t, "hunter2\nsecond\n", func() {
+		got, err := readPassword("Password: ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != "hunter2" {
+			t.Fatalf("got %#v, want \"hunter2\"", got)
+		}
+	})
+
+	// End of input returns nil, like readline, so callers can detect EOF.
+	withStdin(t, "", func() {
+		got, err := readPassword("Password: ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != nil {
+			t.Fatalf("on EOF got %#v, want nil", got)
+		}
+	})
+}


### PR DESCRIPTION
`readline` echoes what you type; there was no way to read a password or secret without it showing on screen. Adds:

```clojure
(def pw (read-password "Password: "))
```

- **Echo disabled** via `golang.org/x/term` (`x/sys` was already an indirect dependency, so this pulls in only `x/term`).
- **Prompt to stderr**, so `pw=$(lisp get-secret.lisp)` capturing stdout doesn't swallow the prompt.
- **Non-terminal fallback**: when stdin is a pipe (scripts, tests, CI) there is no echo to suppress, so it reads a line like `readline`.
- **`nil` on end of input**, matching `readline`, so callers can detect EOF.

Registered explicitly as `read-password` (the reflected Go name would be `readpassword`). `TestReadPasswordPipedFallback` covers the non-terminal path and the EOF contract; the echo-off terminal path needs a pty and was verified by hand.

Verified: `gofmt`/`go vet` (plain + `lispdebug`) clean, golangci-lint v2 clean, full suite green in both build modes, `LANGUAGE.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)