### PR TITLE
feat(cli): lisp --install-bat-syntax, embedded bat highlighting

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/lib/core"
 	"github.com/jig/lisp/repl"
+	"github.com/jig/lisp/tools/bat"
 	"github.com/jig/lisp/types"
 )
 
@@ -31,6 +32,7 @@ type args struct {
 	RunTest   string   `arg:"--run-test" help:"with --dap, run the named deftest after loading the script (used by the editor's Debug Test)" placeholder:"NAME"`
 	LSP       bool     `arg:"--lsp" help:"start a Language Server Protocol server on stdio (requires lispdebug build)"`
 	LSPListen string   `arg:"--lsp-listen" help:"start an LSP server on the given TCP address (requires lispdebug build)" placeholder:"HOST:PORT"`
+	BatSyntax bool     `arg:"--install-bat-syntax" help:"install the jig/lisp syntax into bat (writes to bat's config dir and rebuilds its cache)"`
 	Script    string   `arg:"positional" help:"lisp script to execute"`
 	Args      []string `arg:"positional" help:"arguments to pass to the script"`
 }
@@ -107,6 +109,18 @@ func Execute(cmdArgs []string, repl_env types.EnvType) error {
 		}
 		files = append(files, parsedArgs.Args...)
 		return formatSources(files, parsedArgs.Write)
+	}
+
+	// Installing the bat syntax is a standalone action, like --fmt.
+	if parsedArgs.BatSyntax {
+		dir, err := batsyntax.ConfigDir()
+		if err != nil {
+			return err
+		}
+		if err := batsyntax.Install(dir, os.Stdout); err != nil {
+			return err
+		}
+		return batsyntax.BuildCache(os.Stdout)
 	}
 
 	// DAP server takes precedence over the rest of the modes when set.

--- a/tools/bat/README.md
+++ b/tools/bat/README.md
@@ -1,0 +1,15 @@
+# bat syntax
+
+Syntax highlighting for jig/lisp in [bat](https://github.com/sharkdp/bat). The grammar (`jig-lisp.sublime-syntax`) is hand-maintained in sync with the VS Code TextMate grammar (`tools/vscode-lisp/syntaxes/lisp.tmLanguage.json`) — bat's syntect engine only loads `.sublime-syntax` files. It also highlights `format`/`printf` `%verbs` inside strings, matching the LSP.
+
+## Install
+
+The syntax file is embedded in the `lisp` binary, so any machine with the binary can self-install without the repository:
+
+```
+lisp --install-bat-syntax
+```
+
+This writes `syntaxes/jig-lisp.sublime-syntax` into bat's config dir (`$BAT_CONFIG_DIR`, `bat --config-dir`, or `~/.config/bat`), adds `--map-syntax "*.lisp:jig/lisp"` to bat's `config` (bat bundles a generic "Lisp" syntax for `.lisp`; the mapping overrides it), and runs `bat cache --build`. The command is idempotent.
+
+To undo: remove the syntax file and the `--map-syntax` line, then `bat cache --clear`.

--- a/tools/bat/batsyntax.go
+++ b/tools/bat/batsyntax.go
@@ -1,0 +1,100 @@
+// Package batsyntax installs the jig/lisp syntax definition into bat
+// (https://github.com/sharkdp/bat), so `bat file.lisp` highlights lisp
+// source with the same grammar the VS Code extension uses. The syntax
+// file is embedded, which makes any lisp binary a self-contained
+// installer (`lisp --install-bat-syntax`) — handy on machines that have
+// the binary but not the repository.
+package batsyntax
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	_ "embed"
+)
+
+//go:embed jig-lisp.sublime-syntax
+var syntaxFile []byte
+
+const (
+	syntaxFileName = "jig-lisp.sublime-syntax"
+	// mapSyntaxLine claims the .lisp extension explicitly: bat bundles
+	// its own "Lisp" syntax for that extension, and the config mapping
+	// is the deterministic way to override it.
+	mapSyntaxLine = `--map-syntax "*.lisp:jig/lisp"`
+)
+
+// ConfigDir resolves bat's configuration directory the way bat does:
+// $BAT_CONFIG_DIR first, then `bat --config-dir`, then ~/.config/bat.
+func ConfigDir() (string, error) {
+	if dir := os.Getenv("BAT_CONFIG_DIR"); dir != "" {
+		return dir, nil
+	}
+	if _, err := exec.LookPath("bat"); err == nil {
+		out, err := exec.Command("bat", "--config-dir").Output()
+		if err == nil {
+			if dir := strings.TrimSpace(string(out)); dir != "" {
+				return dir, nil
+			}
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve bat's config dir: %w", err)
+	}
+	return filepath.Join(home, ".config", "bat"), nil
+}
+
+// Install writes the syntax file into dir/syntaxes and ensures the
+// map-syntax override in dir/config. It is idempotent.
+func Install(dir string, w io.Writer) error {
+	syntaxDir := filepath.Join(dir, "syntaxes")
+	if err := os.MkdirAll(syntaxDir, 0o755); err != nil {
+		return err
+	}
+	syntaxPath := filepath.Join(syntaxDir, syntaxFileName)
+	if err := os.WriteFile(syntaxPath, syntaxFile, 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "wrote %s\n", syntaxPath)
+
+	configPath := filepath.Join(dir, "config")
+	current, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if strings.Contains(string(current), mapSyntaxLine) {
+		fmt.Fprintf(w, "%s already maps *.lisp\n", configPath)
+		return nil
+	}
+	updated := string(current)
+	if updated != "" && !strings.HasSuffix(updated, "\n") {
+		updated += "\n"
+	}
+	updated += mapSyntaxLine + "\n"
+	if err := os.WriteFile(configPath, []byte(updated), 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "added %s to %s\n", mapSyntaxLine, configPath)
+	return nil
+}
+
+// BuildCache rebuilds bat's syntax cache so the new definition takes
+// effect. When bat is not on PATH it only prints the pending step.
+func BuildCache(w io.Writer) error {
+	if _, err := exec.LookPath("bat"); err != nil {
+		fmt.Fprintln(w, "bat not found on PATH; run `bat cache --build` once it is installed")
+		return nil
+	}
+	cmd := exec.Command("bat", "cache", "--build")
+	cmd.Stdout = w
+	cmd.Stderr = w
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("bat cache --build: %w", err)
+	}
+	return nil
+}

