### PR TITLE
feat(coreextended): printf, Clojure-style print-of-format sugar

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -356,6 +356,7 @@ Higher-order helpers written in lisp (the prelude): reduce, map, partial, protoc
 | `partial` | `[f & args]` | Returns a function that calls f with the given args plus any it is later called with. |
 | `pos?` | `[n]` | Whether n is greater than 0. |
 | `pprint` | `[obj]` | Pretty-prints a lisp value with indentation. |
+| `printf` | `[fmt & args]` | Prints (format fmt args...) without a trailing newline; returns nil. |
 | `quot` | `[a b]` | Integer quotient of a divided by b, truncated toward zero. |
 | `reduce` | `[f init xs]` | Left fold: (f (.. (f (f init x1) x2) ..) xn) over the elements of xs. |
 | `reduce-kv` | `[f init xs]` | Left fold over a sequence of key/value pairs: applies (f acc k v) across xs. |

--- a/lib/coreextended/coreextended_test.go
+++ b/lib/coreextended/coreextended_test.go
@@ -139,3 +139,12 @@ func TestFormat(t *testing.T) {
 		})
 	}
 }
+
+// TestPrintf checks the printf sugar evaluates and returns nil (its
+// output goes to stdout; the formatting itself is covered by TestFormat).
+func TestPrintf(t *testing.T) {
+	ns := newEnv(t)
+	if got := run(t, ns, `(printf "%s-%d" "x" 1)`); got != "nil" {
+		t.Errorf("(printf ...) = %s, want nil", got)
+	}
+}

--- a/lib/coreextended/header-coreextended.lisp
+++ b/lib/coreextended/header-coreextended.lisp
@@ -446,4 +446,11 @@
     [to from]
     (reduce conj to from))
 
+;;; Printing
+
+  (defn printf
+    "Prints (format fmt args...) without a trailing newline; returns nil."
+    [fmt & args]
+    (print (apply format fmt args)))
+
 )

--- a/lsp/analyse.go
+++ b/lsp/analyse.go
@@ -583,7 +583,7 @@ func (b *semBuilder) list(n types.List) {
 		} else {
 			b.emit(head, b.headType(head.Val), 0)
 		}
-		if head.Val == "format" {
+		if formatHeads[head.Val] {
 			b.formatToks(n)
 		}
 		for _, c := range tail(n.Val, 1) {

--- a/lsp/format.go
+++ b/lsp/format.go
@@ -159,15 +159,19 @@ func scanFormatVerbs(s string) []formatVerb {
 	return out
 }
 
-// formatCall matches a (format "..." args...) call form and locates its
-// literal; ok is false for empty lists, other heads or non-literal
-// format arguments.
+// formatHeads are the call heads whose first argument is a format
+// string: format returns the formatted string, printf prints it.
+var formatHeads = map[string]bool{"format": true, "printf": true}
+
+// formatCall matches a (format "..." args...) or (printf ...) call form
+// and locates its literal; ok is false for empty lists, other heads or
+// non-literal format arguments.
 func formatCall(idx *docIndex, n types.List) (head types.Symbol, lit stringLiteral, ok bool) {
 	if len(n.Val) < 2 {
 		return head, lit, false
 	}
 	head, isSym := n.Val[0].(types.Symbol)
-	if !isSym || head.Val != "format" || head.Cursor == nil {
+	if !isSym || !formatHeads[head.Val] || head.Cursor == nil {
 		return head, lit, false
 	}
 	if _, isString := n.Val[1].(string); !isString {

--- a/lsp/format_test.go
+++ b/lsp/format_test.go
@@ -48,6 +48,8 @@ func TestFormatVerbTokens(t *testing.T) {
 		{`(format fmt-var a)`, nil},
 		// alternate ¬…¬ string literal
 		{`(format ¬%s¬ a)`, []string{"0:10-12"}},
+		// printf gets the same treatment
+		{`(printf "%s\n" a)`, []string{"0:9-11"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.src, func(t *testing.T) {
@@ -82,6 +84,7 @@ func TestFormatDiagnostics(t *testing.T) {
 		{`(quote (format "%s" a b))`, nil}, // quoted data: ignored
 		{`(defn f [x] (format "%s %s" x))`, []string{"consumes 2 argument(s), but 1 given"}}, // nested in a body
 		{"(format \"a\n%d %d\" x)", []string{"consumes 2 argument(s), but 1 given"}},         // multi-line literal
+		{`(printf "%s %d" a)`, []string{"consumes 2 argument(s), but 1 given"}},              // printf too
 	}
 	for _, tc := range cases {
 		t.Run(tc.src, func(t *testing.T) {


### PR DESCRIPTION
`(printf fmt args...)` = `(print (apply format fmt args))`, the exact clojure.core definition, on top of #106. The LSP's format-string support (#108) now also covers `printf` heads: verb highlighting and argument-count diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)