### PR TITLE
feat(web): Ring-style HTTP server library (TLS, mTLS, JWT/Keycloak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,17 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   `«recur»` sentinel as a value
 - multi-line `"…"` strings (Clojure-style): a literal newline is kept
   verbatim; `¬…¬` remains for JSON and other escape-heavy content
+- `web` library — a Ring-style HTTP/HTTPS server: request and response
+  are hash-maps, handlers are `(fn [req] resp)`, middleware is
+  `handler → handler`. `web/serve` (TLS, mTLS, graceful shutdown),
+  `web/router` (data-driven routes with path params), response helpers
+  (`web/json` with clean keys, `web/text`, `web/not-found`, …), and
+  middleware (`web/wrap-recover`, `web/wrap-log` as structured slog
+  JSON, `web/wrap-json-body`, `web/wrap-identity` for mTLS,
+  `web/wrap-jwt`). JWT verification (`web/verify-jwt`) validates against
+  a JWKS with issuer/audience checks — Keycloak-compatible (RS/ES).
+  Client-side and streaming are planned separately. See
+  `lib/web/README.md`
 - `read-password` — reads a line from stdin with terminal echo
   disabled (via `golang.org/x/term`), for passwords and secrets; the
   prompt goes to stderr, and non-terminal input (pipes, tests) falls

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -448,6 +448,28 @@ Attest and verify lisp source (formatting, hashing, Ed25519 signatures).
 | `fmt` | `[s]` | Formats lisp source s into its canonical form (as lisp --fmt does); errors if s does not parse. |
 | `sha2-256` | `[s]` | SHA2-256 digest of string s, as lowercase hex. |
 
+### web
+
+| Name | Arguments | Description |
+| ---- | --------- | ----------- |
+| `web/bad-request` | `[& msg]` | A 400 JSON response. |
+| `web/encode-json` | `[value]` | Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → "id"), unlike core json-encode. |
+| `web/json` | `[status-or-body & maybe-body]` | A JSON response: encodes body and sets content-type. (web/json data) is 200; (web/json status data) sets the status. |
+| `web/log` | `[level msg & kv]` | Emits a structured JSON log line to stderr at level (:debug/:info/:warn/:error) with alternating key/value attributes. |
+| `web/not-found` | `[& msg]` | A 404 JSON response. |
+| `web/redirect` | `[location & status]` | A redirect response (status 302 unless given as the second arg). |
+| `web/response` | `[status body & headers]` | Builds a response map with the given status and body, plus optional header pairs. |
+| `web/router` | `[routes]` | Returns a Ring handler that dispatches on method and path. routes is a vector of ["/path/:param" {:get handler :post handler}] pairs; matched params appear under the request's :path-params. |
+| `web/serve` | `[config]` | Starts an HTTP(S) server and blocks until interrupted. config is a hash-map: :handler (a Ring handler fn), :port or :addr, and optional :tls {:cert :key :client-ca :client-auth} for HTTPS/mTLS. |
+| `web/text` | `[body & status]` | A text/plain response (status 200 unless given). |
+| `web/unauthorized` | `[& msg]` | A 401 JSON response. |
+| `web/verify-jwt` | `[token config]` | Verifies a JWT against a JWKS and returns its claims as a hash-map. config: :jwks-uri (required), :issuer, :audience, :algorithms (defaults to Keycloak's RS/ES set). |
+| `web/wrap-identity` | `[handler]` | Middleware: promotes a verified mTLS client certificate to :identity {:kind :mtls :subject cn}. |
+| `web/wrap-json-body` | `[handler]` | Middleware: when the request body is a non-empty JSON object, decodes it under :json (nil on parse error). |
+| `web/wrap-jwt` | `[config handler]` | Middleware: verifies a Bearer JWT against config (see web/verify-jwt) and sets :identity {:kind :jwt :claims …}; responds 401 when missing or invalid. config is the JWKS/issuer map. |
+| `web/wrap-log` | `[handler]` | Middleware: logs one structured JSON line per request with method, uri, status and elapsed ms. |
+| `web/wrap-recover` | `[handler]` | Middleware: turns any error escaping the handler into a 500 JSON response instead of dropping the connection. |
+
 ### test
 
 | Name | Arguments | Description |

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Changes respect to [kanaka/mal](https://github.com/kanaka/mal):
 - `(hash-map-decode (new-go-object) ¬{"key": "value"}¬)` to decode hash map to a Go struct if that struct has the appropiate Go marshaler
 - `(context (do ...))` provides a Go context. Context contents depend on Go, and might be passed to specific functions context compatible
 - Unit-testing library (`deftest`, `is`, `are`, `with-out-str`) run with `lisp --test DIR`, which loads every `*_test.lisp` / `*_test.mal` file in `DIR` and runs the registered tests. See "Testing lisp code" below
+- `web` library — a Ring-style HTTP/HTTPS server (`web/serve`, `web/router`, response helpers, middleware) with TLS, mTLS and Keycloak-compatible JWT verification. See [lib/web/README.md](./lib/web/README.md)
+- `(read-password prompt)` reads a line from stdin with terminal echo disabled (for secrets); prompt goes to stderr
 - Project compatible with GitHub CodeSpaces. Press `.` on your keyboard and you are ready to deploy a CodeSpace with mal in it
 - `(assert expr & optional-error)` asserts expression is not `nil` nor `false`, otherwise it success returning `nil`
 - Errors are decorated with line numbers

--- a/cmd/lisp/main.go
+++ b/cmd/lisp/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jig/lisp/lib/sql/nssql"
 	"github.com/jig/lisp/lib/system/nssystem"
 	"github.com/jig/lisp/lib/test/nstest"
+	"github.com/jig/lisp/lib/web/nsweb"
 	"github.com/jig/lisp/types"
 )
 
@@ -44,6 +45,7 @@ func libraries(scriptArgs []string) []library {
 		{"sql", nssql.Load},
 		{"cli", nscli.Load},
 		{"integrity", nsintegrity.Load},
+		{"web", nsweb.Load},
 		{"test", nstest.Load},
 	}
 }

--- a/docgen/libraries.go
+++ b/docgen/libraries.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jig/lisp/lib/sql/nssql"
 	"github.com/jig/lisp/lib/system/nssystem"
 	"github.com/jig/lisp/lib/test/nstest"
+	"github.com/jig/lisp/lib/web/nsweb"
 	"github.com/jig/lisp/types"
 )
 
