### PR TITLE
feat(core): print builtin and Go-verb format in coreextended

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -239,6 +239,7 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `or ⁽ᵐ⁾` | `[& xs]` | Evaluates its arguments in order, returning the first truthy one, or nil. |
 | `panic` | `[value]` | Raises value as a Go panic. |
 | `pr-str` | `[& args]` | Like str but with readable (quoted) representations. |
+| `print` | `[& args]` | Prints its arguments (unquoted) separated by spaces, without a trailing newline. |
 | `println` | `[& args]` | Prints its arguments (unquoted) separated by spaces, then a newline. |
 | `prn` | `[& args]` | Prints its arguments (readable) separated by spaces, then a newline. |
 | `range` | `[start end]` | Vector of integers from start to end-1. |
@@ -343,6 +344,7 @@ Higher-order helpers written in lisp (the prelude): reduce, map, partial, protoc
 | `filter` | `[pred xs]` | List of the items in xs for which (pred x) is truthy. |
 | `find-type` | `[obj]` | Returns a keyword naming obj's type (overridable via :type metadata). |
 | `foldr` | `[f init xs]` | Right fold: (f x1 (f x2 (.. (f xn init)))) over the elements of xs. |
+| `format` | `[fmt & args]` | Formats args into fmt using Go verbs (%s %d %f %v %q %x ...); collections and keywords render in their lisp form. Returns the string. |
 | `identity` | `[x]` | Returns its argument unchanged. |
 | `into` | `[to from]` | Pours every item of from into to using conj; the result keeps to's type. |
 | `max` | `[a & more]` | Largest of one or more numbers. |

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -120,6 +120,7 @@ func Load(env EnvType) {
 	call.Call(env, str)
 	call.Call(env, prn)
 	call.Call(env, println)
+	call.CallOverrideFN(env, "print", printNoNewline)
 	call.CallOverrideFN(env, "list", func(a ...MalType) (List, error) { return List{Val: a}, nil })
 	call.CallOverrideFN(env, "vector", func(a ...MalType) (Vector, error) { return Vector{Val: a}, nil })
 	call.Call(env, hash_map)
@@ -485,6 +486,13 @@ func prn(a ...MalType) (MalType, error) {
 
 func println(a ...MalType) (MalType, error) {
 	fmt.Println(printer.Pr_list(a, false, "", "", " "))
+	return nil, nil
+}
+
+// printNoNewline is println without the trailing newline, for composing a
+// line from several prints (e.g. styled fragments).
+func printNoNewline(a ...MalType) (MalType, error) {
+	fmt.Print(printer.Pr_list(a, false, "", "", " "))
 	return nil, nil
 }
 

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -91,6 +91,7 @@ var coreDocs = []struct{ name, arglist, doc string }{
 	{"symbol", "[name]", "Creates a symbol from a string."},
 
 	// I/O
+	{"print", "[& args]", "Prints its arguments (unquoted) separated by spaces, without a trailing newline."},
 	{"println", "[& args]", "Prints its arguments (unquoted) separated by spaces, then a newline."},
 	{"prn", "[& args]", "Prints its arguments (readable) separated by spaces, then a newline."},
 	{"sleep", "[ms]", "Sleeps for ms milliseconds."},

--- a/lib/coreextended/coreextended.go
+++ b/lib/coreextended/coreextended.go
@@ -1,8 +1,64 @@
+// Package coreextended provides the extended standard library: a large
+// pure-lisp part (header-coreextended.lisp) and a few Go builtins that
+// need the Go runtime, like format.
 package coreextended
 
-import _ "embed"
+import (
+	"fmt"
+
+	_ "embed"
+
+	"github.com/jig/lisp/lib/call"
+	"github.com/jig/lisp/printer"
+	. "github.com/jig/lisp/types"
+)
 
 //go:embed header-coreextended.lisp
 var headerCoreExtended string
 
 func HeaderCoreExtended() string { return headerCoreExtended }
+
+// Load registers the Go-implemented builtins of the namespace; the lisp
+// part is evaluated separately by nscoreextended.
+func Load(env EnvType) {
+	call.CallOverrideFN(env, "format", format, 1)
+
+	call.Doc(env, "format", "[fmt & args]",
+		"Formats args into fmt using Go verbs (%s %d %f %v %q %x ...); collections and keywords render in their lisp form. Returns the string.")
+}
+
+// lispArg defers an argument's rendering to the lisp printer, so %s and
+// %v on collections and keywords show lisp forms instead of Go internals.
+type lispArg struct{ v MalType }
+
+func (l lispArg) String() string { return printer.Pr_str(l.v, false) }
+
+// formatArg adapts a lisp value for Go's fmt: primitives pass through so
+// numeric and boolean verbs keep working, values with their own fmt
+// support (e.g. big numbers) pass through too, and everything else is
+// rendered by the lisp printer.
+func formatArg(v MalType) any {
+	switch t := v.(type) {
+	case nil, int, float32, float64, bool:
+		// float32 is the reader's float type; float64 arrives from Go libs
+		return t
+	case string:
+		if Keyword_Q(t) {
+			return lispArg{t}
+		}
+		return t
+	default:
+		if _, ok := t.(fmt.Formatter); ok {
+			return t
+		}
+		return lispArg{t}
+	}
+}
+
+func format(f string, args ...MalType) (MalType, error) {
+	conv := make([]any, len(args))
+	for i, a := range args {
+		conv[i] = formatArg(a)
+	}
+	return fmt.Sprintf(f, conv...), nil
+}

--- a/lib/coreextended/coreextended_test.go
+++ b/lib/coreextended/coreextended_test.go
@@ -113,3 +113,29 @@ func TestInto(t *testing.T) {
 		})
 	}
 }
