### PR TITLE
fix(git): honor global gitignore and fix ssh-agent auth user

### DIFF
--- a/lib/git/README.md
+++ b/lib/git/README.md
@@ -48,8 +48,9 @@ In sha256 repositories the commit signature is stored under the `gpgsig-sha256` 
 
 | `:auth` | Meaning |
 |---|---|
-| absent | Anonymous; also for local path remotes |
-| `:ssh-agent` | Keys from the running SSH agent |
+| absent | Anonymous for HTTP and local paths; SSH URLs fall back to the SSH agent with the URL's user |
+| `:ssh-agent` | Keys from the running SSH agent, user `git` |
+| `{:ssh-agent true :user u}` | SSH agent with an explicit user |
 | `{:ssh-key pem :passphrase p :user u}` | SSH private key (user defaults to `git`) |
 | `{:username u :password p}` | HTTP basic auth |
 | `{:token t}` | GitHub/GitLab personal access token |
@@ -102,6 +103,7 @@ Revisions (`rev`, `:from`, `:at`) accept anything `git rev-parse` style: a hash,
 
 - go-git v6 is pinned to a pre-release (`v6.0.0-alpha.4`); it is the first version with sha256 support. Signing works around its current signer plumbing (which targets the wrong header in sha256 repos) by signing after commit creation, so a signed commit briefly leaves one unsigned dangling object behind — harmless, and `git fsck` stays clean.
 - go-git's worktree status re-hashes files with sha1 regardless of the repo format, spuriously flagging clean files as modified in sha256 repos (breaking `git/status` and `git/pull`). The library compensates by rewriting the index after worktree-mutating operations so go-git keeps trusting file metadata; the consequence is that an edit that preserves a file's size and mtime can go unnoticed by `git/status` — the same blind spot `git status` itself has under mtime-truncating filesystems.
+- go-git only reads `core.excludesfile` from `~/.gitconfig`; the library additionally loads git's XDG default global ignore (`$XDG_CONFIG_HOME/git/ignore`) and the system one so `git/status` agrees with `git status` about ignored files. A `core.excludesfile` declared only in `$XDG_CONFIG_HOME/git/config` is still not seen.
 - Only SSH signatures (any key type ssh-keygen supports; ed25519 recommended). No PGP/X.509 signing or verification.
 - Dual sha1+sha256 compatibility-mode repositories (both signature headers at once) are not supported.
 - go-git needs an author identity: pass `:author {:name … :email …}` (or have `user.name`/`user.email` in the repo or global config).

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -14,13 +14,18 @@ package git
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/go-git/go-billy/v6/osfs"
 	gogit "github.com/go-git/go-git/v6"
 	gitcfg "github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
 	formatcfg "github.com/go-git/go-git/v6/plumbing/format/config"
+	"github.com/go-git/go-git/v6/plumbing/format/gitignore"
 	"github.com/go-git/go-git/v6/plumbing/object"
 
 	_ "embed"
@@ -127,6 +132,53 @@ func Load(env EnvType) {
 		"Verifies the SSH signature of annotated tag name; same contract as git/verify-commit.")
 }
 
+// globalIgnore loads the system and user-global gitignore patterns once.
+// go-git only honors core.excludesfile declared in ~/.gitconfig; git's
+// XDG default ($XDG_CONFIG_HOME/git/ignore, usually ~/.config/git/ignore,
+// used when core.excludesFile is unset) is loaded here explicitly so
+// git/status agrees with git about what is ignored.
+var globalIgnore = sync.OnceValue(func() []gitignore.Pattern {
+	fs := osfs.New("/")
+	var ps []gitignore.Pattern
+	if p, err := gitignore.LoadSystemPatterns(fs); err == nil {
+		ps = append(ps, p...)
+	}
+	if p, err := gitignore.LoadGlobalPatterns(fs); err == nil && len(p) > 0 {
+		return append(ps, p...)
+	}
+	cfgDir := os.Getenv("XDG_CONFIG_HOME")
+	if cfgDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ps
+		}
+		cfgDir = filepath.Join(home, ".config")
+	}
+	data, err := os.ReadFile(filepath.Join(cfgDir, "git", "ignore"))
+	if err != nil {
+		return ps
+	}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		ps = append(ps, gitignore.ParsePattern(line, nil))
+	}
+	return ps
+})
+
+// worktree returns the repo's worktree with the global ignore patterns
+// attached, so ignore handling matches the git CLI.
+func worktree(r *Repo) (*gogit.Worktree, error) {
+	wt, err := r.repo.Worktree()
+	if err != nil {
+		return nil, err
+	}
+	wt.Excludes = globalIgnore()
+	return wt, nil
+}
+
 // refreshIndex rewrites the index so its on-disk timestamp becomes
 // strictly newer than the worktree files. go-git trusts index metadata
 // only in that case (the racy-git rule) and otherwise re-hashes worktree