--- a/tools/bat/batsyntax_test.go
+++ b/tools/bat/batsyntax_test.go
@@ -1,0 +1,72 @@
+package batsyntax
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	var out bytes.Buffer
+
+	if err := Install(dir, &out); err != nil {
+		t.Fatal(err)
+	}
+	syntax, err := os.ReadFile(filepath.Join(dir, "syntaxes", syntaxFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(syntax, []byte("name: jig/lisp")) {
+		t.Error("syntax file lacks the jig/lisp name")
+	}
+	cfg, err := os.ReadFile(filepath.Join(dir, "config"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(cfg), mapSyntaxLine); got != 1 {
+		t.Fatalf("config has %d map-syntax lines, want 1:\n%s", got, cfg)
+	}
+
+	// second run must not duplicate the mapping
+	if err := Install(dir, &out); err != nil {
+		t.Fatal(err)
+	}
+	cfg, _ = os.ReadFile(filepath.Join(dir, "config"))
+	if got := strings.Count(string(cfg), mapSyntaxLine); got != 1 {
+		t.Fatalf("after reinstall, config has %d map-syntax lines, want 1", got)
+	}
+}
+
+func TestInstallAppendsToExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	// existing config without a trailing newline
+	if err := os.WriteFile(filepath.Join(dir, "config"), []byte(`--theme="ansi"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Install(dir, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := os.ReadFile(filepath.Join(dir, "config"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "--theme=\"ansi\"\n" + mapSyntaxLine + "\n"
+	if string(cfg) != want {
+		t.Errorf("config = %q, want %q", cfg, want)
+	}
+}
+
+func TestConfigDirEnvOverride(t *testing.T) {
+	t.Setenv("BAT_CONFIG_DIR", "/custom/bat")
+	dir, err := ConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dir != "/custom/bat" {
+		t.Errorf("ConfigDir() = %q, want /custom/bat", dir)
+	}
+}

--- a/tools/bat/jig-lisp.sublime-syntax
+++ b/tools/bat/jig-lisp.sublime-syntax
@@ -1,0 +1,70 @@
+%YAML 1.2
+---
+# jig/lisp syntax for bat (and Sublime Text). Hand-maintained in sync
+# with tools/vscode-lisp/syntaxes/lisp.tmLanguage.json — bat's syntect
+# engine only loads .sublime-syntax files, not TextMate JSON grammars.
+name: jig/lisp
+file_extensions:
+  - lisp
+scope: source.lisp
+
+contexts:
+  main:
+    # leading `;; $NAME <expr>` placeholder default lines
+    - match: '^(;;)\s(\$[-\w\d]+)\s(.*)$'
+      captures:
+        1: comment.line.semicolon.lisp
+        2: constant.other.placeholder.lisp
+        3: comment.line.semicolon.lisp
+    - match: ';.*$'
+      scope: comment.line.semicolon.lisp
+    - match: '"'
+      scope: punctuation.definition.string.begin.lisp
+      push: string
+    # ¬…¬ JSON-friendly strings; ¬¬ escapes a literal ¬
+    - match: '¬'
+      scope: punctuation.definition.string.begin.lisp
+      push: notation_string
+    - match: '(?<![\w-])-?\d+(\.\d+)?(?![\w-])'
+      scope: constant.numeric.lisp
+    - match: '::?[\w.\-?!*+<>=/]+'
+      scope: support.type.keyword.lisp
+    - match: '(?<=\(|\s)(def|defmacro|defn|let|fn|if|do|quote|quasiquote|unquote|splice-unquote|try|catch|finally|throw|macroexpand|recur|context)(?=\s|\))'
+      scope: keyword.control.lisp
+    # core/coreextended macros and module loading
+    - match: '(?<=\(|\s)(when|cond|and|or|->>|->|require|load-file|load-file-once|future|wait|time|benchmark|partial)(?=\s|\))'
+      scope: keyword.other.macro.lisp
+    - match: '(?<=\(|\s|^)(true|false|nil)(?=\s|\)|$)'
+      scope: constant.language.lisp
+    # the name being defined by def/defn/defmacro
+    - match: '(?<=def\s|defn\s|defmacro\s)[\w\-+*/<>=!?.]+'
+      scope: entity.name.function.definition.lisp
+    # $NAME preamble placeholders, substituted at read time
+    - match: '\$[-\w\d]+'
+      scope: constant.other.placeholder.lisp
+    # symbol in call position, qualified names included
+    - match: '(?<=\()[a-zA-Z_+\-*/<>=!?][\w\-+*/<>=!?.]*'
+      scope: entity.name.function.lisp
+    - match: '[''`~@^]|#(?=\{)'
+      scope: keyword.operator.quote.lisp
+    - match: '[a-zA-Z_+\-*/<>=!?][\w\-+*/<>=!?]*'
+      scope: variable.other.lisp
+
+  string:
+    - meta_scope: string.quoted.double.lisp
+    # format/printf %verbs, matching the LSP's treatment
+    - match: '%(%|[-#0+ '']*(\[\d+\])?[\d*]*(\.[\d*]+)?[a-zA-Z])'
+      scope: constant.other.placeholder.lisp
+    - match: '\\.'
+      scope: constant.character.escape.lisp
+    - match: '"'
+      scope: punctuation.definition.string.end.lisp
+      pop: true
+
+  notation_string:
+    - meta_scope: string.quoted.other.notation.lisp
+    - match: '¬¬'
+      scope: constant.character.escape.lisp
+    - match: '¬(?!¬)'
+      scope: punctuation.definition.string.end.lisp
+      pop: true


### PR DESCRIPTION
`lisp --install-bat-syntax` makes any lisp binary a self-contained installer of jig/lisp highlighting for [bat](https://github.com/sharkdp/bat) — no repo needed on the target machine (raspis with an scp'd binary included):

1. resolves bat's config dir (`$BAT_CONFIG_DIR` → `bat --config-dir` → `~/.config/bat`),
2. writes the embedded `jig-lisp.sublime-syntax` (bat/syntect doesn't read TextMate JSON, so this is a hand-maintained twin of the VS Code grammar, plus `format`/`printf` `%verb` highlighting inside strings to match the LSP),
3. appends `--map-syntax "*.lisp:jig/lisp"` to bat's config — bat bundles a generic "Lisp" syntax for `.lisp`, and the mapping is the deterministic override,
4. runs `bat cache --build`.

Idempotent; verified end-to-end on this machine (`bat demo.lisp` shows special forms, keywords, `¬…¬` strings and `%verbs` correctly, and `bat --list-languages` lists `jig/lisp:lisp,*.lisp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)