### PR TITLE
docs: harmonize interpreter install on go install -tags debugger

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,7 +54,7 @@ in 0.3). Anything users must act on goes in `CHANGELOG.md` under
 6. **Verify** the module is installable at the new tag:
 
    ```bash
-   go install github.com/jig/lisp/cmd/lisp@vNEW
+   go install -tags debugger github.com/jig/lisp/cmd/lisp@vNEW
    ```
 
 ## Backfilling older tags (optional)

--- a/tools/vscode-lisp/README.md
+++ b/tools/vscode-lisp/README.md
@@ -52,12 +52,16 @@ Find-references and rename are not part of this release.
 ## Requirements
 
 The interpreter must be built with the `debugger` build tag — this is
-the artefact that contains the DAP server. From the repo root:
+the artefact that contains the DAP server:
 
 ```sh
-go build -tags debugger -o lisp ./cmd/lisp
-sudo install lisp /usr/local/bin/    # or anywhere on $PATH
+go install -tags debugger github.com/jig/lisp/cmd/lisp@latest
 ```
+
+(`go install` places `lisp` in `$GOBIN`, usually `~/go/bin` — make sure
+it is on your `$PATH`. To try uncommitted local changes instead, run the
+same command from the repo root with `.` in place of `@latest`:
+`go install -tags debugger ./cmd/lisp`.)
 
 By default the extension spawns `lisp --dap <program>`. Override
 the command via the `lisp.debugAdapter.command` setting.


### PR DESCRIPTION
Same install one-liner everywhere: the VS Code extension README dropped its `go build` + `sudo install` flow in favor of `go install -tags debugger github.com/jig/lisp/cmd/lisp@latest` (with a `$GOBIN` note and the local-checkout variant), and RELEASING.md's verify step now includes the tag too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)