@@ -40,6 +41,7 @@ func standardLibraries() []library {
 		{"sql", nssql.Load},
 		{"cli", nscli.Load},
 		{"integrity", nsintegrity.Load},
+		{"web", nsweb.Load},
 		{"test", nstest.Load},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,11 @@ require (
 )
 
 require (
+	github.com/MicahParks/jwkset v0.11.0 // indirect
+	github.com/MicahParks/keyfunc/v3 v3.8.0 // indirect
 	github.com/alexflint/go-scalar v1.2.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
@@ -25,6 +28,7 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.29.0 // indirect
+	golang.org/x/time v0.9.0 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/MicahParks/jwkset v0.11.0 h1:yc0zG+jCvZpWgFDFmvs8/8jqqVBG9oyIbmBtmjOhoyQ=
+github.com/MicahParks/jwkset v0.11.0/go.mod h1:U2oRhRaLgDCLjtpGL2GseNKGmZtLs/3O7p+OZaL5vo0=
+github.com/MicahParks/keyfunc/v3 v3.8.0 h1:Hx2dgIjAXGk9slakM6rV9BOeaWDPEXXZ4Us8guNBfds=
+github.com/MicahParks/keyfunc/v3 v3.8.0/go.mod h1:z66bkCviwqfg2YUp+Jcc/xRE9IXLcMq6DrgV/+Htru0=
 github.com/alexflint/go-arg v1.6.1 h1:uZogJ6VDBjcuosydKgvYYRhh9sRCusjOvoOLZopBlnA=
 github.com/alexflint/go-arg v1.6.1/go.mod h1:nQ0LFYftLJ6njcaee0sU+G0iS2+2XJQfA8I062D0LGc=
 github.com/alexflint/go-scalar v1.2.0 h1:WR7JPKkeNpnYIOfHRa7ivM21aWAdHD0gEWHCx+WQBRw=
@@ -13,6 +17,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -61,6 +67,8 @@ golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
 golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
 golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
+golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
 golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/lib/web/README.md
+++ b/lib/web/README.md
@@ -1,0 +1,111 @@
+# web — Ring-style HTTP server library
+
+A small HTTP/HTTPS server for jig/lisp, modelled on Clojure's
+[Ring](https://github.com/ring-clojure/ring): a **request** is a
+hash-map, a **response** is a hash-map, a **handler** is a function
+`(fn [request] response)`, and **middleware** is a function that wraps a
+handler `(fn [handler] (fn [request] response))`. Everything is data, so
+handlers are ordinary functions — trivial to unit-test with `deftest`,
+no socket required.
+
+## A first server
+
+```clojure
+(def app
+  (-> (web/router
+        [["/ping"        {:get (fn [req] (web/json {:pong true}))}]
+         ["/certs/:id"   {:get (fn [req] (web/json {:id (get (get req :path-params) :id)}))}]])
+      web/wrap-json-body     ; decodes a JSON body under :json
+      web/wrap-log           ; one structured JSON log line per request
+      web/wrap-recover))     ; errors become 500 instead of dropping the connection
+
+(web/serve {:port 8443
+            :handler app
+            :tls {:cert "server.crt" :key "server.key"}})
+```
+
+`web/serve` blocks until interrupted (Ctrl-C / SIGTERM) and shuts down
+gracefully. Omit `:tls` for plain HTTP during development.
+
+Test it:
+
+```sh
+curl -sk https://localhost:8443/ping        # {"pong":true}
+curl -sk https://localhost:8443/certs/42     # {"id":"42"}
+```
+
+## The request map
+
+| key | value |
+|---|---|
+| `:method` | keyword, lower-case (`:get`, `:post`, …) |
+| `:uri` | path, e.g. `"/certs/42"` |
+| `:path-params` | hash-map of names captured by the router (`{:id "42"}`) |
+| `:query` | hash-map of query params (string keys) |
+| `:headers` | hash-map of headers (lower-case string keys) |
+| `:body` | request body as a string |
+| `:scheme` | `:http` or `:https` |
+| `:remote-addr` | client address |
+| `:mtls` | client-certificate identity, when mTLS verified it (below) |
+| `:json` | decoded JSON body, added by `web/wrap-json-body` |
+| `:identity` | added by an auth middleware |
+
+## The response map
+
+`{:status 200 :headers {"content-type" "…"} :body "…"}`. Build it with
+the helpers: `web/response`, `web/text`, `web/json`, `web/not-found`,
+`web/bad-request`, `web/unauthorized`, `web/redirect`. `web/json`
+encodes with clean keys (`:id` → `"id"`), unlike core `json-encode`.
+
+## TLS and mTLS
+
+```clojure
+:tls {:cert "server.crt"
+      :key  "server.key"
+      :client-ca "ca.crt"          ; enables mTLS: verify client certs against this CA
+      :client-auth :require-and-verify}
+```
+
+`:client-auth` is one of `:none`, `:request`, `:require`,
+`:verify-if-given`, `:require-and-verify` (the default once a
+`:client-ca` is given). When a client certificate is verified, the
+request carries `:mtls {:subject-cn … :subject … :issuer-cn … :serial
+"0x…" :sans-dns […] :verified true}`; `web/wrap-identity` promotes it to
+`:identity {:kind :mtls :subject …}`.
+
+## JWT (Keycloak)
+
+```clojure
+(def secured
+  (-> protected-app
+      (web/wrap-jwt {:jwks-uri "https://kc.example/realms/app/protocol/openid-connect/certs"
+                     :issuer   "https://kc.example/realms/app"
+                     :audience "my-api"})))
+```
+
+`web/wrap-jwt` reads the `Authorization: Bearer …` header, verifies the
+token against the JWKS (RS256/384/512 and ES256/384/512 — what Keycloak
+issues), checks issuer/audience/expiry, and sets `:identity {:kind :jwt
+:claims … :subject …}`; a missing or invalid token gets a 401. The JWKS
+is fetched and cached (auto-refreshing). `web/verify-jwt` is the
+underlying primitive if you need the claims directly.
+
+## Middleware
+
+Middleware is `handler → handler`; compose with `->`. Built-in:
+`web/wrap-recover`, `web/wrap-log`, `web/wrap-json-body`,
+`web/wrap-identity`, `web/wrap-jwt`. Write your own the same way:
+
+```clojure
+(defn wrap-require-role [role handler]
+  (fn [req]
+    (if (contains? (get-in req [:identity :claims :realm_access :roles]) role)
+      (handler req)
+      (web/unauthorized "forbidden"))))
+```
+
+## Not yet
+
+Streaming, Server-Sent Events, WebSockets and multipart uploads are out
+of scope for now (the body is read as a string); an HTTP client is
+planned separately.

--- a/lib/web/export_test.go
+++ b/lib/web/export_test.go
@@ -1,0 +1,15 @@
+package web
+
+import (
+	"net/http"
+
+	. "github.com/jig/lisp/types"
+)
+
+// RingHandler exposes the internal ringHandler request→lisp→response
+// bridge to the external test package.
+func RingHandler(h MalType) http.Handler { return ringHandler(h) }
+
+// VerifyJWT exposes the internal JWT verifier to the external test
+// package.
+func VerifyJWT(token string, config MalType) (MalType, error) { return webVerifyJWT(token, config) }

--- a/lib/web/header-web.lisp
+++ b/lib/web/header-web.lisp
@@ -1,0 +1,107 @@
+;; $MODULE header-web
+
+;; Ring-style response helpers and middleware for the web library.
+;; A response is {:status :headers :body}; a handler is (fn [req] resp);
+;; middleware is (fn [handler] (fn [req] resp)). Compose middleware with
+;; -> , e.g. (-> app http/wrap-json-body http/wrap-log http/wrap-recover).
+(do
+    (defn web/response
+        "Builds a response map with the given status and body, plus optional header pairs."
+        [status body & headers]
+        {:status status
+         :headers (apply hash-map headers)
+         :body body})
+
+    (defn web/text
+        "A text/plain response (status 200 unless given)."
+        [body & status]
+        (web/response (if (empty? status) 200 (first status)) body "content-type" "text/plain; charset=utf-8"))
+
+    (defn web/json
+        "A JSON response: encodes body and sets content-type. (web/json data) is 200; (web/json status data) sets the status."
+        [status-or-body & maybe-body]
+        (let [status (if (empty? maybe-body) 200 status-or-body)
+              body   (if (empty? maybe-body) status-or-body (first maybe-body))]
+            (web/response status (web/encode-json body) "content-type" "application/json")))
+
+    (defn web/not-found
+        "A 404 JSON response."
+        [& msg]
+        (web/json 404 {:error (if (empty? msg) "not found" (first msg))}))
+
+    (defn web/bad-request
+        "A 400 JSON response."
+        [& msg]
+        (web/json 400 {:error (if (empty? msg) "bad request" (first msg))}))
+
+    (defn web/unauthorized
+        "A 401 JSON response."
+        [& msg]
+        (web/json 401 {:error (if (empty? msg) "unauthorized" (first msg))}))
+
+    (defn web/redirect
+        "A redirect response (status 302 unless given as the second arg)."
+        [location & status]
+        (web/response (if (empty? status) 302 (first status)) "" "location" location))
+
+    ;; --- middleware ---
+
+    (defn web/wrap-recover
+        "Middleware: turns any error escaping the handler into a 500 JSON response instead of dropping the connection."
+        [handler]
+        (fn [req]
+            (try
+                (handler req)
+                (catch e (web/json 500 {:error (str e)})))))
+
+    (defn web/wrap-json-body
+        "Middleware: when the request body is a non-empty JSON object, decodes it under :json (nil on parse error)."
+        [handler]
+        (fn [req]
+            (let [body (get req :body)]
+                (if (and (string? body) (not (= "" body)))
+                    (handler (assoc req :json (try (json-decode {} body) (catch e nil))))
+                    (handler req)))))
+
+    (defn web/wrap-log
+        "Middleware: logs one structured JSON line per request with method, uri, status and elapsed ms."
+        [handler]
+        (fn [req]
+            (let [start (time-ms)
+                  resp  (handler req)]
+                (web/log :info "http request"
+                    "method" (get req :method)
+                    "uri" (get req :uri)
+                    "status" (get resp :status)
+                    "ms" (- (time-ms) start))
+                resp)))
+
+    (defn web/wrap-identity
+        "Middleware: promotes a verified mTLS client certificate to :identity {:kind :mtls :subject cn}."
+        [handler]
+        (fn [req]
+            (let [mtls (get req :mtls)]
+                (if (and mtls (get mtls :verified))
+                    (handler (assoc req :identity {:kind :mtls :subject (get mtls :subject-cn) :mtls mtls}))
+                    (handler req)))))
+
+    (defn web/-bearer-token
+        "Extracts the bearer token from a request's Authorization header, or nil."
+        [req]
+        (let [auth (get (get req :headers) "authorization")]
+            (if (and (string? auth) (starts-with? auth "Bearer "))
+                (subs auth 7)
+                nil)))
+
+    (defn web/wrap-jwt
+        "Middleware: verifies a Bearer JWT against config (see web/verify-jwt) and sets :identity {:kind :jwt :claims …}; responds 401 when missing or invalid. config is the JWKS/issuer map."
+        [config handler]
+        (fn [req]
+            (let [token (web/-bearer-token req)]
+                (if (nil? token)
+                    (web/unauthorized "missing bearer token")
+                    (let [claims (try (web/verify-jwt token config) (catch e :invalid))]
+                        (if (= claims :invalid)
+                            (web/unauthorized "invalid token")
+                            (handler (assoc req :identity {:kind :jwt :claims claims :subject (get claims :sub)}))))))))
+)

--- a/lib/web/jwt_test.go
+++ b/lib/web/jwt_test.go
@@ -1,0 +1,118 @@
+package web_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/jig/lisp/lib/web"
+	. "github.com/jig/lisp/types"
+)
+
+// TestVerifyJWT covers the Keycloak-style path end to end: a JWKS served
+// over HTTP, an RS256 token signed with the matching private key, and
+// issuer/audience validation, decoded into a claims hash-map.
+func TestVerifyJWT(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const kid = "test-key-1"
+	jwks := jwksJSON(t, &key.PublicKey, kid)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write(jwks)
+	}))
+	defer srv.Close()
+
+	const issuer = "https://kc.example/realms/test"
+	const audience = "my-api"
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, jwt.MapClaims{
+		"sub":                "user-123",
+		"iss":                issuer,
+		"aud":                audience,
+		"exp":                time.Now().Add(time.Hour).Unix(),
+		"preferred_username": "alice",
+		"realm_access":       map[string]any{"roles": []string{"admin", "user"}},
+	})
+	tok.Header["kid"] = kid
+	signed, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := HashMap{Val: map[string]MalType{
+		NewKeyword("jwks-uri"): srv.URL,
+		NewKeyword("issuer"):   issuer,
+		NewKeyword("audience"): audience,
+	}}
+
+	claims, err := web.VerifyJWT(signed, config)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	hm, ok := claims.(HashMap)
+	if !ok {
+		t.Fatalf("claims not a hash-map: %T", claims)
+	}
+	if got := hm.Val[NewKeyword("sub")]; got != "user-123" {
+		t.Fatalf(":sub = %v", got)
+	}
+	if got := hm.Val[NewKeyword("preferred_username")]; got != "alice" {
+		t.Fatalf(":preferred_username = %v", got)
+	}
+	// nested claims convert too
+	ra, ok := hm.Val[NewKeyword("realm_access")].(HashMap)
+	if !ok {
+		t.Fatalf("realm_access not a hash-map")
+	}
+	roles, ok := ra.Val[NewKeyword("roles")].(Vector)
+	if !ok || len(roles.Val) != 2 || roles.Val[0] != "admin" {
+		t.Fatalf("roles = %v", ra.Val[NewKeyword("roles")])
+	}
+
+	// a wrong audience is rejected
+	badCfg := HashMap{Val: map[string]MalType{
+		NewKeyword("jwks-uri"): srv.URL,
+		NewKeyword("audience"): "someone-else",
+	}}
+	if _, err := web.VerifyJWT(signed, badCfg); err == nil {
+		t.Fatal("expected audience mismatch to fail")
+	}
+}
+
+// jwksJSON builds a minimal JWKS containing one RSA public key.
+func jwksJSON(t *testing.T, pub *rsa.PublicKey, kid string) []byte {
+	t.Helper()
+	n := base64.RawURLEncoding.EncodeToString(pub.N.Bytes())
+	eBytes := exponentBytes(pub.E)
+	e := base64.RawURLEncoding.EncodeToString(eBytes)
+	jwk := map[string]any{
+		"keys": []map[string]any{{
+			"kty": "RSA", "use": "sig", "alg": "RS256", "kid": kid, "n": n, "e": e,
+		}},
+	}
+	b, err := json.Marshal(jwk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// exponentBytes returns the minimal big-endian bytes of a small positive int (the
+// RSA public exponent, typically 65537).
+func exponentBytes(v int) []byte {
+	var out []byte
+	for v > 0 {
+		out = append([]byte{byte(v & 0xff)}, out...)
+		v >>= 8
+	}
+	return out
+}

--- a/lib/web/nsweb/nsweb.go
+++ b/lib/web/nsweb/nsweb.go
@@ -1,0 +1,30 @@
+// Package nsweb loads the web (Ring-style HTTP server) namespace into a
+// jig/lisp environment: the Go builtins (web/serve, web/router,
+// web/verify-jwt, web/log) plus the response helpers and middleware
+// defined in header-web.lisp.
+package nsweb
+
+import (
+	"context"
+	"reflect"
+	"strings"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/lib/web"
+	"github.com/jig/lisp/types"
+)
+
+type Here struct{}
+
+var (
+	__package_fullpath__ = strings.Split(reflect.TypeFor[Here]().PkgPath(), "/")
+	_package_            = "$" + __package_fullpath__[len(__package_fullpath__)-1]
+)
+
+func Load(env types.EnvType) error {
+	web.Load(env)
+	if _, err := lisp.REPL(context.Background(), env, web.HeaderWeb(), types.NewCursorFile(_package_)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -1,0 +1,632 @@
+// Package web is a Ring-style HTTP server library for jig/lisp.
+//
+// The contract mirrors Clojure's Ring: an HTTP request is a hash-map, a
+// response is a hash-map {:status :headers :body}, a handler is a
+// function (fn [request] response), and middleware is a function that
+// wraps a handler (fn [handler] (fn [request] response)). The Go side
+// provides the transport (http/serve with TLS and mTLS), a data-driven
+// router (http/router), and JWT verification (http/verify-jwt); the
+// response helpers and middleware live in header-web.lisp.
+package web
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"maps"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/MicahParks/keyfunc/v3"
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/jig/lisp/lib/call"
+	"github.com/jig/lisp/printer"
+	. "github.com/jig/lisp/types"
+)
+
+//go:embed header-web.lisp
+var headerWeb string
+
+// HeaderWeb returns the Lisp source of the response helpers and
+// middleware (see nsweb.Load).
+func HeaderWeb() string { return headerWeb }
+
+// --- value helpers -------------------------------------------------------
+
+func kw(s string) string { return NewKeyword(s) }
+
+// hget reads a keyword-keyed value from a hash-map.
+func hget(m MalType, key string) (MalType, bool) {
+	hm, ok := m.(HashMap)
+	if !ok {
+		return nil, false
+	}
+	v, ok := hm.Val[kw(key)]
+	return v, ok
+}
+
+func hgetStr(m MalType, key, def string) string {
+	if v, ok := hget(m, key); ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return def
+}
+
+func hgetInt(m MalType, key string, def int) int {
+	if v, ok := hget(m, key); ok {
+		if i, ok := v.(int); ok {
+			return i
+		}
+	}
+	return def
+}
+
+// toStr renders a MalType as the raw string that should go on the wire:
+// strings verbatim, everything else via the Lisp printer.
+func toStr(v MalType) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	if v == nil {
+		return ""
+	}
+	return printer.Pr_str(v, false)
+}
+
+// headerName turns a hash-map key (a plain string or a keyword) into an
+// HTTP header name.
+func headerName(k string) string {
+	return http.CanonicalHeaderKey(strings.TrimPrefix(k, "ʞ"))
+}
+
+// --- JSON <-> Lisp (for JWT claims) --------------------------------------
+
+// jsonToMal converts decoded JSON into Lisp data: objects become
+// hash-maps keyed by keywords, arrays become vectors, integral numbers
+// become ints.
+func jsonToMal(v any) MalType {
+	switch v := v.(type) {
+	case map[string]any:
+		out := make(map[string]MalType, len(v))
+		for k, val := range v {
+			out[kw(k)] = jsonToMal(val)
+		}
+		return HashMap{Val: out}
+	case []any:
+		out := make([]MalType, len(v))
+		for i, e := range v {
+			out[i] = jsonToMal(e)
+		}
+		return Vector{Val: out}
+	case float64:
+		if v == float64(int(v)) {
+			return int(v)
+		}
+		return float32(v)
+	default:
+		return v // string, bool, nil
+	}
+}
+
+// malToJSON converts Lisp data to a Go value ready for json.Marshal,
+// producing clean JSON for HTTP clients: keyword map keys and keyword
+// values lose their sigil (:id → "id", :active → "active"), since JSON
+// has no keyword type. This is what a REST client expects, unlike the
+// core json-encode which preserves keywords for lossless round-tripping.
+func malToJSON(v MalType) any {
+	switch v := v.(type) {
+	case string:
+		return strings.TrimPrefix(v, "ʞ")
+	case HashMap:
+		m := make(map[string]any, len(v.Val))
+		for k, val := range v.Val {
+			m[strings.TrimPrefix(k, "ʞ")] = malToJSON(val)
+		}
+		return m
+	case List:
+		out := make([]any, len(v.Val))
+		for i, e := range v.Val {
+			out[i] = malToJSON(e)
+		}
+		return out
+	case Vector:
+		out := make([]any, len(v.Val))
+		for i, e := range v.Val {
+			out[i] = malToJSON(e)
+		}
+		return out
+	case int, float32, float64, bool, nil:
+		return v
+	default:
+		return printer.Pr_str(v, false)
+	}
+}
+
+// webEncodeJSON encodes Lisp data as a JSON string for HTTP responses.
+func webEncodeJSON(v MalType) (MalType, error) {
+	b, err := json.Marshal(malToJSON(v))
+	if err != nil {
+		return nil, err
+	}
+	return string(b), nil
+}
+
+// --- request map ---------------------------------------------------------
+
+// requestMap builds the Ring request hash-map from an *http.Request.
+func requestMap(r *http.Request) (HashMap, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return HashMap{}, err
+	}
+
+	headers := make(map[string]MalType, len(r.Header))
+	for name, vals := range r.Header {
+		if len(vals) > 0 {
+			headers[strings.ToLower(name)] = vals[0]
+		}
+	}
+	query := make(map[string]MalType)
+	for name, vals := range r.URL.Query() {
+		if len(vals) > 0 {
+			query[name] = vals[0]
+		}
+	}
+
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	m := map[string]MalType{
+		kw("method"):      NewKeyword(strings.ToLower(r.Method)),
+		kw("uri"):         r.URL.Path,
+		kw("query"):       HashMap{Val: query},
+		kw("headers"):     HashMap{Val: headers},
+		kw("body"):        string(body),
+		kw("remote-addr"): r.RemoteAddr,
+		kw("scheme"):      NewKeyword(scheme),
+		kw("protocol"):    r.Proto,
+		kw("path-params"): HashMap{Val: map[string]MalType{}},
+	}
+
+	// mTLS: when the transport verified a client certificate, expose its
+	// identity so an authorisation middleware can consume it.
+	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+		leaf := r.TLS.PeerCertificates[0]
+		sans := make([]MalType, len(leaf.DNSNames))
+		for i, s := range leaf.DNSNames {
+			sans[i] = s
+		}
+		m[kw("mtls")] = HashMap{Val: map[string]MalType{
+			kw("subject-cn"): leaf.Subject.CommonName,
+			kw("subject"):    leaf.Subject.String(),
+			kw("issuer-cn"):  leaf.Issuer.CommonName,
+			kw("serial"):     "0x" + strings.ToUpper(leaf.SerialNumber.Text(16)),
+			kw("sans-dns"):   Vector{Val: sans},
+			kw("verified"):   true,
+		}}
+	}
+	return HashMap{Val: m}, nil
+}
+
+// writeResponse writes a Ring response hash-map to the ResponseWriter.
+func writeResponse(w http.ResponseWriter, resp MalType) {
+	hm, ok := resp.(HashMap)
+	if !ok {
+		// A bare string is a 200 text/plain body; anything else is a bug.
+		if s, ok := resp.(string); ok {
+			_, _ = io.WriteString(w, s)
+			return
+		}
+		http.Error(w, "handler did not return a response map", http.StatusInternalServerError)
+		return
+	}
+	if h, ok := hget(hm, "headers"); ok {
+		if hh, ok := h.(HashMap); ok {
+			for k, v := range hh.Val {
+				w.Header().Set(headerName(k), toStr(v))
+			}
+		}
+	}
+	w.WriteHeader(hgetInt(hm, "status", http.StatusOK))
+	if b, ok := hget(hm, "body"); ok {
+		_, _ = io.WriteString(w, toStr(b))
+	}
+}
+
+// --- TLS -----------------------------------------------------------------
+
+var clientAuthTypes = map[string]tls.ClientAuthType{
+	"none":                    tls.NoClientCert,
+	"request":                 tls.RequestClientCert,
+	"require":                 tls.RequireAnyClientCert,
+	"verify-if-given":         tls.VerifyClientCertIfGiven,
+	"require-and-verify":      tls.RequireAndVerifyClientCert,
+	"require-and-verify-mtls": tls.RequireAndVerifyClientCert,
+}
+
+// tlsConfig builds a *tls.Config from the :tls sub-map, or nil for plain
+// HTTP when :tls is absent.
+func tlsConfig(config MalType) (*tls.Config, error) {
+	tlsMap, ok := hget(config, "tls")
+	if !ok {
+		return nil, nil
+	}
+	certFile := hgetStr(tlsMap, "cert", "")
+	keyFile := hgetStr(tlsMap, "key", "")
+	if certFile == "" || keyFile == "" {
+		return nil, errors.New("web/serve: :tls requires :cert and :key")
+	}
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("web/serve: loading server certificate: %w", err)
+	}
+	cfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+	if caFile := hgetStr(tlsMap, "client-ca", ""); caFile != "" {
+		pem, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("web/serve: reading client CA: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, errors.New("web/serve: no certificates found in :client-ca")
+		}
+		cfg.ClientCAs = pool
+		cfg.ClientAuth = tls.RequireAndVerifyClientCert // default when a CA is given
+	}
+	if v, ok := hget(tlsMap, "client-auth"); ok {
+		name := strings.TrimPrefix(toStr(v), "ʞ")
+		at, ok := clientAuthTypes[name]
+		if !ok {
+			return nil, fmt.Errorf("web/serve: unknown :client-auth %q", name)
+		}
+		cfg.ClientAuth = at
+	}
+	return cfg, nil
+}
+
+// ringHandler adapts a Lisp Ring handler (a fn taking the request
+// hash-map and returning a response hash-map) to a net/http handler. It
+// is the single request→lisp→response bridge, shared by webServe and the
+// tests; a panic or a returned error becomes a 500.
+func ringHandler(handler MalType) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				http.Error(w, fmt.Sprintf("panic: %v", rec), http.StatusInternalServerError)
+			}
+		}()
+		req, err := requestMap(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		resp, err := Apply(r.Context(), handler, []MalType{req})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeResponse(w, resp)
+	})
+}
+
+// --- serve ---------------------------------------------------------------
+
+// webServe starts an HTTP(S) server and blocks until the context is
+// cancelled or an interrupt signal arrives, then shuts down gracefully.
+func webServe(ctx context.Context, config MalType) (MalType, error) {
+	handler, ok := hget(config, "handler")
+	if !ok {
+		return nil, errors.New("web/serve: config needs a :handler function")
+	}
+	addr := hgetStr(config, "addr", "")
+	if addr == "" {
+		port := hgetInt(config, "port", 8080)
+		addr = fmt.Sprintf(":%d", port)
+	}
+	cfg, err := tlsConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	srv := &http.Server{
+		Addr:      addr,
+		TLSConfig: cfg,
+		Handler:   ringHandler(handler),
+	}
+
+	// Graceful shutdown on context cancellation or SIGINT/SIGTERM.
+	shutdownCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go func() {
+		<-shutdownCtx.Done()
+		toCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(toCtx)
+	}()
+
+	if cfg != nil {
+		err = srv.ListenAndServeTLS("", "")
+	} else {
+		err = srv.ListenAndServe()
+	}
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil, nil
+	}
+	return nil, err
+}
+
+// --- router --------------------------------------------------------------
+
+type route struct {
+	segments []string           // path split on "/", ":name" captures a param
+	methods  map[string]MalType // lower-case method → handler
+}
+
+// compileRoutes parses the route data: a vector of [path method-map]
+// pairs, where path is "/a/:id/b" and method-map is {:get fn :post fn}.
+func compileRoutes(routes MalType) ([]route, error) {
+	slc, err := GetSlice(routes)
+	if err != nil {
+		return nil, errors.New("web/router: routes must be a vector of [path methods] pairs")
+	}
+	out := make([]route, 0, len(slc))
+	for _, entry := range slc {
+		pair, err := GetSlice(entry)
+		if err != nil || len(pair) != 2 {
+			return nil, errors.New("web/router: each route must be a [path {:method handler}] pair")
+		}
+		path, ok := pair[0].(string)
+		if !ok {
+			return nil, errors.New("web/router: route path must be a string")
+		}
+		mm, ok := pair[1].(HashMap)
+		if !ok {
+			return nil, errors.New("web/router: route methods must be a hash-map")
+		}
+		methods := make(map[string]MalType, len(mm.Val))
+		for k, v := range mm.Val {
+			methods[strings.ToLower(strings.TrimPrefix(k, "ʞ"))] = v
+		}
+		out = append(out, route{segments: splitPath(path), methods: methods})
+	}
+	return out, nil
+}
+
+func splitPath(p string) []string {
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return nil
+	}
+	return strings.Split(p, "/")
+}
+
+// matchRoute matches a request path against a compiled route, returning
+// the captured path params on success.
+func matchRoute(r route, path []string) (map[string]MalType, bool) {
+	if len(r.segments) != len(path) {
+		return nil, false
+	}
+	params := map[string]MalType{}
+	for i, seg := range r.segments {
+		if strings.HasPrefix(seg, ":") {
+			params[kw(seg[1:])] = path[i]
+			continue
+		}
+		if seg != path[i] {
+			return nil, false
+		}
+	}
+	return params, true
+}
+
+// notFound and methodNotAllowed are the router's built-in fallbacks.
+func statusResponse(status int, msg string) HashMap {
+	return HashMap{Val: map[string]MalType{
+		kw("status"):  status,
+		kw("headers"): HashMap{Val: map[string]MalType{"content-type": "text/plain; charset=utf-8"}},
+		kw("body"):    msg,
+	}}
+}
+
+// webRouter compiles the routes and returns a handler Func that
+// dispatches on method and path, filling :path-params.
+func webRouter(routes MalType) (MalType, error) {
+	compiled, err := compileRoutes(routes)
+	if err != nil {
+		return nil, err
+	}
+	fn := func(ctx context.Context, args []MalType) (MalType, error) {
+		if len(args) != 1 {
+			return nil, errors.New("router handler takes one request argument")
+		}
+		req := args[0]
+		path := splitPath(hgetStr(req, "uri", "/"))
+		method := strings.TrimPrefix(toStr(mustGet(req, "method")), "ʞ")
+		pathMatched := false
+		for _, rt := range compiled {
+			params, ok := matchRoute(rt, path)
+			if !ok {
+				continue
+			}
+			pathMatched = true
+			handler, ok := rt.methods[method]
+			if !ok {
+				continue
+			}
+			// assoc :path-params into the request and dispatch.
+			reqHM := req.(HashMap)
+			merged := make(map[string]MalType, len(reqHM.Val)+1)
+			maps.Copy(merged, reqHM.Val)
+			merged[kw("path-params")] = HashMap{Val: params}
+			return Apply(ctx, handler, []MalType{HashMap{Val: merged}})
+		}
+		if pathMatched {
+			return statusResponse(http.StatusMethodNotAllowed, "405 method not allowed"), nil
+		}
+		return statusResponse(http.StatusNotFound, "404 not found"), nil
+	}
+	return Func{Fn: fn}, nil
+}
+
+func mustGet(m MalType, key string) MalType {
+	v, _ := hget(m, key)
+	return v
+}
+
+// --- JWT -----------------------------------------------------------------
+
+// jwksCache holds one auto-refreshing JWKS key set per URL, so verifying
+// tokens does not refetch the key set on every request.
+var (
+	jwksMu    sync.Mutex
+	jwksCache = map[string]keyfunc.Keyfunc{}
+)
+
+func jwksFor(url string) (keyfunc.Keyfunc, error) {
+	jwksMu.Lock()
+	defer jwksMu.Unlock()
+	if k, ok := jwksCache[url]; ok {
+		return k, nil
+	}
+	k, err := keyfunc.NewDefault([]string{url})
+	if err != nil {
+		return nil, err
+	}
+	jwksCache[url] = k
+	return k, nil
+}
+
+// webVerifyJWT verifies a bearer token against a JWKS and the configured
+// issuer/audience, returning its claims as a hash-map. The config map
+// accepts :jwks-uri (required), :issuer and :audience (optional, checked
+// when present), and :algorithms (defaults to RS256/RS384/RS512 and the
+// ES equivalents — what Keycloak issues).
+func webVerifyJWT(token string, config MalType) (MalType, error) {
+	jwksURI := hgetStr(config, "jwks-uri", "")
+	if jwksURI == "" {
+		return nil, errors.New("verify-jwt: config needs :jwks-uri")
+	}
+	k, err := jwksFor(jwksURI)
+	if err != nil {
+		return nil, fmt.Errorf("verify-jwt: loading JWKS: %w", err)
+	}
+	algs := []string{"RS256", "RS384", "RS512", "ES256", "ES384", "ES512"}
+	if v, ok := hget(config, "algorithms"); ok {
+		if slc, err := GetSlice(v); err == nil {
+			algs = algs[:0]
+			for _, a := range slc {
+				algs = append(algs, toStr(a))
+			}
+		}
+	}
+	opts := []jwt.ParserOption{jwt.WithValidMethods(algs)}
+	if iss := hgetStr(config, "issuer", ""); iss != "" {
+		opts = append(opts, jwt.WithIssuer(iss))
+	}
+	if aud := hgetStr(config, "audience", ""); aud != "" {
+		opts = append(opts, jwt.WithAudience(aud))
+	}
+	parsed, err := jwt.Parse(strings.TrimSpace(token), k.Keyfunc, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("verify-jwt: %w", err)
+	}
+	claims, ok := parsed.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, errors.New("verify-jwt: unexpected claims type")
+	}
+	// Round-trip through JSON so nested claims convert uniformly.
+	raw, err := json.Marshal(map[string]any(claims))
+	if err != nil {
+		return nil, err
+	}
+	var generic any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return nil, err
+	}
+	return jsonToMal(generic), nil
+}
+
+// --- logging -------------------------------------------------------------
+
+// webLogger emits structured JSON to stderr, matching the slog-JSON
+// convention used across the surrounding Go services.
+var webLogger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
+
+// logValue renders a Lisp value for a log attribute: keywords lose their
+// sigil, strings/numbers pass through, everything else is printed.
+func logValue(v MalType) any {
+	switch v := v.(type) {
+	case string:
+		if strings.HasPrefix(v, "ʞ") {
+			return strings.TrimPrefix(v, "ʞ")
+		}
+		return v
+	case int, float32, float64, bool, nil:
+		return v
+	default:
+		return printer.Pr_str(v, false)
+	}
+}
+
+// webLog logs msg at level with alternating key/value attributes:
+// (web/log :info "message" "key" value …).
+func webLog(level, msg string, kv ...MalType) (MalType, error) {
+	attrs := make([]any, 0, len(kv))
+	for i, v := range kv {
+		if i%2 == 0 {
+			attrs = append(attrs, strings.TrimPrefix(toStr(v), "ʞ"))
+		} else {
+			attrs = append(attrs, logValue(v))
+		}
+	}
+	switch strings.TrimPrefix(level, "ʞ") {
+	case "debug":
+		webLogger.Debug(msg, attrs...)
+	case "warn":
+		webLogger.Warn(msg, attrs...)
+	case "error":
+		webLogger.Error(msg, attrs...)
+	default:
+		webLogger.Info(msg, attrs...)
+	}
+	return nil, nil
+}
+
+// Load registers the web builtins. The Ring response helpers and
+// middleware are added by the header (see nsweb.Load).
+func Load(env EnvType) {
+	call.CallOverrideFN(env, "web/serve", webServe)
+	call.CallOverrideFN(env, "web/log", webLog)
+	call.Doc(env, "web/log", "[level msg & kv]",
+		"Emits a structured JSON log line to stderr at level (:debug/:info/:warn/:error) with alternating key/value attributes.")
+	call.CallOverrideFN(env, "web/encode-json", webEncodeJSON)
+	call.Doc(env, "web/encode-json", "[value]",
+		"Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → \"id\"), unlike core json-encode.")
+	call.Doc(env, "web/serve", "[config]",
+		"Starts an HTTP(S) server and blocks until interrupted. config is a hash-map: :handler (a Ring handler fn), :port or :addr, and optional :tls {:cert :key :client-ca :client-auth} for HTTPS/mTLS.")
+	call.CallOverrideFN(env, "web/router", webRouter)
+	call.Doc(env, "web/router", "[routes]",
+		"Returns a Ring handler that dispatches on method and path. routes is a vector of [\"/path/:param\" {:get handler :post handler}] pairs; matched params appear under the request's :path-params.")
+	call.CallOverrideFN(env, "web/verify-jwt", webVerifyJWT)
+	call.Doc(env, "web/verify-jwt", "[token config]",
+		"Verifies a JWT against a JWKS and returns its claims as a hash-map. config: :jwks-uri (required), :issuer, :audience, :algorithms (defaults to Keycloak's RS/ES set).")
+}

