### PR TITLE
feat(term): plain-ANSI terminal styling library

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -508,6 +508,23 @@ Attest and verify lisp source (formatting, hashing, Ed25519 signatures).
 | `git-verify-tag` | `[repo name allowed-keys]` | Verifies the SSH signature of annotated tag name; same contract as git-verify-commit. |
 | `git-with-repo ⁽ᵐ⁾` | `[binding & body]` | (git-with-repo [r (git-open …)] body…) binds r and guarantees git-close when body finishes or throws. |
 
+### term
+
+| Name | Arguments | Description |
+| ---- | --------- | ----------- |
+| `term-blue` | `[s]` | — |
+| `term-bold` | `[s]` | — |
+| `term-color?` | `[]` | Whether styled output is enabled: stdout is a terminal, NO_COLOR is unset and TERM is not "dumb"; CLICOLOR_FORCE=1 forces it on. |
+| `term-cyan` | `[s]` | — |
+| `term-gray` | `[s]` | — |
+| `term-green` | `[s]` | — |
+| `term-magenta` | `[s]` | — |
+| `term-red` | `[s]` | — |
+| `term-style` | `[s opts]` | Wraps string s in ANSI codes per opts {:fg :bg :bold :dim :italic :underline :blink :reverse :strikethrough}; colors are keywords (:red, :bright-red, ...), 0-255 ints or "#rrggbb". Returns s unchanged when color is off. |
+| `term-underline` | `[s]` | — |
+| `term-width` | `[]` | The terminal width in columns, or 0 when stdout is not a terminal. |
+| `term-yellow` | `[s]` | — |
+
 ### test
 
 | Name | Arguments | Description |

--- a/cmd/lisp/main.go
+++ b/cmd/lisp/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jig/lisp/lib/require/nsrequire"
 	"github.com/jig/lisp/lib/sql/nssql"
 	"github.com/jig/lisp/lib/system/nssystem"
+	"github.com/jig/lisp/lib/term/nsterm"
 	"github.com/jig/lisp/lib/test/nstest"
 	"github.com/jig/lisp/lib/web/nsweb"
 	"github.com/jig/lisp/types"
@@ -48,6 +49,7 @@ func libraries(scriptArgs []string) []library {
 		{"integrity", nsintegrity.Load},
 		{"web", nsweb.Load},
 		{"git", nsgit.Load},
+		{"term", nsterm.Load},
 		{"test", nstest.Load},
 	}
 }

--- a/docgen/libraries.go
+++ b/docgen/libraries.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jig/lisp/lib/require/nsrequire"
 	"github.com/jig/lisp/lib/sql/nssql"
 	"github.com/jig/lisp/lib/system/nssystem"
+	"github.com/jig/lisp/lib/term/nsterm"
 	"github.com/jig/lisp/lib/test/nstest"
 	"github.com/jig/lisp/lib/web/nsweb"
 	"github.com/jig/lisp/types"
@@ -44,6 +45,7 @@ func standardLibraries() []library {
 		{"integrity", nsintegrity.Load},
 		{"web", nsweb.Load},
 		{"git", nsgit.Load},
+		{"term", nsterm.Load},
 		{"test", nstest.Load},
 	}
 }

