### PR TITLE
feat(lsp): highlight and check %verbs in format calls

### DIFF
--- a/lsp/analyse.go
+++ b/lsp/analyse.go
@@ -420,7 +420,7 @@ type semTok struct {
 // function/macro. It walks the parsed AST; quoted data is not descended
 // into. Tokens are returned in document order.
 func (a *analysis) semanticTokens(content string) []semTok {
-	b := &semBuilder{a: a, docScope: wholeContentRange(content), lines: strings.Split(content, "\n")}
+	b := &semBuilder{a: a, docScope: wholeContentRange(content), lines: strings.Split(content, "\n"), idx: newDocIndex(content)}
 	for _, f := range a.forms {
 		b.walk(f)
 	}
@@ -431,6 +431,7 @@ type semBuilder struct {
 	a        *analysis
 	docScope Range
 	lines    []string
+	idx      *docIndex
 	toks     []semTok
 }
 
@@ -581,6 +582,9 @@ func (b *semBuilder) list(n types.List) {
 			b.emit(head, tokKeyword, 0)
 		} else {
 			b.emit(head, b.headType(head.Val), 0)
+		}
+		if head.Val == "format" {
+			b.formatToks(n)
 		}
 		for _, c := range tail(n.Val, 1) {
 			b.walk(c)

--- a/lsp/format.go
+++ b/lsp/format.go
@@ -1,0 +1,274 @@
+package lsp
+
+// Support for format strings: the %verbs inside the string literal of a
+// (format "..." args...) call are highlighted as semantic tokens, and a
+// mismatch between the verbs and the call's arguments is reported as a
+// warning, in the spirit of what gopls does for Printf-style calls.
+//
+// The reader keeps no source position for string literals (they are
+// plain Go strings in the AST), so the literal is located by scanning
+// the document text right after the `format` head symbol, whose
+// position is known.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/jig/lisp/types"
+)
+
+// docIndex converts between absolute byte offsets in a document and
+// LSP line/character positions.
+type docIndex struct {
+	content   string
+	lineStart []int
+}
+
+func newDocIndex(content string) *docIndex {
+	starts := []int{0}
+	for i := 0; i < len(content); i++ {
+		if content[i] == '\n' {
+			starts = append(starts, i+1)
+		}
+	}
+	return &docIndex{content: content, lineStart: starts}
+}
+
+func (d *docIndex) offset(p Position) int {
+	if p.Line < 0 || p.Line >= len(d.lineStart) {
+		return -1
+	}
+	off := d.lineStart[p.Line] + p.Character
+	if off > len(d.content) {
+		return -1
+	}
+	return off
+}
+
+func (d *docIndex) pos(off int) Position {
+	line := sort.Search(len(d.lineStart), func(i int) bool { return d.lineStart[i] > off }) - 1
+	return Position{Line: line, Character: off - d.lineStart[line]}
+}
+
+// stringLiteral is a located format string: the raw source text between
+// the delimiters and the absolute offsets of its full extent.
+type stringLiteral struct {
+	inner      string // source text between the delimiters (escapes not decoded)
+	innerStart int    // absolute offset of inner's first byte
+	start, end int    // absolute offsets of the literal including delimiters
+}
+
+// literalAfter locates the string literal that follows the head symbol
+// of a (format ...) call in the source text. It only skips whitespace,
+// so anything else (a variable, a comment) makes it bail out.
+func literalAfter(idx *docIndex, head types.Symbol) (stringLiteral, bool) {
+	off := idx.offset(symbolRange(head.Cursor, head.Val).End)
+	if off < 0 {
+		return stringLiteral{}, false
+	}
+	content := idx.content
+	for off < len(content) && strings.ContainsRune(" \t\r\n,", rune(content[off])) {
+		off++
+	}
+	switch {
+	case off < len(content) && content[off] == '"':
+		for j := off + 1; j < len(content); j++ {
+			switch content[j] {
+			case '\\':
+				j++
+			case '"':
+				return stringLiteral{inner: content[off+1 : j], innerStart: off + 1, start: off, end: j + 1}, true
+			}
+		}
+	case strings.HasPrefix(content[off:], "¬"):
+		d := len("¬")
+		if rel := strings.Index(content[off+d:], "¬"); rel >= 0 {
+			return stringLiteral{inner: content[off+d : off+d+rel], innerStart: off + d, start: off, end: off + d + rel + d}, true
+		}
+	}
+	return stringLiteral{}, false
+}
+
+// formatVerb is one % directive found in a format string.
+type formatVerb struct {
+	off, len int  // byte extent within the literal's inner text
+	consumes int  // arguments consumed: 1 per verb plus 1 per '*'
+	indexed  bool // uses an explicit [n] argument index
+	literal  bool // %%: no argument
+	invalid  bool // no verb letter could be parsed
+}
+
+// scanFormatVerbs finds the % directives in the raw source text of a
+// format string. Escape sequences (\n, \") contain no '%', so scanning
+// source text yields the same directives as the decoded value.
+func scanFormatVerbs(s string) []formatVerb {
+	var out []formatVerb
+	for i := 0; i < len(s); i++ {
+		if s[i] != '%' {
+			continue
+		}
+		v := formatVerb{off: i, consumes: 1}
+		j := i + 1
+		for j < len(s) && strings.ContainsRune("#0- +'", rune(s[j])) {
+			j++
+		}
+		if j < len(s) && s[j] == '[' {
+			v.indexed = true
+			for j < len(s) && s[j] != ']' {
+				j++
+			}
+			if j < len(s) {
+				j++
+			}
+		}
+		for j < len(s) && (s[j] == '*' || (s[j] >= '0' && s[j] <= '9')) {
+			if s[j] == '*' {
+				v.consumes++
+			}
+			j++
+		}
+		if j < len(s) && s[j] == '.' {
+			j++
+			for j < len(s) && (s[j] == '*' || (s[j] >= '0' && s[j] <= '9')) {
+				if s[j] == '*' {
+					v.consumes++
+				}
+				j++
+			}
+		}
+		switch {
+		case j >= len(s):
+			v.invalid = true
+			v.consumes = 0
+		case s[j] == '%':
+			j++
+			v.literal = j-i == 2 // "%[1]%" and friends stay invalid-ish but harmless
+			v.consumes = 0
+		case (s[j] >= 'a' && s[j] <= 'z') || (s[j] >= 'A' && s[j] <= 'Z'):
+			j++
+		default:
+			j++
+			v.invalid = true
+			v.consumes = 0
+		}
+		v.len = j - i
+		out = append(out, v)
+		i = j - 1
+	}
+	return out
+}
+
+// formatCall matches a (format "..." args...) call form and locates its
+// literal; ok is false for empty lists, other heads or non-literal
+// format arguments.
+func formatCall(idx *docIndex, n types.List) (head types.Symbol, lit stringLiteral, ok bool) {
+	if len(n.Val) < 2 {
+		return head, lit, false
+	}
+	head, isSym := n.Val[0].(types.Symbol)
+	if !isSym || head.Val != "format" || head.Cursor == nil {
+		return head, lit, false
+	}
+	if _, isString := n.Val[1].(string); !isString {
+		return head, lit, false
+	}
+	lit, ok = literalAfter(idx, head)
+	return head, lit, ok
+}
+
+// formatToks emits one semantic token per % directive of a format call,
+// so verbs read distinctly inside the string. Reuses the keyword token
+// type: no legend (nor VS Code extension) change needed.
+func (b *semBuilder) formatToks(n types.List) {
+	if b.idx == nil {
+		return
+	}
+	_, lit, ok := formatCall(b.idx, n)
+	if !ok {
+		return
+	}
+	for _, v := range scanFormatVerbs(lit.inner) {
+		start := b.idx.pos(lit.innerStart + v.off)
+		end := b.idx.pos(lit.innerStart + v.off + v.len)
+		if start.Line != end.Line {
+			continue // a directive never spans lines; guard anyway
+		}
+		b.toks = append(b.toks, semTok{rng: Range{Start: start, End: end}, typ: tokKeyword})
+	}
+}
+
+// formatDiagnostics walks the document's forms and reports format calls
+// whose argument count cannot match the format string, plus malformed
+// directives. Calls with explicit [n] indexes skip the count check, and
+// non-literal format strings are ignored.
+func formatDiagnostics(anal *analysis, content string) []Diagnostic {
+	idx := newDocIndex(content)
+	var diags []Diagnostic
+	var walk func(form types.MalType)
+	walk = func(form types.MalType) {
+		switch n := form.(type) {
+		case types.Vector:
+			for _, c := range n.Val {
+				walk(c)
+			}
+		case types.HashMap:
+			for _, v := range n.Val {
+				walk(v)
+			}
+		case types.List:
+			if len(n.Val) == 0 {
+				return
+			}
+			if head, ok := n.Val[0].(types.Symbol); ok {
+				switch head.Val {
+				case "quote", "quasiquote", "quasiquoteexpand":
+					return // data, not code
+				}
+			}
+			diags = append(diags, formatCallDiagnostics(idx, n)...)
+			for _, c := range n.Val {
+				walk(c)
+			}
+		}
+	}
+	for _, f := range anal.forms {
+		walk(f)
+	}
+	return diags
+}
+
+func formatCallDiagnostics(idx *docIndex, n types.List) []Diagnostic {
+	_, lit, ok := formatCall(idx, n)
+	if !ok {
+		return nil
+	}
+	var diags []Diagnostic
+	litRange := Range{Start: idx.pos(lit.start), End: idx.pos(lit.end)}
+	consumes, indexed := 0, false
+	for _, v := range scanFormatVerbs(lit.inner) {
+		if v.invalid {
+			diags = append(diags, Diagnostic{
+				Range: Range{
+					Start: idx.pos(lit.innerStart + v.off),
+					End:   idx.pos(lit.innerStart + v.off + v.len),
+				},
+				Severity: severityWarning,
+				Source:   "lisp",
+				Message:  "invalid format directive",
+			})
+			continue
+		}
+		consumes += v.consumes
+		indexed = indexed || v.indexed
+	}
+	if args := len(n.Val) - 2; !indexed && consumes != args {
+		diags = append(diags, Diagnostic{
+			Range:    litRange,
+			Severity: severityWarning,
+			Source:   "lisp",
+			Message:  fmt.Sprintf("format string consumes %d argument(s), but %d given", consumes, args),
+		})
+	}
+	return diags
+}

--- a/lsp/format_test.go
+++ b/lsp/format_test.go
@@ -1,0 +1,103 @@
+package lsp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// verbTokens extracts the semantic tokens produced for format directives
+// (keyword-typed tokens that are not call heads or special forms), as
+// "line:start-end" strings.
+func verbTokens(t *testing.T, src string) []string {
+	t.Helper()
+	a := analyseDocument("t.lisp", src)
+	idx := newDocIndex(src)
+	var out []string
+	for _, s := range a.semanticTokens(src) {
+		if s.typ != tokKeyword {
+			continue
+		}
+		off := idx.offset(s.rng.Start)
+		if off < 0 || src[off] != '%' {
+			continue
+		}
+		out = append(out, tokenSpan(s))
+	}
+	return out
+}
+
+func tokenSpan(s semTok) string {
+	return fmt.Sprintf("%d:%d-%d", s.rng.Start.Line, s.rng.Start.Character, s.rng.End.Character)
+}
+
+func TestFormatVerbTokens(t *testing.T) {
+	cases := []struct {
+		src  string
+		want []string
+	}{
+		// (format "%s and %03d" a b) — %s at col 9, %03d at col 16
+		{`(format "%s and %03d" a b)`, []string{"0:9-11", "0:16-20"}},
+		// %% is highlighted too
+		{`(format "100%%" )`, []string{"0:12-14"}},
+		// truecolor-ish mix of flags, width, precision, star
+		{`(format "%-8.2f|%*d" a b c)`, []string{"0:9-15", "0:16-19"}},
+		// multi-line string: the verb sits on the second line
+		{"(format \"a\n%s\" x)", []string{"1:0-2"}},
+		// non-literal format argument: nothing to highlight
+		{`(format fmt-var a)`, nil},
+		// alternate ¬…¬ string literal
+		{`(format ¬%s¬ a)`, []string{"0:10-12"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.src, func(t *testing.T) {
+			got := verbTokens(t, tc.src)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("token %d: got %s, want %s", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFormatDiagnostics(t *testing.T) {
+	cases := []struct {
+		src     string
+		wantMsg []string // substrings, one per expected diagnostic
+	}{
+		{`(format "%s %d" a b)`, nil},
+		{`(format "%s" a b)`, []string{"consumes 1 argument(s), but 2 given"}},
+		{`(format "%s %d" a)`, []string{"consumes 2 argument(s), but 1 given"}},
+		{`(format "100%%")`, nil},         // %% consumes nothing
+		{`(format "%*d" a b)`, nil},       // * consumes an extra argument
+		{`(format "%[1]d %[1]d" a)`, nil}, // indexed: count check skipped
+		{`(format "abc")`, nil},           // no verbs, no args
+		{`(format "%")`, []string{"invalid format directive"}},
+		{`(format "% !" a)`, []string{"invalid format directive", "consumes 0 argument(s), but 1 given"}},
+		{`(format fmt-var a b)`, nil},      // dynamic format string: ignored
+		{`(quote (format "%s" a b))`, nil}, // quoted data: ignored
+		{`(defn f [x] (format "%s %s" x))`, []string{"consumes 2 argument(s), but 1 given"}}, // nested in a body
+		{"(format \"a\n%d %d\" x)", []string{"consumes 2 argument(s), but 1 given"}},         // multi-line literal
+	}
+	for _, tc := range cases {
+		t.Run(tc.src, func(t *testing.T) {
+			a := analyseDocument("t.lisp", tc.src)
+			diags := formatDiagnostics(a, tc.src)
+			if len(diags) != len(tc.wantMsg) {
+				t.Fatalf("got %d diagnostics (%v), want %d", len(diags), diags, len(tc.wantMsg))
+			}
+			for i, want := range tc.wantMsg {
+				if !strings.Contains(diags[i].Message, want) {
+					t.Errorf("diagnostic %d = %q, want substring %q", i, diags[i].Message, want)
+				}
+				if diags[i].Severity != severityWarning {
+					t.Errorf("diagnostic %d severity = %d, want warning", i, diags[i].Severity)
+				}
+			}
+		})
+	}
+}

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -216,6 +216,7 @@ func (s *Server) updateDocument(uri, content string) {
 	diags := append([]Diagnostic{}, anal.diagnostics...)
 	diags = append(diags, requireDiags...)
 	diags = append(diags, s.unknownSymbolDiagnostics(anal, external)...)
+	diags = append(diags, formatDiagnostics(anal, content)...)
 	s.notify("textDocument/publishDiagnostics", PublishDiagnosticsParams{
 		URI: uri, Diagnostics: diags,
 	})


### PR DESCRIPTION
Last piece of the formatted-output work (#106, #107): editor support for the new `format` builtin, in the spirit of what gopls does for Printf-style calls.

- **Semantic tokens**: every `%` directive inside the string literal of `(format "..." args...)` is emitted as its own token, so verbs read distinctly inside the string. The existing `keyword` legend entry is reused — no legend or VS Code extension change required.
- **Diagnostics**: warnings for argument-count mismatches (`format string consumes 2 argument(s), but 1 given`) and malformed directives (`%` with no verb letter). `%%` consumes nothing, `*` width/precision consume an extra argument, explicit `[n]` indexes skip the count check, and dynamic (non-literal) format strings are ignored.
- Works with multi-line `"..."` literals and `¬...¬` strings. Quoted forms are not analysed.

Implementation note: the reader stores string literals as bare Go strings with no source position, so the literal is located by scanning the document text right after the `format` head symbol (whose position is known) — see `lsp/format.go`.

DAP needed no changes (no format-string surface there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)