+
+// TestFormat covers the Go-verb format builtin: primitives keep their
+// numeric/boolean verbs, keywords and collections render as lisp forms.
+func TestFormat(t *testing.T) {
+	ns := newEnv(t)
+	cases := []struct{ src, want string }{
+		{`(format "plain")`, `"plain"`},
+		{`(format "%s %d" "a" 42)`, `"a 42"`},
+		{`(format "%05.2f" 3.14159)`, `"03.14"`},
+		{`(format "%q" "quo\"ted")`, `"\"quo\\\"ted\""`},
+		{`(format "%x" 255)`, `"ff"`},
+		{`(format "%v" true)`, `"true"`},
+		{`(format "%v" nil)`, `"<nil>"`},
+		{`(format "%s" :key)`, `":key"`},
+		{`(format "%v" [1 2 3])`, `"[1 2 3]"`},
+		{`(format "%v" (list 1 :a "s"))`, `"(1 :a s)"`},
+		{`(format "%3d|" 7)`, `"  7|"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.src, func(t *testing.T) {
+			if got := run(t, ns, tc.src); got != tc.want {
+				t.Errorf("%s = %s, want %s", tc.src, got, tc.want)
+			}
+		})
+	}
+}

--- a/lib/coreextended/nscoreextended/nscoreextended.go
+++ b/lib/coreextended/nscoreextended/nscoreextended.go
@@ -19,6 +19,8 @@ var (
 )
 
 func Load(env types.EnvType) error {
+	coreextended.Load(env)
+
 	if _, err := lisp.REPL(context.Background(), env, coreextended.HeaderCoreExtended(), types.NewCursorFile(_package_)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Groundwork for formatted terminal output (lib/term follows in a separate PR):

- **`print`** (core): `println` without the trailing newline, so a line can be composed from several styled fragments.
- **`format`** (coreextended, its first Go builtin — the loader now runs `coreextended.Load` before the lisp header): `(format "%s: %03d" name n)` with Go verbs. Argument conversion is lisp-aware: primitives keep numeric/boolean verbs working (the reader's `float32` included), keywords and collections render as lisp forms (`(format "%v" [1 2 3])` → `"[1 2 3]"`), and values with native `fmt` support (big numbers) pass through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)