--- a/lib/term/README.md
+++ b/lib/term/README.md
@@ -1,0 +1,65 @@
+# term
+
+Plain-ANSI terminal styling: colors and text attributes for formatted stdout, with no dependencies and no TUI runtime. Pairs with `print` and `format` for composing styled lines.
+
+## Loading
+
+The namespace is loaded by the `lisp` binary. Embedders load it with:
+
+```go
+import "github.com/jig/lisp/lib/term/nsterm"
+
+nsterm.Load(env)
+```
+
+## Quick example
+
+```clojure
+(println (term-style "error:" {:fg :red :bold true})
+         (format "%s (%d retries)" "connection refused" 3))
+
+(println (term-style "deploy" {:fg "#ff8800" :underline true})
+         (term-green "ok"))
+```
+
+## When color is emitted
+
+`term-style` wraps its input in ANSI codes only when styled output makes sense; otherwise it returns the string unchanged, so styled code degrades to plain text in pipes and logs:
+
+- stdout is a terminal, **and**
+- `NO_COLOR` is unset, **and**
+- `TERM` is not `dumb`.
+
+`CLICOLOR_FORCE=1` forces color on regardless (e.g. when piping into a pager that renders ANSI). `(term-color?)` reports the decision.
+
+## Colors
+
+`:fg` and `:bg` accept three forms:
+
+| Form | Example | ANSI |
+|---|---|---|
+| keyword | `:red`, `:bright-cyan`, `:gray` | 16-color SGR |
+| int 0-255 | `208` | 256-color palette |
+| hex string | `"#ff8800"` | 24-bit truecolor |
+
+Named colors: `:black :red :green :yellow :blue :magenta :cyan :white`, their `:bright-*` variants, and `:gray` (alias of `:bright-black`).
+
+Attributes (booleans): `:bold :dim :italic :underline :blink :reverse :strikethrough`.
+
+Unknown options and invalid colors throw — also when color is off — so typos never pass silently.
+
+## API
+
+| Builtin | Arguments | Returns |
+|---|---|---|
+| `term-style` | `[s opts]` | s wrapped in ANSI codes per opts, or s unchanged when color is off |
+| `term-color?` | `[]` | whether styled output is enabled |
+| `term-width` | `[]` | terminal width in columns, 0 when stdout is not a terminal |
+| `term-red` … `term-cyan`, `term-gray` | `[s]` | color sugar over `term-style` |
+| `term-bold`, `term-underline` | `[s]` | attribute sugar over `term-style` |
+
+## Limitations (v1)
+
+- Styling only: no cursor movement, screen clearing or raw mode — a TUI layer would build on top of this.
+- The color decision is made once per process (cached); changing `NO_COLOR` at runtime has no effect.
+- `term-width` reads the size at call time but does not watch for terminal resizes.

--- a/lib/term/export_test.go
+++ b/lib/term/export_test.go
@@ -1,0 +1,9 @@
+package term
+
+import "sync"
+
+// ResetColorCache re-evaluates the color decision on next use, so tests
+// can flip the environment between cases.
+func ResetColorCache() {
+	colorEnabled = sync.OnceValue(colorDecision)
+}

--- a/lib/term/header-term.lisp
+++ b/lib/term/header-term.lisp
@@ -1,0 +1,13 @@
+;; $MODULE header-term
+
+(do
+  ;; Color and attribute sugar over term-style.
+  (defn term-red [s] (term-style s {:fg :red}))
+  (defn term-green [s] (term-style s {:fg :green}))
+  (defn term-yellow [s] (term-style s {:fg :yellow}))
+  (defn term-blue [s] (term-style s {:fg :blue}))
+  (defn term-magenta [s] (term-style s {:fg :magenta}))
+  (defn term-cyan [s] (term-style s {:fg :cyan}))
+  (defn term-gray [s] (term-style s {:fg :gray}))
+  (defn term-bold [s] (term-style s {:bold true}))
+  (defn term-underline [s] (term-style s {:underline true})))

