### PR TITLE
refactor(web,git): rename builtins from ns/fn style to hyphenated names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,12 +149,12 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   verbatim; `¬…¬` remains for JSON and other escape-heavy content
 - `web` library — a Ring-style HTTP/HTTPS server: request and response
   are hash-maps, handlers are `(fn [req] resp)`, middleware is
-  `handler → handler`. `web/serve` (TLS, mTLS, graceful shutdown),
-  `web/router` (data-driven routes with path params), response helpers
-  (`web/json` with clean keys, `web/text`, `web/not-found`, …), and
-  middleware (`web/wrap-recover`, `web/wrap-log` as structured slog
-  JSON, `web/wrap-json-body`, `web/wrap-identity` for mTLS,
-  `web/wrap-jwt`). JWT verification (`web/verify-jwt`) validates against
+  `handler → handler`. `web-serve` (TLS, mTLS, graceful shutdown),
+  `web-router` (data-driven routes with path params), response helpers
+  (`web-json` with clean keys, `web-text`, `web-not-found`, …), and
+  middleware (`web-wrap-recover`, `web-wrap-log` as structured slog
+  JSON, `web-wrap-json-body`, `web-wrap-identity` for mTLS,
+  `web-wrap-jwt`). JWT verification (`web-verify-jwt`) validates against
   a JWKS with issuer/audience checks — Keycloak-compatible (RS/ES).
   Client-side and streaming are planned separately. See
   `lib/web/README.md`

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -452,53 +452,54 @@ Attest and verify lisp source (formatting, hashing, Ed25519 signatures).
 
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
-| `web/bad-request` | `[& msg]` | A 400 JSON response. |
-| `web/encode-json` | `[value]` | Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → "id"), unlike core json-encode. |
-| `web/json` | `[status-or-body & maybe-body]` | A JSON response: encodes body and sets content-type. (web/json data) is 200; (web/json status data) sets the status. |
-| `web/log` | `[level msg & kv]` | Emits a structured JSON log line to stderr at level (:debug/:info/:warn/:error) with alternating key/value attributes. |
-| `web/not-found` | `[& msg]` | A 404 JSON response. |
-| `web/redirect` | `[location & status]` | A redirect response (status 302 unless given as the second arg). |
-| `web/response` | `[status body & headers]` | Builds a response map with the given status and body, plus optional header pairs. |
-| `web/router` | `[routes]` | Returns a Ring handler that dispatches on method and path. routes is a vector of ["/path/:param" {:get handler :post handler}] pairs; matched params appear under the request's :path-params. |
-| `web/serve` | `[config]` | Starts an HTTP(S) server and blocks until interrupted. config is a hash-map: :handler (a Ring handler fn), :port or :addr, and optional :tls {:cert :key :client-ca :client-auth} for HTTPS/mTLS. |
-| `web/text` | `[body & status]` | A text/plain response (status 200 unless given). |
-| `web/unauthorized` | `[& msg]` | A 401 JSON response. |
-| `web/verify-jwt` | `[token config]` | Verifies a JWT against a JWKS and returns its claims as a hash-map. config: :jwks-uri (required), :issuer, :audience, :algorithms (defaults to Keycloak's RS/ES set). |
-| `web/wrap-identity` | `[handler]` | Middleware: promotes a verified mTLS client certificate to :identity {:kind :mtls :subject cn}. |
-| `web/wrap-json-body` | `[handler]` | Middleware: when the request body is a non-empty JSON object, decodes it under :json (nil on parse error). |
-| `web/wrap-jwt` | `[config handler]` | Middleware: verifies a Bearer JWT against config (see web/verify-jwt) and sets :identity {:kind :jwt :claims …}; responds 401 when missing or invalid. config is the JWKS/issuer map. |
-| `web/wrap-log` | `[handler]` | Middleware: logs one structured JSON line per request with method, uri, status and elapsed ms. |
-| `web/wrap-recover` | `[handler]` | Middleware: turns any error escaping the handler into a 500 JSON response instead of dropping the connection. |
+| `web--bearer-token` | `[req]` | Extracts the bearer token from a request's Authorization header, or nil. |
+| `web-bad-request` | `[& msg]` | A 400 JSON response. |
+| `web-encode-json` | `[value]` | Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → "id"), unlike core json-encode. |
+| `web-json` | `[status-or-body & maybe-body]` | A JSON response: encodes body and sets content-type. (web-json data) is 200; (web-json status data) sets the status. |
+| `web-log` | `[level msg & kv]` | Emits a structured JSON log line to stderr at level (:debug/:info/:warn/:error) with alternating key/value attributes. |
+| `web-not-found` | `[& msg]` | A 404 JSON response. |
+| `web-redirect` | `[location & status]` | A redirect response (status 302 unless given as the second arg). |
+| `web-response` | `[status body & headers]` | Builds a response map with the given status and body, plus optional header pairs. |
+| `web-router` | `[routes]` | Returns a Ring handler that dispatches on method and path. routes is a vector of ["/path/:param" {:get handler :post handler}] pairs; matched params appear under the request's :path-params. |
+| `web-serve` | `[config]` | Starts an HTTP(S) server and blocks until interrupted. config is a hash-map: :handler (a Ring handler fn), :port or :addr, and optional :tls {:cert :key :client-ca :client-auth} for HTTPS/mTLS. |
+| `web-text` | `[body & status]` | A text/plain response (status 200 unless given). |
+| `web-unauthorized` | `[& msg]` | A 401 JSON response. |
+| `web-verify-jwt` | `[token config]` | Verifies a JWT against a JWKS and returns its claims as a hash-map. config: :jwks-uri (required), :issuer, :audience, :algorithms (defaults to Keycloak's RS/ES set). |
+| `web-wrap-identity` | `[handler]` | Middleware: promotes a verified mTLS client certificate to :identity {:kind :mtls :subject cn}. |
+| `web-wrap-json-body` | `[handler]` | Middleware: when the request body is a non-empty JSON object, decodes it under :json (nil on parse error). |
+| `web-wrap-jwt` | `[config handler]` | Middleware: verifies a Bearer JWT against config (see web-verify-jwt) and sets :identity {:kind :jwt :claims …}; responds 401 when missing or invalid. config is the JWKS/issuer map. |
+| `web-wrap-log` | `[handler]` | Middleware: logs one structured JSON line per request with method, uri, status and elapsed ms. |
+| `web-wrap-recover` | `[handler]` | Middleware: turns any error escaping the handler into a 500 JSON response instead of dropping the connection. |
 
 ### git
 
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
-| `git/add` | `[repo path & {:all :glob}]` | Stages path ("." for everything); :all true stages all modified/deleted files, :glob true treats path as a glob pattern. |
-| `git/branch` | `[repo name & {:checkout :at}]` | Creates branch name at HEAD (or :at rev); :checkout true switches to it. |
-| `git/branches` | `[repo]` | Returns a vector of {:name :hash :head} for local branches. |
-| `git/checkout` | `[repo ref & {:create :force}]` | Checks out a branch, tag or revision; :create true creates the branch first. |
-| `git/clone` | `[url path & {:auth :branch :depth :single-branch :bare}]` | Clones url into path and returns a handle; see git/push for the :auth map. |
-| `git/close` | `[repo]` | Closes a repository handle. |
-| `git/commit` | `[repo msg & {:author {:name :email} :committer :sign {:key :passphrase} :all :allow-empty :amend}]` | Commits staged changes and returns the commit map; :sign takes an OpenSSH private key (PEM string) and produces an SSH signature. |
-| `git/fetch` | `[repo & {:auth :remote :refspecs :depth :prune :force}]` | Fetches from :remote (default origin); returns :ok or :up-to-date. |
-| `git/head` | `[repo]` | Returns {:name :branch :hash} for HEAD. |
-| `git/init` | `[path & {:bare :object-format}]` | Creates a repository at path and returns a handle; :object-format "sha256" for a SHA-256 repo. |
-| `git/log` | `[repo & {:max :from :all :path}]` | Returns a vector of commit maps from HEAD (or :from rev), newest first. |
-| `git/open` | `[path]` | Opens an existing repository and returns a handle. |
-| `git/pull` | `[repo & {:auth :remote :branch :depth :force}]` | Pulls into the current branch; returns :ok or :up-to-date. |
-| `git/push` | `[repo & {:auth :remote :refspecs :force :prune :follow-tags}]` | Pushes to :remote (default origin); returns :ok or :up-to-date. :auth is :ssh-agent, {:ssh-key pem :passphrase p :user u :known-hosts path :insecure-host-key bool}, {:username u :password p}, {:token t} or {:bearer t}. |
-| `git/remote-add` | `[repo name url]` | Adds a remote. |
-| `git/remotes` | `[repo]` | Returns a vector of {:name :urls} for the configured remotes. |
-| `git/show` | `[repo rev]` | Returns the commit map for rev (hash, "HEAD", branch or tag name). |
-| `git/status` | `[repo]` | Returns {:clean bool :files {path {:staging kw :worktree kw}}} for the worktree. |
-| `git/tag` | `[repo name & {:at :message :tagger {:name :email} :sign}]` | Creates a tag at HEAD (or :at rev); :message makes it annotated, :sign (requires :message) signs it. |
-| `git/tag-verified?` | `[repo name allowed-keys]` | (git/tag-verified? repo name allowed-keys) is true when the tag's SSH signature verifies against allowed-keys. |
-| `git/tags` | `[repo]` | Returns a vector of {:name :hash :target :annotated} for all tags. |
-| `git/verified?` | `[repo rev allowed-keys]` | (git/verified? repo rev allowed-keys) is true when the commit's SSH signature verifies against allowed-keys. |
-| `git/verify-commit` | `[repo rev allowed-keys]` | Verifies the SSH signature of rev against allowed-keys (authorized_keys-format lines); returns {:valid true :key-type :fingerprint :hash-algorithm :signer} or throws. |
-| `git/verify-tag` | `[repo name allowed-keys]` | Verifies the SSH signature of annotated tag name; same contract as git/verify-commit. |
-| `git/with-repo ⁽ᵐ⁾` | `[binding & body]` | (git/with-repo [r (git/open …)] body…) binds r and guarantees git/close when body finishes or throws. |
+| `git-add` | `[repo path & {:all :glob}]` | Stages path ("." for everything); :all true stages all modified/deleted files, :glob true treats path as a glob pattern. |
+| `git-branch` | `[repo name & {:checkout :at}]` | Creates branch name at HEAD (or :at rev); :checkout true switches to it. |
+| `git-branches` | `[repo]` | Returns a vector of {:name :hash :head} for local branches. |
+| `git-checkout` | `[repo ref & {:create :force}]` | Checks out a branch, tag or revision; :create true creates the branch first. |
+| `git-clone` | `[url path & {:auth :branch :depth :single-branch :bare}]` | Clones url into path and returns a handle; see git-push for the :auth map. |
+| `git-close` | `[repo]` | Closes a repository handle. |
+| `git-commit` | `[repo msg & {:author {:name :email} :committer :sign {:key :passphrase} :all :allow-empty :amend}]` | Commits staged changes and returns the commit map; :sign takes an OpenSSH private key (PEM string) and produces an SSH signature. |
+| `git-fetch` | `[repo & {:auth :remote :refspecs :depth :prune :force}]` | Fetches from :remote (default origin); returns :ok or :up-to-date. |
+| `git-head` | `[repo]` | Returns {:name :branch :hash} for HEAD. |
+| `git-init` | `[path & {:bare :object-format}]` | Creates a repository at path and returns a handle; :object-format "sha256" for a SHA-256 repo. |
+| `git-log` | `[repo & {:max :from :all :path}]` | Returns a vector of commit maps from HEAD (or :from rev), newest first. |
+| `git-open` | `[path]` | Opens an existing repository and returns a handle. |
+| `git-pull` | `[repo & {:auth :remote :branch :depth :force}]` | Pulls into the current branch; returns :ok or :up-to-date. |
+| `git-push` | `[repo & {:auth :remote :refspecs :force :prune :follow-tags}]` | Pushes to :remote (default origin); returns :ok or :up-to-date. :auth is :ssh-agent, {:ssh-key pem :passphrase p :user u :known-hosts path :insecure-host-key bool}, {:username u :password p}, {:token t} or {:bearer t}. |
+| `git-remote-add` | `[repo name url]` | Adds a remote. |
+| `git-remotes` | `[repo]` | Returns a vector of {:name :urls} for the configured remotes. |
+| `git-show` | `[repo rev]` | Returns the commit map for rev (hash, "HEAD", branch or tag name). |
+| `git-status` | `[repo]` | Returns {:clean bool :files {path {:staging kw :worktree kw}}} for the worktree. |
+| `git-tag` | `[repo name & {:at :message :tagger {:name :email} :sign}]` | Creates a tag at HEAD (or :at rev); :message makes it annotated, :sign (requires :message) signs it. |
+| `git-tag-verified?` | `[repo name allowed-keys]` | (git-tag-verified? repo name allowed-keys) is true when the tag's SSH signature verifies against allowed-keys. |
+| `git-tags` | `[repo]` | Returns a vector of {:name :hash :target :annotated} for all tags. |
+| `git-verified?` | `[repo rev allowed-keys]` | (git-verified? repo rev allowed-keys) is true when the commit's SSH signature verifies against allowed-keys. |
+| `git-verify-commit` | `[repo rev allowed-keys]` | Verifies the SSH signature of rev against allowed-keys (authorized_keys-format lines); returns {:valid true :key-type :fingerprint :hash-algorithm :signer} or throws. |
+| `git-verify-tag` | `[repo name allowed-keys]` | Verifies the SSH signature of annotated tag name; same contract as git-verify-commit. |
+| `git-with-repo ⁽ᵐ⁾` | `[binding & body]` | (git-with-repo [r (git-open …)] body…) binds r and guarantees git-close when body finishes or throws. |
 
 ### test
 

--- a/lib/git/README.md
+++ b/lib/git/README.md
@@ -18,12 +18,12 @@ nsgit.Load(env)
 (def key (slurp "/home/me/.ssh/id_ed25519"))
 (def pub (slurp "/home/me/.ssh/id_ed25519.pub"))
 
-(git/with-repo [r (git/init "/tmp/demo" {:object-format "sha256"})]
+(git-with-repo [r (git-init "/tmp/demo" {:object-format "sha256"})]
   (spit "/tmp/demo/a.txt" "hello\n")
-  (git/add r "a.txt")
-  (git/commit r "first" {:author {:name "Me" :email "me@example.com"}
+  (git-add r "a.txt")
+  (git-commit r "first" {:author {:name "Me" :email "me@example.com"}
                          :sign   {:key key}})
-  (git/verify-commit r "HEAD" pub))
+  (git-verify-commit r "HEAD" pub))
 ;; => {:valid true :key-type "ssh-ed25519" :fingerprint "SHA256:…"
 ;;     :hash-algorithm "sha512" :signer "me@laptop"}
 ```
@@ -40,11 +40,11 @@ In sha256 repositories the commit signature is stored under the `gpgsig-sha256` 
 
 ## Verification — fail closed
 
-`git/verify-commit` and `git/verify-tag` take the allowed public keys as a string of authorized_keys-format lines (`ssh-ed25519 AAAA… comment`, one per line; blank lines and `#` comments are skipped — a `.pub` file or an `allowed_signers`-style list both work). They return a result map **only** when a listed key produced a valid signature over the object's exact payload; every other outcome — unsigned object, no matching key, altered content, corrupt signature — throws a catchable error. `git/verified?` and `git/tag-verified?` wrap them when only a boolean is wanted.
+`git-verify-commit` and `git-verify-tag` take the allowed public keys as a string of authorized_keys-format lines (`ssh-ed25519 AAAA… comment`, one per line; blank lines and `#` comments are skipped — a `.pub` file or an `allowed_signers`-style list both work). They return a result map **only** when a listed key produced a valid signature over the object's exact payload; every other outcome — unsigned object, no matching key, altered content, corrupt signature — throws a catchable error. `git-verified?` and `git-tag-verified?` wrap them when only a boolean is wanted.
 
 ## Remotes and authentication
 
-`git/clone`, `git/push`, `git/pull` and `git/fetch` accept an `:auth` option:
+`git-clone`, `git-push`, `git-pull` and `git-fetch` accept an `:auth` option:
 
 | `:auth` | Meaning |
 |---|---|
@@ -62,31 +62,31 @@ SSH host keys are checked against the default `known_hosts` files. Override with
 
 | Builtin | Arguments | Returns |
 |---|---|---|
-| `git/init` | `[path & {:bare :object-format}]` | repo handle; `:object-format "sha256"` for a SHA-256 repo |
-| `git/open` | `[path]` | repo handle |
-| `git/clone` | `[url path & {:auth :branch :depth :single-branch :bare}]` | repo handle |
-| `git/close` | `[repo]` | nil |
-| `git/with-repo` | `[[r expr] & body]` | body value; guarantees `git/close` |
-| `git/add` | `[repo path & {:all :glob}]` | nil |
-| `git/commit` | `[repo msg & {:author :committer :sign :all :allow-empty :amend}]` | commit map |
-| `git/log` | `[repo & {:max :from :all :path}]` | vector of commit maps, newest first |
-| `git/show` | `[repo rev]` | commit map |
-| `git/status` | `[repo]` | `{:clean bool :files {path {:staging kw :worktree kw}}}` |
-| `git/head` | `[repo]` | `{:name :branch :hash}` |
-| `git/branch` | `[repo name & {:checkout :at}]` | nil |
-| `git/branches` | `[repo]` | vector of `{:name :hash :head}` |
-| `git/checkout` | `[repo ref & {:create :force}]` | nil |
-| `git/tag` | `[repo name & {:at :message :tagger :sign}]` | `{:name :hash :target :annotated}` |
-| `git/tags` | `[repo]` | vector of tag maps |
-| `git/remote-add` | `[repo name url]` | nil |
-| `git/remotes` | `[repo]` | vector of `{:name :urls}` |
-| `git/push` | `[repo & {:auth :remote :refspecs :force :prune :follow-tags}]` | `:ok` or `:up-to-date` |
-| `git/pull` | `[repo & {:auth :remote :branch :depth :force}]` | `:ok` or `:up-to-date` |
-| `git/fetch` | `[repo & {:auth :remote :refspecs :depth :prune :force}]` | `:ok` or `:up-to-date` |
-| `git/verify-commit` | `[repo rev allowed-keys]` | `{:valid :key-type :fingerprint :hash-algorithm :signer}` or throws |
-| `git/verify-tag` | `[repo name allowed-keys]` | same, for annotated tags |
-| `git/verified?` | `[repo rev allowed-keys]` | boolean |
-| `git/tag-verified?` | `[repo name allowed-keys]` | boolean |
+| `git-init` | `[path & {:bare :object-format}]` | repo handle; `:object-format "sha256"` for a SHA-256 repo |
+| `git-open` | `[path]` | repo handle |
+| `git-clone` | `[url path & {:auth :branch :depth :single-branch :bare}]` | repo handle |
+| `git-close` | `[repo]` | nil |
+| `git-with-repo` | `[[r expr] & body]` | body value; guarantees `git-close` |
+| `git-add` | `[repo path & {:all :glob}]` | nil |
+| `git-commit` | `[repo msg & {:author :committer :sign :all :allow-empty :amend}]` | commit map |
+| `git-log` | `[repo & {:max :from :all :path}]` | vector of commit maps, newest first |
+| `git-show` | `[repo rev]` | commit map |
+| `git-status` | `[repo]` | `{:clean bool :files {path {:staging kw :worktree kw}}}` |
+| `git-head` | `[repo]` | `{:name :branch :hash}` |
+| `git-branch` | `[repo name & {:checkout :at}]` | nil |
+| `git-branches` | `[repo]` | vector of `{:name :hash :head}` |
+| `git-checkout` | `[repo ref & {:create :force}]` | nil |
+| `git-tag` | `[repo name & {:at :message :tagger :sign}]` | `{:name :hash :target :annotated}` |
+| `git-tags` | `[repo]` | vector of tag maps |
+| `git-remote-add` | `[repo name url]` | nil |
+| `git-remotes` | `[repo]` | vector of `{:name :urls}` |
+| `git-push` | `[repo & {:auth :remote :refspecs :force :prune :follow-tags}]` | `:ok` or `:up-to-date` |
+| `git-pull` | `[repo & {:auth :remote :branch :depth :force}]` | `:ok` or `:up-to-date` |
+| `git-fetch` | `[repo & {:auth :remote :refspecs :depth :prune :force}]` | `:ok` or `:up-to-date` |
+| `git-verify-commit` | `[repo rev allowed-keys]` | `{:valid :key-type :fingerprint :hash-algorithm :signer}` or throws |
+| `git-verify-tag` | `[repo name allowed-keys]` | same, for annotated tags |
+| `git-verified?` | `[repo rev allowed-keys]` | boolean |
+| `git-tag-verified?` | `[repo name allowed-keys]` | boolean |
 
 Commit maps look like:
 
@@ -102,8 +102,8 @@ Revisions (`rev`, `:from`, `:at`) accept anything `git rev-parse` style: a hash,
 ## Limitations (v1)
 
 - go-git v6 is pinned to a pre-release (`v6.0.0-alpha.4`); it is the first version with sha256 support. Signing works around its current signer plumbing (which targets the wrong header in sha256 repos) by signing after commit creation, so a signed commit briefly leaves one unsigned dangling object behind — harmless, and `git fsck` stays clean.
-- go-git's worktree status re-hashes files with sha1 regardless of the repo format, spuriously flagging clean files as modified in sha256 repos (breaking `git/status` and `git/pull`). The library compensates by rewriting the index after worktree-mutating operations so go-git keeps trusting file metadata; the consequence is that an edit that preserves a file's size and mtime can go unnoticed by `git/status` — the same blind spot `git status` itself has under mtime-truncating filesystems.
-- go-git only reads `core.excludesfile` from `~/.gitconfig`; the library additionally loads git's XDG default global ignore (`$XDG_CONFIG_HOME/git/ignore`) and the system one so `git/status` agrees with `git status` about ignored files. A `core.excludesfile` declared only in `$XDG_CONFIG_HOME/git/config` is still not seen.
+- go-git's worktree status re-hashes files with sha1 regardless of the repo format, spuriously flagging clean files as modified in sha256 repos (breaking `git-status` and `git-pull`). The library compensates by rewriting the index after worktree-mutating operations so go-git keeps trusting file metadata; the consequence is that an edit that preserves a file's size and mtime can go unnoticed by `git-status` — the same blind spot `git status` itself has under mtime-truncating filesystems.
+- go-git only reads `core.excludesfile` from `~/.gitconfig`; the library additionally loads git's XDG default global ignore (`$XDG_CONFIG_HOME/git/ignore`) and the system one so `git-status` agrees with `git status` about ignored files. A `core.excludesfile` declared only in `$XDG_CONFIG_HOME/git/config` is still not seen.
 - Only SSH signatures (any key type ssh-keygen supports; ed25519 recommended). No PGP/X.509 signing or verification.
 - Dual sha1+sha256 compatibility-mode repositories (both signature headers at once) are not supported.
 - go-git needs an author identity: pass `:author {:name … :email …}` (or have `user.name`/`user.email` in the repo or global config).

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -63,80 +63,80 @@ func asRepo(name string, v MalType) (*Repo, error) {
 
 // Load registers the git builtins in env.
 func Load(env EnvType) {
-	call.CallOverrideFN(env, "git/init", gitInit, 1, 2)
-	call.CallOverrideFN(env, "git/open", gitOpen)
-	call.CallOverrideFN(env, "git/clone", gitClone, 3, 4)
-	call.CallOverrideFN(env, "git/close", gitClose)
-	call.CallOverrideFN(env, "git/add", gitAdd, 2, 3)
-	call.CallOverrideFN(env, "git/commit", gitCommit, 2, 3)
-	call.CallOverrideFN(env, "git/log", gitLog, 1, 2)
-	call.CallOverrideFN(env, "git/show", gitShow)
-	call.CallOverrideFN(env, "git/status", gitStatus)
-	call.CallOverrideFN(env, "git/head", gitHead)
-	call.CallOverrideFN(env, "git/branch", gitBranch, 2, 3)
-	call.CallOverrideFN(env, "git/branches", gitBranches)
-	call.CallOverrideFN(env, "git/checkout", gitCheckout, 2, 3)
-	call.CallOverrideFN(env, "git/tag", gitTag, 2, 3)
-	call.CallOverrideFN(env, "git/tags", gitTags)
-	call.CallOverrideFN(env, "git/remote-add", gitRemoteAdd)
-	call.CallOverrideFN(env, "git/remotes", gitRemotes)
-	call.CallOverrideFN(env, "git/push", gitPush, 2, 3)
-	call.CallOverrideFN(env, "git/pull", gitPull, 2, 3)
-	call.CallOverrideFN(env, "git/fetch", gitFetch, 2, 3)
-	call.CallOverrideFN(env, "git/verify-commit", gitVerifyCommit)
-	call.CallOverrideFN(env, "git/verify-tag", gitVerifyTag)
+	call.CallOverrideFN(env, "git-init", gitInit, 1, 2)
+	call.CallOverrideFN(env, "git-open", gitOpen)
+	call.CallOverrideFN(env, "git-clone", gitClone, 3, 4)
+	call.CallOverrideFN(env, "git-close", gitClose)
+	call.CallOverrideFN(env, "git-add", gitAdd, 2, 3)
+	call.CallOverrideFN(env, "git-commit", gitCommit, 2, 3)
+	call.CallOverrideFN(env, "git-log", gitLog, 1, 2)
+	call.CallOverrideFN(env, "git-show", gitShow)
+	call.CallOverrideFN(env, "git-status", gitStatus)
+	call.CallOverrideFN(env, "git-head", gitHead)
+	call.CallOverrideFN(env, "git-branch", gitBranch, 2, 3)
+	call.CallOverrideFN(env, "git-branches", gitBranches)
+	call.CallOverrideFN(env, "git-checkout", gitCheckout, 2, 3)
+	call.CallOverrideFN(env, "git-tag", gitTag, 2, 3)
+	call.CallOverrideFN(env, "git-tags", gitTags)
+	call.CallOverrideFN(env, "git-remote-add", gitRemoteAdd)
+	call.CallOverrideFN(env, "git-remotes", gitRemotes)
+	call.CallOverrideFN(env, "git-push", gitPush, 2, 3)
+	call.CallOverrideFN(env, "git-pull", gitPull, 2, 3)
+	call.CallOverrideFN(env, "git-fetch", gitFetch, 2, 3)
+	call.CallOverrideFN(env, "git-verify-commit", gitVerifyCommit)
+	call.CallOverrideFN(env, "git-verify-tag", gitVerifyTag)
 
-	call.Doc(env, "git/init", "[path & {:bare :object-format}]",
+	call.Doc(env, "git-init", "[path & {:bare :object-format}]",
 		"Creates a repository at path and returns a handle; :object-format \"sha256\" for a SHA-256 repo.")
-	call.Doc(env, "git/open", "[path]",
+	call.Doc(env, "git-open", "[path]",
 		"Opens an existing repository and returns a handle.")
-	call.Doc(env, "git/clone", "[url path & {:auth :branch :depth :single-branch :bare}]",
-		"Clones url into path and returns a handle; see git/push for the :auth map.")
-	call.Doc(env, "git/close", "[repo]",
+	call.Doc(env, "git-clone", "[url path & {:auth :branch :depth :single-branch :bare}]",
+		"Clones url into path and returns a handle; see git-push for the :auth map.")
+	call.Doc(env, "git-close", "[repo]",
 		"Closes a repository handle.")
-	call.Doc(env, "git/add", "[repo path & {:all :glob}]",
+	call.Doc(env, "git-add", "[repo path & {:all :glob}]",
 		"Stages path (\".\" for everything); :all true stages all modified/deleted files, :glob true treats path as a glob pattern.")
-	call.Doc(env, "git/commit", "[repo msg & {:author {:name :email} :committer :sign {:key :passphrase} :all :allow-empty :amend}]",
+	call.Doc(env, "git-commit", "[repo msg & {:author {:name :email} :committer :sign {:key :passphrase} :all :allow-empty :amend}]",
 		"Commits staged changes and returns the commit map; :sign takes an OpenSSH private key (PEM string) and produces an SSH signature.")
-	call.Doc(env, "git/log", "[repo & {:max :from :all :path}]",
+	call.Doc(env, "git-log", "[repo & {:max :from :all :path}]",
 		"Returns a vector of commit maps from HEAD (or :from rev), newest first.")
-	call.Doc(env, "git/show", "[repo rev]",
+	call.Doc(env, "git-show", "[repo rev]",
 		"Returns the commit map for rev (hash, \"HEAD\", branch or tag name).")
-	call.Doc(env, "git/status", "[repo]",
+	call.Doc(env, "git-status", "[repo]",
 		"Returns {:clean bool :files {path {:staging kw :worktree kw}}} for the worktree.")
-	call.Doc(env, "git/head", "[repo]",
+	call.Doc(env, "git-head", "[repo]",
 		"Returns {:name :branch :hash} for HEAD.")
-	call.Doc(env, "git/branch", "[repo name & {:checkout :at}]",
+	call.Doc(env, "git-branch", "[repo name & {:checkout :at}]",
 		"Creates branch name at HEAD (or :at rev); :checkout true switches to it.")
-	call.Doc(env, "git/branches", "[repo]",
+	call.Doc(env, "git-branches", "[repo]",
 		"Returns a vector of {:name :hash :head} for local branches.")
-	call.Doc(env, "git/checkout", "[repo ref & {:create :force}]",
+	call.Doc(env, "git-checkout", "[repo ref & {:create :force}]",
 		"Checks out a branch, tag or revision; :create true creates the branch first.")
-	call.Doc(env, "git/tag", "[repo name & {:at :message :tagger {:name :email} :sign}]",
+	call.Doc(env, "git-tag", "[repo name & {:at :message :tagger {:name :email} :sign}]",
 		"Creates a tag at HEAD (or :at rev); :message makes it annotated, :sign (requires :message) signs it.")
-	call.Doc(env, "git/tags", "[repo]",
+	call.Doc(env, "git-tags", "[repo]",
 		"Returns a vector of {:name :hash :target :annotated} for all tags.")
-	call.Doc(env, "git/remote-add", "[repo name url]",
+	call.Doc(env, "git-remote-add", "[repo name url]",
 		"Adds a remote.")
-	call.Doc(env, "git/remotes", "[repo]",
+	call.Doc(env, "git-remotes", "[repo]",
 		"Returns a vector of {:name :urls} for the configured remotes.")
-	call.Doc(env, "git/push", "[repo & {:auth :remote :refspecs :force :prune :follow-tags}]",
+	call.Doc(env, "git-push", "[repo & {:auth :remote :refspecs :force :prune :follow-tags}]",
 		"Pushes to :remote (default origin); returns :ok or :up-to-date. :auth is :ssh-agent, {:ssh-key pem :passphrase p :user u :known-hosts path :insecure-host-key bool}, {:username u :password p}, {:token t} or {:bearer t}.")
-	call.Doc(env, "git/pull", "[repo & {:auth :remote :branch :depth :force}]",
+	call.Doc(env, "git-pull", "[repo & {:auth :remote :branch :depth :force}]",
 		"Pulls into the current branch; returns :ok or :up-to-date.")
-	call.Doc(env, "git/fetch", "[repo & {:auth :remote :refspecs :depth :prune :force}]",
+	call.Doc(env, "git-fetch", "[repo & {:auth :remote :refspecs :depth :prune :force}]",
 		"Fetches from :remote (default origin); returns :ok or :up-to-date.")
-	call.Doc(env, "git/verify-commit", "[repo rev allowed-keys]",
+	call.Doc(env, "git-verify-commit", "[repo rev allowed-keys]",
 		"Verifies the SSH signature of rev against allowed-keys (authorized_keys-format lines); returns {:valid true :key-type :fingerprint :hash-algorithm :signer} or throws.")
-	call.Doc(env, "git/verify-tag", "[repo name allowed-keys]",
-		"Verifies the SSH signature of annotated tag name; same contract as git/verify-commit.")
+	call.Doc(env, "git-verify-tag", "[repo name allowed-keys]",
+		"Verifies the SSH signature of annotated tag name; same contract as git-verify-commit.")
 }
 
 // globalIgnore loads the system and user-global gitignore patterns once.
 // go-git only honors core.excludesfile declared in ~/.gitconfig; git's
 // XDG default ($XDG_CONFIG_HOME/git/ignore, usually ~/.config/git/ignore,
 // used when core.excludesFile is unset) is loaded here explicitly so
-// git/status agrees with git about what is ignored.
+// git-status agrees with git about what is ignored.
 var globalIgnore = sync.OnceValue(func() []gitignore.Pattern {
 	fs := osfs.New("/")
 	var ps []gitignore.Pattern
@@ -226,7 +226,7 @@ func gitInit(path string, params ...MalType) (MalType, error) {
 		case "sha256":
 			initOpts = append(initOpts, gogit.WithObjectFormat(formatcfg.SHA256))
 		default:
-			return nil, fmt.Errorf("git/init: :object-format must be \"sha1\" or \"sha256\", got %q", s)
+			return nil, fmt.Errorf("git-init: :object-format must be \"sha1\" or \"sha256\", got %q", s)
 		}
 	}
 	repo, err := gogit.PlainInit(path, optBool(o, "bare"), initOpts...)
@@ -245,7 +245,7 @@ func gitOpen(path string) (MalType, error) {
 }
 
 func gitClose(rv MalType) (MalType, error) {
-	r, err := asRepo("git/close", rv)
+	r, err := asRepo("git-close", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +253,7 @@ func gitClose(rv MalType) (MalType, error) {
 }
 
 func gitAdd(rv MalType, path string, params ...MalType) (MalType, error) {
-	r, err := asRepo("git/add", rv)
+	r, err := asRepo("git-add", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func gitAdd(rv MalType, path string, params ...MalType) (MalType, error) {
 }
 
 func gitCommit(rv MalType, msg string, params ...MalType) (MalType, error) {
-	r, err := asRepo("git/commit", rv)
+	r, err := asRepo("git-commit", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +330,7 @@ func gitCommit(rv MalType, msg string, params ...MalType) (MalType, error) {
 }
 
 func gitLog(rv MalType, params ...MalType) (MalType, error) {
-	r, err := asRepo("git/log", rv)
+	r, err := asRepo("git-log", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -379,7 +379,7 @@ func gitLog(rv MalType, params ...MalType) (MalType, error) {
 }
 
 func gitShow(rv MalType, rev string) (MalType, error) {
-	r, err := asRepo("git/show", rv)
+	r, err := asRepo("git-show", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +391,7 @@ func gitShow(rv MalType, rev string) (MalType, error) {
 }
 
 func gitStatus(rv MalType) (MalType, error) {
-	r, err := asRepo("git/status", rv)
+	r, err := asRepo("git-status", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -417,7 +417,7 @@ func gitStatus(rv MalType) (MalType, error) {
 }
 
 func gitHead(rv MalType) (MalType, error) {
-	r, err := asRepo("git/head", rv)
+	r, err := asRepo("git-head", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -433,7 +433,7 @@ func gitHead(rv MalType) (MalType, error) {
 }
 
 func gitBranch(rv MalType, name string, params ...MalType) (MalType, error) {
-	r, err := asRepo("git/branch", rv)
+	r, err := asRepo("git-branch", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -469,7 +469,7 @@ func gitBranch(rv MalType, name string, params ...MalType) (MalType, error) {
 }
 
 func gitBranches(rv MalType) (MalType, error) {
-	r, err := asRepo("git/branches", rv)
+	r, err := asRepo("git-branches", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -498,7 +498,7 @@ func gitBranches(rv MalType) (MalType, error) {
 }
 
 func gitCheckout(rv MalType, ref string, params ...MalType) (MalType, error) {
-	r, err := asRepo("git/checkout", rv)
+	r, err := asRepo("git-checkout", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -531,7 +531,7 @@ func gitCheckout(rv MalType, ref string, params ...MalType) (MalType, error) {
 }
 
 func gitRemoteAdd(rv MalType, name, url string) (MalType, error) {
-	r, err := asRepo("git/remote-add", rv)
+	r, err := asRepo("git-remote-add", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -540,7 +540,7 @@ func gitRemoteAdd(rv MalType, name, url string) (MalType, error) {
 }
 
 func gitRemotes(rv MalType) (MalType, error) {
-	r, err := asRepo("git/remotes", rv)
+	r, err := asRepo("git-remotes", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -563,7 +563,7 @@ func gitRemotes(rv MalType) (MalType, error) {
 }
 
 func gitTag(rv MalType, name string, params ...MalType) (MalType, error) {
-	r, err := asRepo("git/tag", rv)
+	r, err := asRepo("git-tag", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -590,7 +590,7 @@ func gitTag(rv MalType, name string, params ...MalType) (MalType, error) {
 		return nil, err
 	}
 	if signer != nil && !annotated {
-		return nil, fmt.Errorf("git/tag: :sign requires :message (only annotated tags can be signed)")
+		return nil, fmt.Errorf("git-tag: :sign requires :message (only annotated tags can be signed)")
 	}
 	var tagOpts *gogit.CreateTagOptions
 	if annotated {
@@ -617,7 +617,7 @@ func gitTag(rv MalType, name string, params ...MalType) (MalType, error) {
 }
 
 func gitTags(rv MalType) (MalType, error) {
-	r, err := asRepo("git/tags", rv)
+	r, err := asRepo("git-tags", rv)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/git/git_test.go
+++ b/lib/git/git_test.go
@@ -103,12 +103,12 @@ func TestInitAddCommitLog(t *testing.T) {
 		t.Run(format, func(t *testing.T) {
 			ns := newEnv(t)
 			dir := t.TempDir()
-			eval(t, ns, fmt.Sprintf(`(def r (git/init %q {:object-format %q}))`, dir, format))
+			eval(t, ns, fmt.Sprintf(`(def r (git-init %q {:object-format %q}))`, dir, format))
 			if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hola\n"), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			eval(t, ns, `(git/add r "a.txt")`)
-			eval(t, ns, `(def c (git/commit r "first" {:author `+author+`}))`)
+			eval(t, ns, `(git-add r "a.txt")`)
+			eval(t, ns, `(def c (git-commit r "first" {:author `+author+`}))`)
 			expectTrue(t, ns, `(= false (get c :signed))`)
 			expectTrue(t, ns, `(= "first" (get c :message))`)
 			expectTrue(t, ns, `(= "Test" (get-in c [:author :name]))`)
@@ -118,11 +118,11 @@ func TestInitAddCommitLog(t *testing.T) {
 			if !ok || len(hash) != wantLen {
 				t.Fatalf("hash %q: want a %d-char hex string", hash, wantLen)
 			}
-			expectTrue(t, ns, `(= 1 (count (git/log r)))`)
-			expectTrue(t, ns, `(= (get c :hash) (get (git/show r "HEAD") :hash))`)
-			expectTrue(t, ns, `(get (git/status r) :clean)`)
-			expectTrue(t, ns, `(= "master" (get (git/head r) :branch))`)
-			eval(t, ns, `(git/close r)`)
+			expectTrue(t, ns, `(= 1 (count (git-log r)))`)
+			expectTrue(t, ns, `(= (get c :hash) (get (git-show r "HEAD") :hash))`)
+			expectTrue(t, ns, `(get (git-status r) :clean)`)
+			expectTrue(t, ns, `(= "master" (get (git-head r) :branch))`)
+			eval(t, ns, `(git-close r)`)
 		})
 	}
 }
@@ -133,21 +133,21 @@ func TestSignedCommitVerify(t *testing.T) {
 			ns := newEnv(t)
 			dir := t.TempDir()
 			privPEM, authorized := testKey(t, "alice")
-			eval(t, ns, fmt.Sprintf(`(def r (git/init %q {:object-format %q}))`, dir, format))
+			eval(t, ns, fmt.Sprintf(`(def r (git-init %q {:object-format %q}))`, dir, format))
 			if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hola\n"), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			eval(t, ns, `(git/add r "a.txt")`)
-			eval(t, ns, fmt.Sprintf(`(def c (git/commit r "signed" {:author %s :sign {:key %q}}))`, author, privPEM))
+			eval(t, ns, `(git-add r "a.txt")`)
+			eval(t, ns, fmt.Sprintf(`(def c (git-commit r "signed" {:author %s :sign {:key %q}}))`, author, privPEM))
 			expectTrue(t, ns, `(get c :signed)`)
-			eval(t, ns, fmt.Sprintf(`(def v (git/verify-commit r "HEAD" %q))`, authorized))
+			eval(t, ns, fmt.Sprintf(`(def v (git-verify-commit r "HEAD" %q))`, authorized))
 			expectTrue(t, ns, `(get v :valid)`)
 			expectTrue(t, ns, `(= "ssh-ed25519" (get v :key-type))`)
 			expectTrue(t, ns, `(= "sha512" (get v :hash-algorithm))`)
 			expectTrue(t, ns, `(= "alice" (get v :signer))`)
 			// log and show see the signed commit at HEAD
-			expectTrue(t, ns, `(get (get (git/log r) 0) :signed)`)
-			eval(t, ns, `(git/close r)`)
+			expectTrue(t, ns, `(get (get (git-log r) 0) :signed)`)
+			eval(t, ns, `(git-close r)`)
 		})
 	}
 }
@@ -157,67 +157,67 @@ func TestVerifyFailClosed(t *testing.T) {
 	dir := t.TempDir()
 	privPEM, authorized := testKey(t, "alice")
 	_, otherAuthorized := testKey(t, "mallory")
-	eval(t, ns, fmt.Sprintf(`(def r (git/init %q))`, dir))
+	eval(t, ns, fmt.Sprintf(`(def r (git-init %q))`, dir))
 	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	eval(t, ns, `(git/add r "a.txt")`)
-	eval(t, ns, `(git/commit r "unsigned" {:author `+author+`})`)
+	eval(t, ns, `(git-add r "a.txt")`)
+	eval(t, ns, `(git-commit r "unsigned" {:author `+author+`})`)
 
 	// unsigned commit: verify throws, verified? is false
-	expectThrow(t, ns, fmt.Sprintf(`(git/verify-commit r "HEAD" %q)`, authorized))
-	expectTrue(t, ns, fmt.Sprintf(`(= false (git/verified? r "HEAD" %q))`, authorized))
+	expectThrow(t, ns, fmt.Sprintf(`(git-verify-commit r "HEAD" %q)`, authorized))
+	expectTrue(t, ns, fmt.Sprintf(`(= false (git-verified? r "HEAD" %q))`, authorized))
 
 	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("2\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	eval(t, ns, `(git/add r "a.txt")`)
-	eval(t, ns, fmt.Sprintf(`(git/commit r "signed" {:author %s :sign {:key %q}})`, author, privPEM))
+	eval(t, ns, `(git-add r "a.txt")`)
+	eval(t, ns, fmt.Sprintf(`(git-commit r "signed" {:author %s :sign {:key %q}})`, author, privPEM))
 
 	// wrong key throws; a multi-line allowed-keys with the right key passes
-	expectThrow(t, ns, fmt.Sprintf(`(git/verify-commit r "HEAD" %q)`, otherAuthorized))
+	expectThrow(t, ns, fmt.Sprintf(`(git-verify-commit r "HEAD" %q)`, otherAuthorized))
 	multi := "# team keys\n" + otherAuthorized + "\n" + authorized + "\n"
-	expectTrue(t, ns, fmt.Sprintf(`(get (git/verify-commit r "HEAD" %q) :valid)`, multi))
-	expectTrue(t, ns, fmt.Sprintf(`(= "alice" (get (git/verify-commit r "HEAD" %q) :signer))`, multi))
-	expectTrue(t, ns, fmt.Sprintf(`(git/verified? r "HEAD" %q)`, authorized))
-	eval(t, ns, `(git/close r)`)
+	expectTrue(t, ns, fmt.Sprintf(`(get (git-verify-commit r "HEAD" %q) :valid)`, multi))
+	expectTrue(t, ns, fmt.Sprintf(`(= "alice" (get (git-verify-commit r "HEAD" %q) :signer))`, multi))
+	expectTrue(t, ns, fmt.Sprintf(`(git-verified? r "HEAD" %q)`, authorized))
+	eval(t, ns, `(git-close r)`)
 }
 
 func TestBranchesTagsStatus(t *testing.T) {
 	ns := newEnv(t)
 	dir := t.TempDir()
 	privPEM, authorized := testKey(t, "alice")
-	eval(t, ns, fmt.Sprintf(`(def r (git/init %q))`, dir))
+	eval(t, ns, fmt.Sprintf(`(def r (git-init %q))`, dir))
 	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	expectTrue(t, ns, `(= false (get (git/status r) :clean))`)
-	expectTrue(t, ns, `(= :untracked (get-in (git/status r) [:files "a.txt" :worktree]))`)
-	eval(t, ns, `(git/add r ".")`)
-	eval(t, ns, `(git/commit r "first" {:author `+author+`})`)
-	expectTrue(t, ns, `(get (git/status r) :clean)`)
+	expectTrue(t, ns, `(= false (get (git-status r) :clean))`)
+	expectTrue(t, ns, `(= :untracked (get-in (git-status r) [:files "a.txt" :worktree]))`)
+	eval(t, ns, `(git-add r ".")`)
+	eval(t, ns, `(git-commit r "first" {:author `+author+`})`)
+	expectTrue(t, ns, `(get (git-status r) :clean)`)
 
 	// branches
-	eval(t, ns, `(git/branch r "feature" {:checkout true})`)
-	expectTrue(t, ns, `(= "feature" (get (git/head r) :branch))`)
-	expectTrue(t, ns, `(= 2 (count (git/branches r)))`)
-	eval(t, ns, `(git/checkout r "master")`)
-	expectTrue(t, ns, `(= "master" (get (git/head r) :branch))`)
+	eval(t, ns, `(git-branch r "feature" {:checkout true})`)
+	expectTrue(t, ns, `(= "feature" (get (git-head r) :branch))`)
+	expectTrue(t, ns, `(= 2 (count (git-branches r)))`)
+	eval(t, ns, `(git-checkout r "master")`)
+	expectTrue(t, ns, `(= "master" (get (git-head r) :branch))`)
 
 	// tags: lightweight, annotated, signed
-	eval(t, ns, `(git/tag r "light")`)
-	eval(t, ns, `(git/tag r "annotated" {:message "v1" :tagger `+author+`})`)
-	eval(t, ns, fmt.Sprintf(`(git/tag r "signed" {:message "v2" :tagger %s :sign {:key %q}})`, author, privPEM))
-	expectTrue(t, ns, `(= 3 (count (git/tags r)))`)
-	expectTrue(t, ns, fmt.Sprintf(`(get (git/verify-tag r "signed" %q) :valid)`, authorized))
-	expectThrow(t, ns, fmt.Sprintf(`(git/verify-tag r "annotated" %q)`, authorized))
-	expectThrow(t, ns, fmt.Sprintf(`(git/verify-tag r "light" %q)`, authorized))
-	expectTrue(t, ns, fmt.Sprintf(`(git/tag-verified? r "signed" %q)`, authorized))
-	expectTrue(t, ns, fmt.Sprintf(`(= false (git/tag-verified? r "light" %q))`, authorized))
+	eval(t, ns, `(git-tag r "light")`)
+	eval(t, ns, `(git-tag r "annotated" {:message "v1" :tagger `+author+`})`)
+	eval(t, ns, fmt.Sprintf(`(git-tag r "signed" {:message "v2" :tagger %s :sign {:key %q}})`, author, privPEM))
+	expectTrue(t, ns, `(= 3 (count (git-tags r)))`)
+	expectTrue(t, ns, fmt.Sprintf(`(get (git-verify-tag r "signed" %q) :valid)`, authorized))
+	expectThrow(t, ns, fmt.Sprintf(`(git-verify-tag r "annotated" %q)`, authorized))
+	expectThrow(t, ns, fmt.Sprintf(`(git-verify-tag r "light" %q)`, authorized))
+	expectTrue(t, ns, fmt.Sprintf(`(git-tag-verified? r "signed" %q)`, authorized))
+	expectTrue(t, ns, fmt.Sprintf(`(= false (git-tag-verified? r "light" %q))`, authorized))
 
 	// :sign without :message is rejected
-	expectThrow(t, ns, fmt.Sprintf(`(git/tag r "bad" {:sign {:key %q}})`, privPEM))
-	eval(t, ns, `(git/close r)`)
+	expectThrow(t, ns, fmt.Sprintf(`(git-tag r "bad" {:sign {:key %q}})`, privPEM))
+	eval(t, ns, `(git-close r)`)
 }
 
 func TestPushPullFetchLocalRemote(t *testing.T) {
@@ -229,34 +229,34 @@ func TestPushPullFetchLocalRemote(t *testing.T) {
 			bare := filepath.Join(base, "bare")
 			clone := filepath.Join(base, "clone")
 
-			eval(t, ns, fmt.Sprintf(`(def bare (git/init %q {:bare true :object-format %q}))`, bare, format))
-			eval(t, ns, fmt.Sprintf(`(def r (git/init %q {:object-format %q}))`, work, format))
+			eval(t, ns, fmt.Sprintf(`(def bare (git-init %q {:bare true :object-format %q}))`, bare, format))
+			eval(t, ns, fmt.Sprintf(`(def r (git-init %q {:object-format %q}))`, work, format))
 			if err := os.WriteFile(filepath.Join(work, "a.txt"), []byte("1\n"), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			eval(t, ns, `(git/add r "a.txt")`)
-			eval(t, ns, `(git/commit r "first" {:author `+author+`})`)
-			eval(t, ns, fmt.Sprintf(`(git/remote-add r "origin" %q)`, bare))
-			expectTrue(t, ns, `(= 1 (count (git/remotes r)))`)
-			expectTrue(t, ns, `(= :ok (git/push r))`)
-			expectTrue(t, ns, `(= :up-to-date (git/push r))`)
+			eval(t, ns, `(git-add r "a.txt")`)
+			eval(t, ns, `(git-commit r "first" {:author `+author+`})`)
+			eval(t, ns, fmt.Sprintf(`(git-remote-add r "origin" %q)`, bare))
+			expectTrue(t, ns, `(= 1 (count (git-remotes r)))`)
+			expectTrue(t, ns, `(= :ok (git-push r))`)
+			expectTrue(t, ns, `(= :up-to-date (git-push r))`)
 
-			eval(t, ns, fmt.Sprintf(`(def r2 (git/clone %q %q))`, bare, clone))
-			expectTrue(t, ns, `(= (get (git/head r) :hash) (get (git/head r2) :hash))`)
+			eval(t, ns, fmt.Sprintf(`(def r2 (git-clone %q %q))`, bare, clone))
+			expectTrue(t, ns, `(= (get (git-head r) :hash) (get (git-head r2) :hash))`)
 
 			// new commit upstream, then pull and fetch downstream
 			if err := os.WriteFile(filepath.Join(work, "a.txt"), []byte("2\n"), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			eval(t, ns, `(git/add r "a.txt")`)
-			eval(t, ns, `(git/commit r "second" {:author `+author+`})`)
-			expectTrue(t, ns, `(= :ok (git/push r))`)
-			expectTrue(t, ns, `(= :ok (git/pull r2))`)
-			expectTrue(t, ns, `(= :up-to-date (git/pull r2))`)
-			expectTrue(t, ns, `(= (get (git/head r) :hash) (get (git/head r2) :hash))`)
-			expectTrue(t, ns, `(= 2 (count (git/log r2)))`)
-			expectTrue(t, ns, `(= :up-to-date (git/fetch r2))`)
-			eval(t, ns, `(do (git/close r) (git/close r2) (git/close bare))`)
+			eval(t, ns, `(git-add r "a.txt")`)
+			eval(t, ns, `(git-commit r "second" {:author `+author+`})`)
+			expectTrue(t, ns, `(= :ok (git-push r))`)
+			expectTrue(t, ns, `(= :ok (git-pull r2))`)
+			expectTrue(t, ns, `(= :up-to-date (git-pull r2))`)
+			expectTrue(t, ns, `(= (get (git-head r) :hash) (get (git-head r2) :hash))`)
+			expectTrue(t, ns, `(= 2 (count (git-log r2)))`)
+			expectTrue(t, ns, `(= :up-to-date (git-fetch r2))`)
+			eval(t, ns, `(do (git-close r) (git-close r2) (git-close bare))`)
 		})
 	}
 }
@@ -280,14 +280,14 @@ func TestGitCLIInterop(t *testing.T) {
 			if err := os.WriteFile(allowed, []byte("* "+authorized+"\n"), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			eval(t, ns, fmt.Sprintf(`(def r (git/init %q {:object-format %q}))`, dir, format))
+			eval(t, ns, fmt.Sprintf(`(def r (git-init %q {:object-format %q}))`, dir, format))
 			if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hola\n"), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			eval(t, ns, `(git/add r "a.txt")`)
-			eval(t, ns, fmt.Sprintf(`(git/commit r "signed" {:author %s :sign {:key %q}})`, author, privPEM))
-			eval(t, ns, fmt.Sprintf(`(git/tag r "v1" {:message "v1" :tagger %s :sign {:key %q}})`, author, privPEM))
-			eval(t, ns, `(git/close r)`)
+			eval(t, ns, `(git-add r "a.txt")`)
+			eval(t, ns, fmt.Sprintf(`(git-commit r "signed" {:author %s :sign {:key %q}})`, author, privPEM))
+			eval(t, ns, fmt.Sprintf(`(git-tag r "v1" {:message "v1" :tagger %s :sign {:key %q}})`, author, privPEM))
+			eval(t, ns, `(git-close r)`)
 
 			for _, args := range [][]string{
 				{"-C", dir, "fsck"},

--- a/lib/git/header-git.lisp
+++ b/lib/git/header-git.lisp
@@ -1,30 +1,30 @@
 ;; $MODULE header-git
 
 (do
-  ;; (git/with-repo [r (git/open ...)] body...) binds r to a repository
+  ;; (git-with-repo [r (git-open ...)] body...) binds r to a repository
   ;; handle and guarantees it is closed when body finishes or throws.
-  (defmacro git/with-repo
+  (defmacro git-with-repo
     (with-meta
       (fn [binding & body]
         `(let [~(nth binding 0) ~(nth binding 1)]
            (try
              ~@body
-             (finally (git/close ~(nth binding 0))))))
-      {:doc "(git/with-repo [r (git/open …)] body…) binds r and guarantees git/close when body finishes or throws."}))
+             (finally (git-close ~(nth binding 0))))))
+      {:doc "(git-with-repo [r (git-open …)] body…) binds r and guarantees git-close when body finishes or throws."}))
 
   ;; Boolean conveniences over the fail-closed verify builtins.
-  (def git/verified?
+  (def git-verified?
     (with-meta
       (fn [repo rev allowed-keys]
         (try
-          (do (git/verify-commit repo rev allowed-keys) true)
+          (do (git-verify-commit repo rev allowed-keys) true)
           (catch e false)))
-      {:doc "(git/verified? repo rev allowed-keys) is true when the commit's SSH signature verifies against allowed-keys."}))
+      {:doc "(git-verified? repo rev allowed-keys) is true when the commit's SSH signature verifies against allowed-keys."}))
 
-  (def git/tag-verified?
+  (def git-tag-verified?
     (with-meta
       (fn [repo name allowed-keys]
         (try
-          (do (git/verify-tag repo name allowed-keys) true)
+          (do (git-verify-tag repo name allowed-keys) true)
           (catch e false)))
-      {:doc "(git/tag-verified? repo name allowed-keys) is true when the tag's SSH signature verifies against allowed-keys."})))
+      {:doc "(git-tag-verified? repo name allowed-keys) is true when the tag's SSH signature verifies against allowed-keys."})))

--- a/lib/git/remote.go
+++ b/lib/git/remote.go
@@ -187,7 +187,7 @@ func gitClone(ctx context.Context, url, path string, params ...MalType) (MalType
 }
 
 func gitPush(ctx context.Context, rv MalType, params ...MalType) (MalType, error) {
-	r, err := asRepo("git/push", rv)
+	r, err := asRepo("git-push", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func gitPush(ctx context.Context, rv MalType, params ...MalType) (MalType, error
 }
 
 func gitPull(ctx context.Context, rv MalType, params ...MalType) (MalType, error) {
-	r, err := asRepo("git/pull", rv)
+	r, err := asRepo("git-pull", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +261,7 @@ func gitPull(ctx context.Context, rv MalType, params ...MalType) (MalType, error
 }
 
 func gitFetch(ctx context.Context, rv MalType, params ...MalType) (MalType, error) {
-	r, err := asRepo("git/fetch", rv)
+	r, err := asRepo("git-fetch", rv)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/git/sign.go
+++ b/lib/git/sign.go
@@ -133,7 +133,7 @@ func resignTag(r *Repo, ref *plumbing.Reference, signer gossh.Signer) (*plumbing
 }
 
 func gitVerifyCommit(rv MalType, rev string, allowedKeys string) (MalType, error) {
-	r, err := asRepo("git/verify-commit", rv)
+	r, err := asRepo("git-verify-commit", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -146,13 +146,13 @@ func gitVerifyCommit(rv MalType, rev string, allowedKeys string) (MalType, error
 		armored = c.Signature
 	}
 	if armored == "" {
-		return nil, fmt.Errorf("git/verify-commit: commit %s is not signed", c.Hash)
+		return nil, fmt.Errorf("git-verify-commit: commit %s is not signed", c.Hash)
 	}
 	return verifySignature(c, armored, allowedKeys)
 }
 
 func gitVerifyTag(rv MalType, name string, allowedKeys string) (MalType, error) {
-	r, err := asRepo("git/verify-tag", rv)
+	r, err := asRepo("git-verify-tag", rv)
 	if err != nil {
 		return nil, err
 	}
@@ -162,14 +162,14 @@ func gitVerifyTag(rv MalType, name string, allowedKeys string) (MalType, error) 
 	}
 	tag, err := r.repo.TagObject(ref.Hash())
 	if err != nil {
-		return nil, fmt.Errorf("git/verify-tag: %q is not an annotated tag", name)
+		return nil, fmt.Errorf("git-verify-tag: %q is not an annotated tag", name)
 	}
 	armored := tag.SignatureSHA256
 	if armored == "" {
 		armored = tag.Signature
 	}
 	if armored == "" {
-		return nil, fmt.Errorf("git/verify-tag: tag %q is not signed", name)
+		return nil, fmt.Errorf("git-verify-tag: tag %q is not signed", name)
 	}
 	return verifySignature(tag, armored, allowedKeys)
 }

--- a/lib/web/README.md
+++ b/lib/web/README.md
@@ -12,19 +12,19 @@ no socket required.
 
 ```clojure
 (def app
-  (-> (web/router
-        [["/ping"        {:get (fn [req] (web/json {:pong true}))}]
-         ["/certs/:id"   {:get (fn [req] (web/json {:id (get (get req :path-params) :id)}))}]])
-      web/wrap-json-body     ; decodes a JSON body under :json
-      web/wrap-log           ; one structured JSON log line per request
-      web/wrap-recover))     ; errors become 500 instead of dropping the connection
+  (-> (web-router
+        [["/ping"        {:get (fn [req] (web-json {:pong true}))}]
+         ["/certs/:id"   {:get (fn [req] (web-json {:id (get (get req :path-params) :id)}))}]])
+      web-wrap-json-body     ; decodes a JSON body under :json
+      web-wrap-log           ; one structured JSON log line per request
+      web-wrap-recover))     ; errors become 500 instead of dropping the connection
 
-(web/serve {:port 8443
+(web-serve {:port 8443
             :handler app
             :tls {:cert "server.crt" :key "server.key"}})
 ```
 
-`web/serve` blocks until interrupted (Ctrl-C / SIGTERM) and shuts down
+`web-serve` blocks until interrupted (Ctrl-C / SIGTERM) and shuts down
 gracefully. Omit `:tls` for plain HTTP during development.
 
 Test it:
@@ -47,14 +47,14 @@ curl -sk https://localhost:8443/certs/42     # {"id":"42"}
 | `:scheme` | `:http` or `:https` |
 | `:remote-addr` | client address |
 | `:mtls` | client-certificate identity, when mTLS verified it (below) |
-| `:json` | decoded JSON body, added by `web/wrap-json-body` |
+| `:json` | decoded JSON body, added by `web-wrap-json-body` |
 | `:identity` | added by an auth middleware |
 
 ## The response map
 
 `{:status 200 :headers {"content-type" "…"} :body "…"}`. Build it with
-the helpers: `web/response`, `web/text`, `web/json`, `web/not-found`,
-`web/bad-request`, `web/unauthorized`, `web/redirect`. `web/json`
+the helpers: `web-response`, `web-text`, `web-json`, `web-not-found`,
+`web-bad-request`, `web-unauthorized`, `web-redirect`. `web-json`
 encodes with clean keys (`:id` → `"id"`), unlike core `json-encode`.
 
 ## TLS and mTLS
@@ -70,7 +70,7 @@ encodes with clean keys (`:id` → `"id"`), unlike core `json-encode`.
 `:verify-if-given`, `:require-and-verify` (the default once a
 `:client-ca` is given). When a client certificate is verified, the
 request carries `:mtls {:subject-cn … :subject … :issuer-cn … :serial
-"0x…" :sans-dns […] :verified true}`; `web/wrap-identity` promotes it to
+"0x…" :sans-dns […] :verified true}`; `web-wrap-identity` promotes it to
 `:identity {:kind :mtls :subject …}`.
 
 ## JWT (Keycloak)
@@ -78,30 +78,30 @@ request carries `:mtls {:subject-cn … :subject … :issuer-cn … :serial
 ```clojure
 (def secured
   (-> protected-app
-      (web/wrap-jwt {:jwks-uri "https://kc.example/realms/app/protocol/openid-connect/certs"
+      (web-wrap-jwt {:jwks-uri "https://kc.example/realms/app/protocol/openid-connect/certs"
                      :issuer   "https://kc.example/realms/app"
                      :audience "my-api"})))
 ```
 
-`web/wrap-jwt` reads the `Authorization: Bearer …` header, verifies the
+`web-wrap-jwt` reads the `Authorization: Bearer …` header, verifies the
 token against the JWKS (RS256/384/512 and ES256/384/512 — what Keycloak
 issues), checks issuer/audience/expiry, and sets `:identity {:kind :jwt
 :claims … :subject …}`; a missing or invalid token gets a 401. The JWKS
-is fetched and cached (auto-refreshing). `web/verify-jwt` is the
+is fetched and cached (auto-refreshing). `web-verify-jwt` is the
 underlying primitive if you need the claims directly.
 
 ## Middleware
 
 Middleware is `handler → handler`; compose with `->`. Built-in:
-`web/wrap-recover`, `web/wrap-log`, `web/wrap-json-body`,
-`web/wrap-identity`, `web/wrap-jwt`. Write your own the same way:
+`web-wrap-recover`, `web-wrap-log`, `web-wrap-json-body`,
+`web-wrap-identity`, `web-wrap-jwt`. Write your own the same way:
 
 ```clojure
 (defn wrap-require-role [role handler]
   (fn [req]
     (if (contains? (get-in req [:identity :claims :realm_access :roles]) role)
       (handler req)
-      (web/unauthorized "forbidden"))))
+      (web-unauthorized "forbidden"))))
 ```
 
 ## Not yet

--- a/lib/web/header-web.lisp
+++ b/lib/web/header-web.lisp
@@ -5,56 +5,56 @@
 ;; middleware is (fn [handler] (fn [req] resp)). Compose middleware with
 ;; -> , e.g. (-> app http/wrap-json-body http/wrap-log http/wrap-recover).
 (do
-    (defn web/response
+    (defn web-response
         "Builds a response map with the given status and body, plus optional header pairs."
         [status body & headers]
         {:status status
          :headers (apply hash-map headers)
          :body body})
 
-    (defn web/text
+    (defn web-text
         "A text/plain response (status 200 unless given)."
         [body & status]
-        (web/response (if (empty? status) 200 (first status)) body "content-type" "text/plain; charset=utf-8"))
+        (web-response (if (empty? status) 200 (first status)) body "content-type" "text/plain; charset=utf-8"))
 
-    (defn web/json
-        "A JSON response: encodes body and sets content-type. (web/json data) is 200; (web/json status data) sets the status."
+    (defn web-json
+        "A JSON response: encodes body and sets content-type. (web-json data) is 200; (web-json status data) sets the status."
         [status-or-body & maybe-body]
         (let [status (if (empty? maybe-body) 200 status-or-body)
               body   (if (empty? maybe-body) status-or-body (first maybe-body))]
-            (web/response status (web/encode-json body) "content-type" "application/json")))
+            (web-response status (web-encode-json body) "content-type" "application/json")))
 
-    (defn web/not-found
+    (defn web-not-found
         "A 404 JSON response."
         [& msg]
-        (web/json 404 {:error (if (empty? msg) "not found" (first msg))}))
+        (web-json 404 {:error (if (empty? msg) "not found" (first msg))}))
 
-    (defn web/bad-request
+    (defn web-bad-request
         "A 400 JSON response."
         [& msg]
-        (web/json 400 {:error (if (empty? msg) "bad request" (first msg))}))
+        (web-json 400 {:error (if (empty? msg) "bad request" (first msg))}))
 
-    (defn web/unauthorized
+    (defn web-unauthorized
         "A 401 JSON response."
         [& msg]
-        (web/json 401 {:error (if (empty? msg) "unauthorized" (first msg))}))
+        (web-json 401 {:error (if (empty? msg) "unauthorized" (first msg))}))
 
-    (defn web/redirect
+    (defn web-redirect
         "A redirect response (status 302 unless given as the second arg)."
         [location & status]
-        (web/response (if (empty? status) 302 (first status)) "" "location" location))
+        (web-response (if (empty? status) 302 (first status)) "" "location" location))
 
     ;; --- middleware ---
 
-    (defn web/wrap-recover
+    (defn web-wrap-recover
         "Middleware: turns any error escaping the handler into a 500 JSON response instead of dropping the connection."
         [handler]
         (fn [req]
             (try
                 (handler req)
-                (catch e (web/json 500 {:error (str e)})))))
+                (catch e (web-json 500 {:error (str e)})))))
 
-    (defn web/wrap-json-body
+    (defn web-wrap-json-body
         "Middleware: when the request body is a non-empty JSON object, decodes it under :json (nil on parse error)."
         [handler]
         (fn [req]
@@ -63,20 +63,20 @@
                     (handler (assoc req :json (try (json-decode {} body) (catch e nil))))
                     (handler req)))))
 
-    (defn web/wrap-log
+    (defn web-wrap-log
         "Middleware: logs one structured JSON line per request with method, uri, status and elapsed ms."
         [handler]
         (fn [req]
             (let [start (time-ms)
                   resp  (handler req)]
-                (web/log :info "http request"
+                (web-log :info "http request"
                     "method" (get req :method)
                     "uri" (get req :uri)
                     "status" (get resp :status)
                     "ms" (- (time-ms) start))
                 resp)))
 
-    (defn web/wrap-identity
+    (defn web-wrap-identity
         "Middleware: promotes a verified mTLS client certificate to :identity {:kind :mtls :subject cn}."
         [handler]
         (fn [req]
@@ -85,7 +85,7 @@
                     (handler (assoc req :identity {:kind :mtls :subject (get mtls :subject-cn) :mtls mtls}))
                     (handler req)))))
 
-    (defn web/-bearer-token
+    (defn web--bearer-token
         "Extracts the bearer token from a request's Authorization header, or nil."
         [req]
         (let [auth (get (get req :headers) "authorization")]
@@ -93,15 +93,15 @@
                 (subs auth 7)
                 nil)))
 
-    (defn web/wrap-jwt
-        "Middleware: verifies a Bearer JWT against config (see web/verify-jwt) and sets :identity {:kind :jwt :claims …}; responds 401 when missing or invalid. config is the JWKS/issuer map."
+    (defn web-wrap-jwt
+        "Middleware: verifies a Bearer JWT against config (see web-verify-jwt) and sets :identity {:kind :jwt :claims …}; responds 401 when missing or invalid. config is the JWKS/issuer map."
         [config handler]
         (fn [req]
-            (let [token (web/-bearer-token req)]
+            (let [token (web--bearer-token req)]
                 (if (nil? token)
-                    (web/unauthorized "missing bearer token")
-                    (let [claims (try (web/verify-jwt token config) (catch e :invalid))]
+                    (web-unauthorized "missing bearer token")
+                    (let [claims (try (web-verify-jwt token config) (catch e :invalid))]
                         (if (= claims :invalid)
-                            (web/unauthorized "invalid token")
+                            (web-unauthorized "invalid token")
                             (handler (assoc req :identity {:kind :jwt :claims claims :subject (get claims :sub)}))))))))
 )

--- a/lib/web/nsweb/nsweb.go
+++ b/lib/web/nsweb/nsweb.go
@@ -1,6 +1,6 @@
 // Package nsweb loads the web (Ring-style HTTP server) namespace into a
-// jig/lisp environment: the Go builtins (web/serve, web/router,
-// web/verify-jwt, web/log) plus the response helpers and middleware
+// jig/lisp environment: the Go builtins (web-serve, web-router,
+// web-verify-jwt, web-log) plus the response helpers and middleware
 // defined in header-web.lisp.
 package nsweb
 

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -270,11 +270,11 @@ func tlsConfig(config MalType) (*tls.Config, error) {
 	certFile := hgetStr(tlsMap, "cert", "")
 	keyFile := hgetStr(tlsMap, "key", "")
 	if certFile == "" || keyFile == "" {
-		return nil, errors.New("web/serve: :tls requires :cert and :key")
+		return nil, errors.New("web-serve: :tls requires :cert and :key")
 	}
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return nil, fmt.Errorf("web/serve: loading server certificate: %w", err)
+		return nil, fmt.Errorf("web-serve: loading server certificate: %w", err)
 	}
 	cfg := &tls.Config{
 		Certificates: []tls.Certificate{cert},
@@ -283,11 +283,11 @@ func tlsConfig(config MalType) (*tls.Config, error) {
 	if caFile := hgetStr(tlsMap, "client-ca", ""); caFile != "" {
 		pem, err := os.ReadFile(caFile)
 		if err != nil {
-			return nil, fmt.Errorf("web/serve: reading client CA: %w", err)
+			return nil, fmt.Errorf("web-serve: reading client CA: %w", err)
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(pem) {
-			return nil, errors.New("web/serve: no certificates found in :client-ca")
+			return nil, errors.New("web-serve: no certificates found in :client-ca")
 		}
 		cfg.ClientCAs = pool
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert // default when a CA is given
@@ -296,7 +296,7 @@ func tlsConfig(config MalType) (*tls.Config, error) {
 		name := strings.TrimPrefix(toStr(v), "ʞ")
 		at, ok := clientAuthTypes[name]
 		if !ok {
-			return nil, fmt.Errorf("web/serve: unknown :client-auth %q", name)
+			return nil, fmt.Errorf("web-serve: unknown :client-auth %q", name)
 		}
 		cfg.ClientAuth = at
 	}
@@ -335,7 +335,7 @@ func ringHandler(handler MalType) http.Handler {
 func webServe(ctx context.Context, config MalType) (MalType, error) {
 	handler, ok := hget(config, "handler")
 	if !ok {
-		return nil, errors.New("web/serve: config needs a :handler function")
+		return nil, errors.New("web-serve: config needs a :handler function")
 	}
 	addr := hgetStr(config, "addr", "")
 	if addr == "" {
@@ -386,21 +386,21 @@ type route struct {
 func compileRoutes(routes MalType) ([]route, error) {
 	slc, err := GetSlice(routes)
 	if err != nil {
-		return nil, errors.New("web/router: routes must be a vector of [path methods] pairs")
+		return nil, errors.New("web-router: routes must be a vector of [path methods] pairs")
 	}
 	out := make([]route, 0, len(slc))
 	for _, entry := range slc {
 		pair, err := GetSlice(entry)
 		if err != nil || len(pair) != 2 {
-			return nil, errors.New("web/router: each route must be a [path {:method handler}] pair")
+			return nil, errors.New("web-router: each route must be a [path {:method handler}] pair")
 		}
 		path, ok := pair[0].(string)
 		if !ok {
-			return nil, errors.New("web/router: route path must be a string")
+			return nil, errors.New("web-router: route path must be a string")
 		}
 		mm, ok := pair[1].(HashMap)
 		if !ok {
-			return nil, errors.New("web/router: route methods must be a hash-map")
+			return nil, errors.New("web-router: route methods must be a hash-map")
 		}
 		methods := make(map[string]MalType, len(mm.Val))
 		for k, v := range mm.Val {
@@ -588,7 +588,7 @@ func logValue(v MalType) any {
 }
 
 // webLog logs msg at level with alternating key/value attributes:
-// (web/log :info "message" "key" value …).
+// (web-log :info "message" "key" value …).
 func webLog(level, msg string, kv ...MalType) (MalType, error) {
 	attrs := make([]any, 0, len(kv))
 	for i, v := range kv {
@@ -614,19 +614,19 @@ func webLog(level, msg string, kv ...MalType) (MalType, error) {
 // Load registers the web builtins. The Ring response helpers and
 // middleware are added by the header (see nsweb.Load).
 func Load(env EnvType) {
-	call.CallOverrideFN(env, "web/serve", webServe)
-	call.CallOverrideFN(env, "web/log", webLog)
-	call.Doc(env, "web/log", "[level msg & kv]",
+	call.CallOverrideFN(env, "web-serve", webServe)
+	call.CallOverrideFN(env, "web-log", webLog)
+	call.Doc(env, "web-log", "[level msg & kv]",
 		"Emits a structured JSON log line to stderr at level (:debug/:info/:warn/:error) with alternating key/value attributes.")
-	call.CallOverrideFN(env, "web/encode-json", webEncodeJSON)
-	call.Doc(env, "web/encode-json", "[value]",
+	call.CallOverrideFN(env, "web-encode-json", webEncodeJSON)
+	call.Doc(env, "web-encode-json", "[value]",
 		"Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → \"id\"), unlike core json-encode.")
-	call.Doc(env, "web/serve", "[config]",
+	call.Doc(env, "web-serve", "[config]",
 		"Starts an HTTP(S) server and blocks until interrupted. config is a hash-map: :handler (a Ring handler fn), :port or :addr, and optional :tls {:cert :key :client-ca :client-auth} for HTTPS/mTLS.")
-	call.CallOverrideFN(env, "web/router", webRouter)
-	call.Doc(env, "web/router", "[routes]",
+	call.CallOverrideFN(env, "web-router", webRouter)
+	call.Doc(env, "web-router", "[routes]",
 		"Returns a Ring handler that dispatches on method and path. routes is a vector of [\"/path/:param\" {:get handler :post handler}] pairs; matched params appear under the request's :path-params.")
-	call.CallOverrideFN(env, "web/verify-jwt", webVerifyJWT)
-	call.Doc(env, "web/verify-jwt", "[token config]",
+	call.CallOverrideFN(env, "web-verify-jwt", webVerifyJWT)
+	call.Doc(env, "web-verify-jwt", "[token config]",
 		"Verifies a JWT against a JWKS and returns its claims as a hash-map. config: :jwks-uri (required), :issuer, :audience, :algorithms (defaults to Keycloak's RS/ES set).")
 }

--- a/lib/web/web_test.go
+++ b/lib/web/web_test.go
@@ -67,12 +67,12 @@ func TestServeHTTPRoundTrip(t *testing.T) {
 	ns := newEnv(t)
 	// A router with a param route, wrapped in the JSON/log/recover stack.
 	h := handlerFrom(t, ns, `
-	  (-> (web/router
-	        [["/hello/:name" {:get (fn [req] (web/json {:hi (get (get req :path-params) :name)
+	  (-> (web-router
+	        [["/hello/:name" {:get (fn [req] (web-json {:hi (get (get req :path-params) :name)
 	                                                    :q  (get (get req :query) "n")}))}]
 	         ["/boom" {:get (fn [req] (throw "kaboom"))}]])
-	      web/wrap-json-body
-	      web/wrap-recover)`)
+	      web-wrap-json-body
+	      web-wrap-recover)`)
 
 	srv := httptest.NewServer(web.RingHandler(h))
 	defer srv.Close()
@@ -107,9 +107,9 @@ func TestServeHTTPRoundTrip(t *testing.T) {
 func TestServeMTLS(t *testing.T) {
 	ns := newEnv(t)
 	h := handlerFrom(t, ns, `
-	  (-> (fn [req] (web/json {:subject (get (get req :identity) :subject)
+	  (-> (fn [req] (web-json {:subject (get (get req :identity) :subject)
 	                           :kind    (get (get req :identity) :kind)}))
-	      web/wrap-identity)`)
+	      web-wrap-identity)`)
 
 	caCert, caKey := makeCA(t)
 	srv := httptest.NewUnstartedServer(web.RingHandler(h))


### PR DESCRIPTION
Stacked on #102 (retargets to `develop` automatically when it merges).

`web/serve`-style names faked a namespace mechanism the language doesn't have — for builtins the `/` is just another symbol character, while real namespacing is `require`'s job (whose module paths do use `/`). This renames all `web/*` and `git/*` builtins, lisp-header helpers and macros to the hyphenated style of the rest of the standard library (`sql-open`, `future-call`):

- `web/serve` → `web-serve`, `web/router` → `web-router`, `web/wrap-*` → `web-wrap-*`, etc.
- `git/commit` → `git-commit`, `git/with-repo` → `git-with-repo`, `git/verified?` → `git-verified?`, etc.

Docs (`LANGUAGE.md`, READMEs, CHANGELOG) updated; full suite, race tests and a REPL smoke test on this repo pass. Both libraries are unreleased, so no published API breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)