### PR TITLE
refactor(cli): rename builtins from ns/fn style to hyphenated names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,7 +234,7 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
 - `require` with `:as` / `:refer` / `:refer :all`, a module search path
   and `LISPPATH`
 - `cli` library — command-line option parsing modelled on
-  clojure/tools.cli (`cli/parse-opts`), plus the `subs`, `starts-with?`
+  clojure/tools.cli (`cli-parse-opts`), plus the `subs`, `starts-with?`
   and `ends-with?` string builtins it builds on
 - `integrity` library — attest and verify lisp source: `fmt` (canonical
   formatting, as `lisp --fmt`), `sha2-256`, and deterministic Ed25519

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -433,8 +433,13 @@ Command-line option parsing (clojure/tools.cli style).
 
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
-| `cli/parse-opts` | `[args specs]` | Parses args (typically *ARGV*) against a vector of option specs. Returns a map:   :options   parsed values keyed by :id   :arguments leftover positional arguments   :summary   generated help text   :errors    a vector of messages, or nil when all is well |
-| `cli/summarize` | `[specs]` | Builds a help string from a vector of option specs, one line per option. |
+| `cli--coerce` | `[spec raw]` | — |
+| `cli--compile-spec` | `[spec]` | — |
+| `cli--defaults` | `[compiled]` | — |
+| `cli--find-spec` | `[compiled tok]` | — |
+| `cli--option-token?` | `[tok]` | — |
+| `cli-parse-opts` | `[args specs]` | Parses args (typically *ARGV*) against a vector of option specs. Returns a map:   :options   parsed values keyed by :id   :arguments leftover positional arguments   :summary   generated help text   :errors    a vector of messages, or nil when all is well |
+| `cli-summarize` | `[specs]` | Builds a help string from a vector of option specs, one line per option. |
 
 ### integrity
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Changes respect to [kanaka/mal](https://github.com/kanaka/mal):
 - `subs`, `starts-with?` and `ends-with?` string functions (Clojure-style; `subs` counts in Unicode code points)
 - `spit`, the write counterpart of `slurp` (Clojure-style): `(spit filename s)` creates or truncates, `(spit filename s :append true)` appends
 - `*FILE*` holds the absolute path of the script being executed (cf. Clojure's `*file*`), so a script can read its own source; unset in the REPL and `-e`
-- `cli` library for command-line option parsing, modelled on [clojure/tools.cli](https://github.com/clojure/tools.cli) — `(cli/parse-opts *ARGV* specs)`. See [./lib/cli/README.md](./lib/cli/README.md)
+- `cli` library for command-line option parsing, modelled on [clojure/tools.cli](https://github.com/clojure/tools.cli) — `(cli-parse-opts *ARGV* specs)`. See [./lib/cli/README.md](./lib/cli/README.md)
 - `integrity` library to attest and verify lisp source: `fmt` (canonical formatting, as `lisp --fmt`), `sha2-256`, and deterministic Ed25519 signatures (`ed25519-generate`, `ed25519-sign`, `ed25519-verify`). See [./lib/integrity/README.md](./lib/integrity/README.md)
 
 ## Embed jig/lisp in Go code

--- a/lib/cli/README.md
+++ b/lib/cli/README.md
@@ -8,7 +8,7 @@ string, and any errors.
 
 ## Loading
 
-`cmd/lisp` loads it by default, so scripts can use `cli/parse-opts`
+`cmd/lisp` loads it by default, so scripts can use `cli-parse-opts`
 directly. To embed it:
 
 ```go
@@ -38,7 +38,7 @@ So the minimal load sequence is `nscore.Load`, `nsconcurrent.Load`
    ["-v" "--verbose" "Verbose output"]
    ["-h" "--help"    "Show help"]])
 
-(def parsed (cli/parse-opts *ARGV* specs))
+(def parsed (cli-parse-opts *ARGV* specs))
 
 (get parsed :options)    ; => {:port 8080 :verbose true}
 (get parsed :arguments)  ; => ["file.txt"]   (positionals)

--- a/lib/cli/cli.go
+++ b/lib/cli/cli.go
@@ -1,7 +1,7 @@
 // Package cli provides command-line option parsing for jig/lisp,
 // modelled on clojure/tools.cli. It is pure Lisp: the namespace is a
 // header evaluated into the environment (see nscli.Load), exposing
-// cli/parse-opts and cli/summarize.
+// cli-parse-opts and cli-summarize.
 package cli
 
 import _ "embed"

--- a/lib/cli/cli_test.go
+++ b/lib/cli/cli_test.go
@@ -56,20 +56,20 @@ func TestParseOpts(t *testing.T) {
 
 	cases := []struct{ name, src, want string }{
 		// Map fields are read with get to avoid map key-order flakiness.
-		{"long-with-arg", `(get (get (cli/parse-opts ["--port" "8080"] specs) :options) :port)`, "8080"},
-		{"default-applied", `(get (get (cli/parse-opts [] specs) :options) :port)`, "80"},
-		{"short-boolean-flag", `(get (get (cli/parse-opts ["-v"] specs) :options) :verbose)`, "true"},
-		{"positional-args", `(get (cli/parse-opts ["-v" "a" "b"] specs) :arguments)`, `["a" "b"]`},
-		{"double-dash-separator", `(get (cli/parse-opts ["--" "--port" "x"] specs) :arguments)`, `["--port" "x"]`},
-		{"no-errors-when-ok", `(get (cli/parse-opts ["--port" "80"] specs) :errors)`, "nil"},
-		{"unknown-option", `(get (cli/parse-opts ["--nope"] specs) :errors)`, `["Unknown option: --nope"]`},
-		{"validate-failure", `(get (cli/parse-opts ["--port" "99999"] specs) :errors)`, `["--port: must be 0..65535"]`},
-		{"missing-argument", `(get (cli/parse-opts ["--port"] specs) :errors)`, `["Missing argument for --port"]`},
+		{"long-with-arg", `(get (get (cli-parse-opts ["--port" "8080"] specs) :options) :port)`, "8080"},
+		{"default-applied", `(get (get (cli-parse-opts [] specs) :options) :port)`, "80"},
+		{"short-boolean-flag", `(get (get (cli-parse-opts ["-v"] specs) :options) :verbose)`, "true"},
+		{"positional-args", `(get (cli-parse-opts ["-v" "a" "b"] specs) :arguments)`, `["a" "b"]`},
+		{"double-dash-separator", `(get (cli-parse-opts ["--" "--port" "x"] specs) :arguments)`, `["--port" "x"]`},
+		{"no-errors-when-ok", `(get (cli-parse-opts ["--port" "80"] specs) :errors)`, "nil"},
+		{"unknown-option", `(get (cli-parse-opts ["--nope"] specs) :errors)`, `["Unknown option: --nope"]`},
+		{"validate-failure", `(get (cli-parse-opts ["--port" "99999"] specs) :errors)`, `["--port: must be 0..65535"]`},
+		{"missing-argument", `(get (cli-parse-opts ["--port"] specs) :errors)`, `["Missing argument for --port"]`},
 		// *ARGV* is a List, not a Vector: parse-opts must accept both.
-		{"accepts-a-list", `(get (get (cli/parse-opts (list "--port" "22") specs) :options) :port)`, "22"},
+		{"accepts-a-list", `(get (get (cli-parse-opts (list "--port" "22") specs) :options) :port)`, "22"},
 		// A failed validation must not leave a bad value in :options
 		// (the default stays).
-		{"invalid-keeps-default", `(get (get (cli/parse-opts ["--port" "0"] specs) :options) :port)`, "80"},
+		{"invalid-keeps-default", `(get (get (cli-parse-opts ["--port" "0"] specs) :options) :port)`, "80"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -82,7 +82,7 @@ func TestParseOpts(t *testing.T) {
 
 func TestSummarize(t *testing.T) {
 	ns := newEnv(t)
-	got := run(t, ns, `(cli/summarize [["-v" "--verbose" "Be loud"]])`)
+	got := run(t, ns, `(cli-summarize [["-v" "--verbose" "Be loud"]])`)
 	want := `"  -v --verbose  Be loud\n"`
 	if got != want {
 		t.Fatalf("summarize = %q, want %q", got, want)

--- a/lib/cli/header-cli.lisp
+++ b/lib/cli/header-cli.lisp
@@ -1,7 +1,7 @@
 ;; cli — command-line option parsing for jig/lisp, modelled on
 ;; clojure/tools.cli (a pragmatic subset). Pure Lisp.
 ;;
-;; (cli/parse-opts args specs) parses a sequence of argument strings
+;; (cli-parse-opts args specs) parses a sequence of argument strings
 ;; (typically *ARGV*) against a vector of option specs and returns a map
 ;;   {:options   {…}      ; parsed option values, keyed by :id
 ;;    :arguments [...]     ; leftover positional arguments
@@ -24,7 +24,7 @@
 ;; (no "--opt=val"), no short grouping ("-abc"), no :update-fn/:multi,
 ;; no in-order/sub-command parsing.
 (do
-  (defn cli/-compile-spec [spec]
+  (defn cli--compile-spec [spec]
     (let [short (nth spec 0)
           long  (nth spec 1)
           desc  (nth spec 2)
@@ -44,13 +44,13 @@
         :parse-fn    (get kvs :parse-fn)
         :validate    (get kvs :validate))))
 
-  (defn cli/-find-spec [compiled tok]
+  (defn cli--find-spec [compiled tok]
     (first (filter
              (fn [s] (or (= (get s :long) tok) (= (get s :short) tok)))
              compiled)))
 
   ;; Apply parse-fn then validate. Returns [ok? value-or-message].
-  (defn cli/-coerce [spec raw]
+  (defn cli--coerce [spec raw]
     (let [pf  (get spec :parse-fn)
           val (if pf (pf raw) raw)
           v   (get spec :validate)]
@@ -60,16 +60,16 @@
           [false (str (get spec :long) ": " (nth v 1))])
         [true val])))
 
-  (defn cli/-defaults [compiled]
+  (defn cli--defaults [compiled]
     (reduce
       (fn [m s] (if (get s :has-default) (assoc m (get s :id) (get s :default)) m))
       {}
       compiled))
 
-  (defn cli/-option-token? [tok]
+  (defn cli--option-token? [tok]
     (and (starts-with? tok "-") (not (= tok "-")) (not (= tok "--"))))
 
-  (defn cli/summarize
+  (defn cli-summarize
     "Builds a help string from a vector of option specs, one line per option."
     [specs]
     (reduce
@@ -80,9 +80,9 @@
              (if (get s :arg-name) (str " " (get s :arg-name)) "")
              "  " (get s :desc) "\n"))
       ""
-      (map cli/-compile-spec specs)))
+      (map cli--compile-spec specs)))
 
-  (defn cli/parse-opts
+  (defn cli-parse-opts
     ¬Parses args (typically *ARGV*) against a vector of option specs.
 Returns a map:
   :options   parsed values keyed by :id
@@ -90,9 +90,9 @@ Returns a map:
   :summary   generated help text
   :errors    a vector of messages, or nil when all is well¬
     [args specs]
-    (let [compiled (map cli/-compile-spec specs)]
+    (let [compiled (map cli--compile-spec specs)]
       (loop [toks    args
-             opts    (cli/-defaults compiled)
+             opts    (cli--defaults compiled)
              posargs []
              errs    []
              no-opts false]
@@ -100,7 +100,7 @@ Returns a map:
           (hash-map
             :options   opts
             :arguments posargs
-            :summary   (cli/summarize specs)
+            :summary   (cli-summarize specs)
             :errors    (if (empty? errs) nil errs))
           (let [tok  (first toks)
                 more (rest toks)]
@@ -109,15 +109,15 @@ Returns a map:
                 (recur more opts (conj posargs tok) errs true)
               (= tok "--")
                 (recur more opts posargs errs true)
-              (cli/-option-token? tok)
-                (let [spec (cli/-find-spec compiled tok)]
+              (cli--option-token? tok)
+                (let [spec (cli--find-spec compiled tok)]
                   (cond
                     (nil? spec)
                       (recur more opts posargs (conj errs (str "Unknown option: " tok)) no-opts)
                     (get spec :takes-arg)
                       (if (empty? more)
                         (recur more opts posargs (conj errs (str "Missing argument for " tok)) no-opts)
-                        (let [res (cli/-coerce spec (first more))]
+                        (let [res (cli--coerce spec (first more))]
                           (if (nth res 0)
                             (recur (rest more) (assoc opts (get spec :id) (nth res 1)) posargs errs no-opts)
                             (recur (rest more) opts posargs (conj errs (nth res 1)) no-opts))))


### PR DESCRIPTION
Completes the naming cleanup started in #104: `cli/parse-opts` → `cli-parse-opts`, `cli/summarize` → `cli-summarize`, private helpers `cli/-*` → `cli--*`. Docs and CHANGELOG updated, `LANGUAGE.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)