--- a/lib/web/web_test.go
+++ b/lib/web/web_test.go
@@ -1,0 +1,200 @@
+package web_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/concurrent/nsconcurrent"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/coreextended/nscoreextended"
+	"github.com/jig/lisp/lib/web"
+	"github.com/jig/lisp/lib/web/nsweb"
+	"github.com/jig/lisp/types"
+)
+
+// newEnv loads core + concurrent + the web namespace.
+func newEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	if err := nscore.Load(ns); err != nil {
+		t.Fatal(err)
+	}
+	if err := nscore.LoadInput(ns); err != nil {
+		t.Fatal(err)
+	}
+	if err := nsconcurrent.Load(ns); err != nil {
+		t.Fatal(err)
+	}
+	if err := nscoreextended.Load(ns); err != nil {
+		t.Fatal(err)
+	}
+	if err := nsweb.Load(ns); err != nil {
+		t.Fatal(err)
+	}
+	return ns
+}
+
+// handlerFrom evaluates src to a Ring handler value.
+func handlerFrom(t *testing.T, ns types.EnvType, src string) types.MalType {
+	t.Helper()
+	ast, err := lisp.READ(src, types.NewCursorFile(t.Name()), ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := lisp.EVAL(context.Background(), ast, ns)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+// ringHandler is exported for tests via the test hook.
+func TestServeHTTPRoundTrip(t *testing.T) {
+	ns := newEnv(t)
+	// A router with a param route, wrapped in the JSON/log/recover stack.
+	h := handlerFrom(t, ns, `
+	  (-> (web/router
+	        [["/hello/:name" {:get (fn [req] (web/json {:hi (get (get req :path-params) :name)
+	                                                    :q  (get (get req :query) "n")}))}]
+	         ["/boom" {:get (fn [req] (throw "kaboom"))}]])
+	      web/wrap-json-body
+	      web/wrap-recover)`)
+
+	srv := httptest.NewServer(web.RingHandler(h))
+	defer srv.Close()
+
+	// happy path with a path param and a query param
+	resp := get(t, srv.Client(), srv.URL+"/hello/world?n=42")
+	if resp.status != 200 {
+		t.Fatalf("status %d", resp.status)
+	}
+	if resp.body != `{"hi":"world","q":"42"}` {
+		t.Fatalf("body %q", resp.body)
+	}
+	if ct := resp.header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type %q", ct)
+	}
+
+	// wrap-recover turns a thrown error into a 500 JSON body
+	boom := get(t, srv.Client(), srv.URL+"/boom")
+	if boom.status != 500 {
+		t.Fatalf("boom status %d", boom.status)
+	}
+
+	// unknown path → router 404
+	nf := get(t, srv.Client(), srv.URL+"/nope")
+	if nf.status != 404 {
+		t.Fatalf("404 status %d", nf.status)
+	}
+}
+
+// TestServeMTLS checks that a verified client certificate surfaces as
+// :mtls in the request and can be promoted to :identity.
+func TestServeMTLS(t *testing.T) {
+	ns := newEnv(t)
+	h := handlerFrom(t, ns, `
+	  (-> (fn [req] (web/json {:subject (get (get req :identity) :subject)
+	                           :kind    (get (get req :identity) :kind)}))
+	      web/wrap-identity)`)
+
+	caCert, caKey := makeCA(t)
+	srv := httptest.NewUnstartedServer(web.RingHandler(h))
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	srv.TLS = &tls.Config{ClientCAs: pool, ClientAuth: tls.RequireAndVerifyClientCert}
+	srv.StartTLS()
+	defer srv.Close()
+
+	clientCert := makeClientCert(t, caCert, caKey, "svc-worker")
+	client := srv.Client()
+	tr := client.Transport.(*http.Transport)
+	tr.TLSClientConfig.Certificates = []tls.Certificate{clientCert}
+
+	resp := get(t, client, srv.URL+"/")
+	if resp.status != 200 {
+		t.Fatalf("status %d body %q", resp.status, resp.body)
+	}
+	if resp.body != `{"kind":"mtls","subject":"svc-worker"}` {
+		t.Fatalf("identity body %q", resp.body)
+	}
+}
+
+// --- helpers -------------------------------------------------------------
+
+type response struct {
+	status int
+	body   string
+	header http.Header
+}
+
+func get(t *testing.T, c *http.Client, url string) response {
+	t.Helper()
+	r, err := c.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Body.Close() }()
+	b, _ := io.ReadAll(r.Body)
+	return response{status: r.StatusCode, body: string(b), header: r.Header}
+}
+
+func makeCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert, key
+}
+
+func makeClientCert(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, cn string) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: nil}
+}