@@ -209,7 +261,7 @@ func gitAdd(rv MalType, path string, params ...MalType) (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
-	wt, err := r.repo.Worktree()
+	wt, err := worktree(r)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +303,7 @@ func gitCommit(rv MalType, msg string, params ...MalType) (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
-	wt, err := r.repo.Worktree()
+	wt, err := worktree(r)
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +395,7 @@ func gitStatus(rv MalType) (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
-	wt, err := r.repo.Worktree()
+	wt, err := worktree(r)
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +456,7 @@ func gitBranch(rv MalType, name string, params ...MalType) (MalType, error) {
 		return nil, err
 	}
 	if optBool(o, "checkout") {
-		wt, err := r.repo.Worktree()
+		wt, err := worktree(r)
 		if err != nil {
 			return nil, err
 		}
@@ -454,7 +506,7 @@ func gitCheckout(rv MalType, ref string, params ...MalType) (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
-	wt, err := r.repo.Worktree()
+	wt, err := worktree(r)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/git/remote.go
+++ b/lib/git/remote.go
@@ -17,19 +17,21 @@ import (
 )
 
 // clientOpts maps the :auth option to go-git transport client options.
-// Supported shapes: the keyword :ssh-agent, {:ssh-key pem :passphrase p
-// :user u :known-hosts path :insecure-host-key bool}, {:username u
-// :password p}, {:token t} (GitHub/GitLab PATs over basic auth) and
-// {:bearer t} (true Bearer servers). Absent :auth means anonymous, which
-// also covers local path remotes. When no host-key option is given go-git
-// falls back to the default known_hosts files — the secure default.
+// Supported shapes: the keyword :ssh-agent (user "git"), {:ssh-agent
+// true :user u}, {:ssh-key pem :passphrase p :user u :known-hosts path
+// :insecure-host-key bool}, {:username u :password p}, {:token t}
+// (GitHub/GitLab PATs over basic auth) and {:bearer t} (true Bearer
+// servers). Absent :auth means anonymous for HTTP and local paths, while
+// for SSH URLs go-git itself falls back to agent auth with the URL's
+// user. When no host-key option is given go-git uses the default
+// known_hosts files — the secure default.
 func clientOpts(o map[string]MalType) ([]client.Option, error) {
 	v, ok := optGet(o, "auth")
 	if !ok || v == nil {
 		return nil, nil
 	}
 	if v == NewKeyword("ssh-agent") {
-		auth, err := transportssh.NewSSHAgentAuth("")
+		auth, err := transportssh.NewSSHAgentAuth(transportssh.DefaultUsername)
 		if err != nil {
 			return nil, err
 		}
@@ -40,6 +42,20 @@ func clientOpts(o map[string]MalType) ([]client.Option, error) {
 		return nil, fmt.Errorf(":auth must be :ssh-agent or a map, got %T", v)
 	}
 	auth := hm.Val
+	if optBool(auth, "ssh-agent") {
+		user, _, err := optString(auth, "user")
+		if err != nil {
+			return nil, err
+		}
+		if user == "" {
+			user = transportssh.DefaultUsername
+		}
+		agentAuth, err := transportssh.NewSSHAgentAuth(user)
+		if err != nil {
+			return nil, err
+		}
+		return []client.Option{client.WithSSHAuth(agentAuth)}, nil
+	}
 	if pem, ok, err := optString(auth, "ssh-key"); err != nil {
 		return nil, err
 	} else if ok {
@@ -90,7 +106,7 @@ func clientOpts(o map[string]MalType) ([]client.Option, error) {
 	} else if ok {
 		return []client.Option{client.WithHTTPAuth(&transporthttp.TokenAuth{Token: bearer})}, nil
 	}
-	return nil, fmt.Errorf(":auth map must contain :ssh-key, :username, :token or :bearer")
+	return nil, fmt.Errorf(":auth map must contain :ssh-key, :ssh-agent, :username, :token or :bearer")
 }
 
 // refSpecs converts a :refspecs vector of strings.
@@ -233,7 +249,7 @@ func gitPull(ctx context.Context, rv MalType, params ...MalType) (MalType, error
 	} else if ok {
 		pullOpts.ReferenceName = plumbing.NewBranchReferenceName(branch)
 	}
-	wt, err := r.repo.Worktree()
+	wt, err := worktree(r)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Two fixes found while exercising `lib/git` from the REPL against real repositories (jig/lisp worktree and SSH/HTTPS clones of jig/scanner from GitHub):

- **`git/status` vs `git status` disagreement**: go-git only honors `core.excludesfile` declared in `~/.gitconfig`; files ignored via git's XDG default (`$XDG_CONFIG_HOME/git/ignore`, usually `~/.config/git/ignore`) or `/etc/gitconfig` showed up as untracked. The library now loads system + global patterns once and attaches them to every worktree through `Worktree.Excludes`.
- **`:auth :ssh-agent` never authenticated**: the agent auth was built with an empty SSH user, so `git@` hosts rejected it (`no supported methods remain`). It now defaults to user `git`, and `{:ssh-agent true :user u}` covers non-`git` users. SSH URLs without `:auth` were unaffected — go-git falls back to agent auth with the URL's user.

Verified from the REPL: `git/status` now matches `git status` on this repo, and `git@github.com:jig/scanner.git` clones succeed with `:auth :ssh-agent`, with the map form, and with no `:auth` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)