--- a/lib/term/nsterm/nsterm.go
+++ b/lib/term/nsterm/nsterm.go
@@ -1,0 +1,29 @@
+// Package nsterm loads the term namespace into a jig/lisp environment.
+package nsterm
+
+import (
+	"context"
+	"reflect"
+	"strings"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/lib/term"
+	"github.com/jig/lisp/types"
+)
+
+type Here struct{}
+
+var (
+	__package_fullpath__ = strings.Split(reflect.TypeFor[Here]().PkgPath(), "/")
+	_package_            = "$" + __package_fullpath__[len(__package_fullpath__)-1]
+)
+
+func Load(env types.EnvType) error {
+	term.Load(env)
+
+	if _, err := lisp.REPL(context.Background(), env, term.HeaderTerm(), types.NewCursorFile(_package_)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lib/term/term.go
+++ b/lib/term/term.go
@@ -1,0 +1,189 @@
+// Package term provides plain-ANSI terminal styling for jig/lisp:
+// term-style wraps a string in SGR escape codes chosen from a declarative
+// options map, and helpers report whether color is appropriate and how
+// wide the terminal is. No external dependencies and no TUI runtime —
+// just colors and text attributes for formatted stdout.
+//
+// Color is emitted only when it makes sense: stdout must be a terminal,
+// NO_COLOR must be unset and TERM must not be "dumb". CLICOLOR_FORCE=1
+// forces color on regardless (useful when piping styled output). When
+// color is off, term-style returns its input unchanged, so styled code
+// degrades to plain text in pipes and logs.
+package term
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	_ "embed"
+
+	"golang.org/x/term"
+
+	"github.com/jig/lisp/lib/call"
+	. "github.com/jig/lisp/types"
+)
+
+//go:embed header-term.lisp
+var headerTerm string
+
+// HeaderTerm returns the lisp-defined part of the namespace (the color
+// and attribute sugar), loaded by nsterm.
+func HeaderTerm() string { return headerTerm }
+
+// Load registers the term builtins in env.
+func Load(env EnvType) {
+	call.CallOverrideFN(env, "term-style", termStyle)
+	call.CallOverrideFN(env, "term-color?", termColorQ)
+	call.CallOverrideFN(env, "term-width", termWidth)
+
+	call.Doc(env, "term-style", "[s opts]",
+		"Wraps string s in ANSI codes per opts {:fg :bg :bold :dim :italic :underline :blink :reverse :strikethrough}; colors are keywords (:red, :bright-red, ...), 0-255 ints or \"#rrggbb\". Returns s unchanged when color is off.")
+	call.Doc(env, "term-color?", "[]",
+		"Whether styled output is enabled: stdout is a terminal, NO_COLOR is unset and TERM is not \"dumb\"; CLICOLOR_FORCE=1 forces it on.")
+	call.Doc(env, "term-width", "[]",
+		"The terminal width in columns, or 0 when stdout is not a terminal.")
+}
+
+// colorEnabled decides once whether to emit ANSI codes.
+var colorEnabled = sync.OnceValue(colorDecision)
+
+func colorDecision() bool {
+	if os.Getenv("CLICOLOR_FORCE") == "1" {
+		return true
+	}
+	if _, present := os.LookupEnv("NO_COLOR"); present {
+		return false
+	}
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	return term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// namedColors maps color keywords to their base SGR foreground code;
+// backgrounds add 10.
+var namedColors = map[string]int{
+	"black": 30, "red": 31, "green": 32, "yellow": 33,
+	"blue": 34, "magenta": 35, "cyan": 36, "white": 37,
+	"bright-black": 90, "bright-red": 91, "bright-green": 92, "bright-yellow": 93,
+	"bright-blue": 94, "bright-magenta": 95, "bright-cyan": 96, "bright-white": 97,
+	"gray": 90, // alias of bright-black
+}
+
+// attrs maps boolean style options to their SGR code.
+var attrs = []struct {
+	name string
+	code int
+}{
+	{"bold", 1}, {"dim", 2}, {"italic", 3}, {"underline", 4},
+	{"blink", 5}, {"reverse", 7}, {"strikethrough", 9},
+}
+
+// colorCodes renders a color option (keyword, 0-255 int or "#rrggbb")
+// as SGR codes; base is 38 for foreground, 48 for background.
+func colorCodes(v MalType, base int) ([]string, error) {
+	switch t := v.(type) {
+	case string:
+		if Keyword_Q(t) {
+			name := t[len("ʞ"):]
+			code, ok := namedColors[name]
+			if !ok {
+				return nil, fmt.Errorf("unknown color :%s", name)
+			}
+			if base == 48 {
+				code += 10
+			}
+			return []string{strconv.Itoa(code)}, nil
+		}
+		if len(t) == 7 && t[0] == '#' {
+			r, errR := strconv.ParseUint(t[1:3], 16, 8)
+			g, errG := strconv.ParseUint(t[3:5], 16, 8)
+			b, errB := strconv.ParseUint(t[5:7], 16, 8)
+			if errR == nil && errG == nil && errB == nil {
+				return []string{strconv.Itoa(base), "2",
+					strconv.FormatUint(r, 10), strconv.FormatUint(g, 10), strconv.FormatUint(b, 10)}, nil
+			}
+		}
+		return nil, fmt.Errorf("invalid color %q (use a keyword, 0-255 or \"#rrggbb\")", t)
+	case int:
+		if t < 0 || t > 255 {
+			return nil, fmt.Errorf("color index %d out of range 0-255", t)
+		}
+		return []string{strconv.Itoa(base), "5", strconv.Itoa(t)}, nil
+	default:
+		return nil, fmt.Errorf("invalid color type %T", v)
+	}
+}
+
+func termStyle(s string, opts MalType) (MalType, error) {
+	hm, ok := opts.(HashMap)
+	if !ok {
+		return nil, fmt.Errorf("term-style: options must be a map, got %T", opts)
+	}
+	codes, err := sgrCodes(hm.Val)
+	if err != nil {
+		return nil, err
+	}
+	if len(codes) == 0 || !colorEnabled() {
+		return s, nil
+	}
+	return "\x1b[" + strings.Join(codes, ";") + "m" + s + "\x1b[0m", nil
+}
+
+// sgrCodes translates the options map into an SGR code sequence. Unknown
+// options error, so typos do not silently produce unstyled output.
+func sgrCodes(opts map[string]MalType) ([]string, error) {
+	known := map[string]bool{"fg": true, "bg": true}
+	var codes []string
+	for _, a := range attrs {
+		known[a.name] = true
+		if v, ok := opts[NewKeyword(a.name)]; ok {
+			b, isBool := v.(bool)
+			if !isBool {
+				return nil, fmt.Errorf(":%s must be a boolean, got %T", a.name, v)
+			}
+			if b {
+				codes = append(codes, strconv.Itoa(a.code))
+			}
+		}
+	}
+	if v, ok := opts[NewKeyword("fg")]; ok && v != nil {
+		c, err := colorCodes(v, 38)
+		if err != nil {
+			return nil, err
+		}
+		codes = append(codes, c...)
+	}
+	if v, ok := opts[NewKeyword("bg")]; ok && v != nil {
+		c, err := colorCodes(v, 48)
+		if err != nil {
+			return nil, err
+		}
+		codes = append(codes, c...)
+	}
+	for k := range opts {
+		name := k
+		if Keyword_Q(k) {
+			name = k[len("ʞ"):]
+		}
+		if !known[name] {
+			return nil, fmt.Errorf("term-style: unknown option :%s", name)
+		}
+	}
+	return codes, nil
+}
+
+func termColorQ() (MalType, error) {
+	return colorEnabled(), nil
+}
+
+func termWidth() (MalType, error) {
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil {
+		return 0, nil
+	}
+	return w, nil
+}

--- a/lib/term/term_test.go
+++ b/lib/term/term_test.go
@@ -1,0 +1,127 @@
+package term_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/term"
+	"github.com/jig/lisp/lib/term/nsterm"
+	"github.com/jig/lisp/types"
+)
+
+func newEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	if err := nscore.Load(ns); err != nil {
+		t.Fatal(err)
+	}
+	if err := nsterm.Load(ns); err != nil {
+		t.Fatal(err)
+	}
+	return ns
+}
+
+func eval(t *testing.T, ns types.EnvType, src string) (types.MalType, error) {
+	t.Helper()
+	ast, err := lisp.READ(src, types.NewCursorFile(t.Name()), ns)
+	if err != nil {
+		t.Fatalf("READ %s: %v", src, err)
+	}
+	return lisp.EVAL(context.Background(), ast, ns)
+}
+
+func evalString(t *testing.T, ns types.EnvType, src string) string {
+	t.Helper()
+	v, err := eval(t, ns, src)
+	if err != nil {
+		t.Fatalf("EVAL %s: %v", src, err)
+	}
+	s, ok := v.(string)
+	if !ok {
+		t.Fatalf("EVAL %s: got %T, want string", src, v)
+	}
+	return s
+}
+
+// TestStyleForced covers the ANSI sequences with color forced on.
+func TestStyleForced(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1")
+	term.ResetColorCache()
+	ns := newEnv(t)
+	cases := []struct{ src, want string }{
+		{`(term-style "x" {:fg :red})`, "\x1b[31mx\x1b[0m"},
+		{`(term-style "x" {:fg :bright-red})`, "\x1b[91mx\x1b[0m"},
+		{`(term-style "x" {:bg :blue})`, "\x1b[44mx\x1b[0m"},
+		{`(term-style "x" {:bold true})`, "\x1b[1mx\x1b[0m"},
+		{`(term-style "x" {:bold true :fg :green})`, "\x1b[1;32mx\x1b[0m"},
+		{`(term-style "x" {:underline true :strikethrough true})`, "\x1b[4;9mx\x1b[0m"},
+		{`(term-style "x" {:fg 208})`, "\x1b[38;5;208mx\x1b[0m"},
+		{`(term-style "x" {:bg 17})`, "\x1b[48;5;17mx\x1b[0m"},
+		{`(term-style "x" {:fg "#ff8800"})`, "\x1b[38;2;255;136;0mx\x1b[0m"},
+		{`(term-style "x" {})`, "x"},
+		{`(term-style "x" {:bold false})`, "x"},
+		{`(term-red "x")`, "\x1b[31mx\x1b[0m"},
+		{`(term-bold "x")`, "\x1b[1mx\x1b[0m"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.src, func(t *testing.T) {
+			if got := evalString(t, ns, tc.src); got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.src, got, tc.want)
+			}
+		})
+	}
+
+	if v, err := eval(t, ns, `(term-color?)`); err != nil || v != true {
+		t.Errorf("(term-color?) = %v, %v; want true under CLICOLOR_FORCE", v, err)
+	}
+}
+
+func TestStyleErrors(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1")
+	term.ResetColorCache()
+	ns := newEnv(t)
+	for _, src := range []string{
+		`(term-style "x" {:fg :no-such-color})`,
+		`(term-style "x" {:fg "#zzzzzz"})`,
+		`(term-style "x" {:fg 300})`,
+		`(term-style "x" {:bold "yes"})`,
+		`(term-style "x" {:typo true})`,
+		`(term-style "x" nil)`,
+	} {
+		if _, err := eval(t, ns, src); err == nil {
+			t.Errorf("%s did not error", src)
+		}
+	}
+}
+
+// TestStylePlain covers the off switch: NO_COLOR set (and no tty in the
+// test binary anyway) must yield the input unchanged.
+func TestStylePlain(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	term.ResetColorCache()
+	ns := newEnv(t)
+	if got := evalString(t, ns, `(term-style "x" {:fg :red :bold true})`); got != "x" {
+		t.Errorf("styled under NO_COLOR: %q", got)
+	}
+	if v, err := eval(t, ns, `(term-color?)`); err != nil || v != false {
+		t.Errorf("(term-color?) = %v, %v; want false under NO_COLOR", v, err)
+	}
+	// invalid options still error even when color is off
+	if _, err := eval(t, ns, `(term-style "x" {:fg :no-such-color})`); err == nil {
+		t.Error("invalid color did not error with color off")
+	}
+}
+
+func TestWidthNonTTY(t *testing.T) {
+	ns := newEnv(t)
+	v, err := eval(t, ns, `(term-width)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 0 {
+		t.Errorf("(term-width) = %v, want 0 outside a terminal", v)
+	}
+}


### PR DESCRIPTION
Second piece of the formatted-output work (after #106): a dependency-free ANSI styling namespace, deliberately smaller than lipgloss/bubbletea — colors and attributes only, no TUI runtime.

```clojure
(println (term-style "error:" {:fg :red :bold true})
         (format "%s (%d retries)" "connection refused" 3))
```

- `term-style [s opts]` — `:fg`/`:bg` as keywords (`:red`, `:bright-cyan`, `:gray`), 0-255 palette ints or `"#rrggbb"` truecolor; boolean attributes `:bold :dim :italic :underline :blink :reverse :strikethrough`. Unknown options and bad colors throw, even with color off.
- Color gating: tty + `NO_COLOR` unset + `TERM != dumb`; `CLICOLOR_FORCE=1` forces on. With color off the string passes through unchanged, so styled scripts degrade cleanly in pipes/logs.
- `term-color?`, `term-width`, and header sugar (`term-red` … `term-gray`, `term-bold`, `term-underline`).

Uses `golang.org/x/term` (already a dependency) for tty/width detection. Registered in both library lists; `LANGUAGE.md` regenerated; tests cover SGR sequences, gating on/off and error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)