### PR DESCRIPTION
A new `lib/web` namespace for web services, server-first as requested (client + streaming later). Modelled on Clojure's **Ring**: request and response are hash-maps, a handler is `(fn [req] resp)`, middleware is `handler → handler` — so handlers are ordinary functions, unit-testable with `deftest`, no socket needed.

```clojure
(def app
  (-> (web/router
        [["/certs/:id" {:get (fn [req] (web/json {:id (get (get req :path-params) :id)}))}]])
      web/wrap-json-body web/wrap-log web/wrap-recover))

(web/serve {:port 8443 :handler app
            :tls {:cert "server.crt" :key "server.key"}})
```
```sh
curl -sk https://localhost:8443/certs/42   # {"id":"42"}
```

## What's in v1

- **`web/serve`** — HTTP(S) with TLS and **mTLS** (`:client-auth`), graceful shutdown on SIGINT/SIGTERM or ctx cancel. Verified client certs surface as `:mtls` on the request.
- **`web/router`** — data-driven routes with path params (`:path-params`), 404/405 fallbacks.
- **Response helpers** — `web/json` (clean keys `:id`→`"id"`, unlike core `json-encode`), `web/text`, `web/not-found`, `web/bad-request`, `web/unauthorized`, `web/redirect`.
- **Middleware** — `web/wrap-recover`, `web/wrap-log` (structured **slog JSON**), `web/wrap-json-body`, `web/wrap-identity` (mTLS → `:identity`), `web/wrap-jwt`.
- **JWT / Keycloak** — `web/verify-jwt` validates a bearer token against a **JWKS** (auto-refreshing) with issuer/audience/expiry checks, RS256/384/512 + ES256/384/512. `web/wrap-jwt` turns it into `:identity {:kind :jwt :claims …}` or a 401.
- **`web/log`** — structured JSON to stderr via `log/slog`.

Deps added: `golang-jwt/jwt/v5`, `MicahParks/keyfunc/v3` (JWKS). `net/http` and `crypto/tls` are stdlib.

## Tests

- `web_test.go` — httptest round-trip (router, path+query params, `wrap-recover` → 500, router 404) and **mTLS** client-cert identity end to end.
- `jwt_test.go` — full **JWKS + RS256** verification with issuer/audience and nested-claim decoding, plus wrong-audience rejection.
- Exercised by hand with `curl` over HTTPS (clean JSON, structured log line, graceful stop).

`gofmt`/`go vet` clean, golangci-lint v2 clean, full suite green (plain + `lispdebug`), `-race` on lib/web green, docgen sync guard passes, `LANGUAGE.md` regenerated, `lib/web/README.md` added.

## Out of scope (next)

HTTP client (service-to-service mTLS/JWT), streaming/SSE/WebSockets, multipart uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)