### PR TITLE
feat(integrity): --integrity mode, .state/ store and INTEGRITY.md spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,19 @@ identifiers or bit patterns keep working and now survive any width.
 
 Non-breaking, for context (see `git log v0.2.24..` for the full list):
 
+- `--integrity REF` — run a script if and only if it matches what is
+  committed in its Git repository at REF (a commit hash, tag or
+  branch): HEAD must be exactly REF, the script must byte-match its
+  committed blob, and the check cascades to every `require` resolved
+  inside the same repository (modules resolving outside it are
+  refused). `--integrity-signers FILE` additionally requires REF to be
+  SSH-signed by a key listed in FILE (authorized_keys format, as
+  `git-verify-commit`). The new `(assert-integrity)` builtin throws
+  unless the run is verified — so committed code can demand the flag —
+  and returns the verified commit hash. This is an operational
+  assurance against drift and uncommitted edits, not a security
+  boundary against whoever can rewrite the repository or the binary.
+  See `lib/integrity/README.md`
 - `exit` builtin: `(exit)` / `(exit status)` ends the process with the
   given status (`0` by default), like Clojure's `System/exit`. It stops
   before the interpreter echoes a script's final value, so a program run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,17 +155,25 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
 
 - `--integrity REF` — run a script if and only if it matches what is
   committed in its Git repository at REF (a commit hash, tag or
-  branch): HEAD must be exactly REF, the script must byte-match its
-  committed blob, and the check cascades to every `require` resolved
-  inside the same repository (modules resolving outside it are
-  refused). `--integrity-signers FILE` additionally requires REF to be
-  SSH-signed by a key listed in FILE (authorized_keys format, as
-  `git-verify-commit`). The new `(assert-integrity)` builtin throws
-  unless the run is verified — so committed code can demand the flag —
-  and returns the verified commit hash. This is an operational
-  assurance against drift and uncommitted edits, not a security
-  boundary against whoever can rewrite the repository or the binary.
-  See `lib/integrity/README.md`
+  branch): HEAD must be exactly REF (or a `.state/`-only descendant),
+  the script must byte-match its committed blob, and the check
+  cascades to every file evaluated as code — `require` modules and
+  `load-file` targets — resolved inside the same repository (files
+  resolving outside it are refused). `--integrity-signers FILE`
+  additionally requires REF to be SSH-signed by a key listed in FILE
+  (authorized_keys format, as `git-verify-commit`); a JSON audit line
+  is logged on successful verification. New builtins:
+  `(assert-integrity)` throws unless the run is verified — so
+  committed code can demand the flag — and returns the verified commit
+  hash; `(state-save name value)` / `(state-load name & [default])`
+  persist program state as canonical lisp data under `.state/`,
+  committing on save and verifying against HEAD on load, so state
+  commits keep the original REF valid across restarts; `slurp-source`
+  (which `load-file` now builds on) is `slurp` plus the code
+  verification. This is an operational assurance against drift and
+  uncommitted edits, not a security boundary against whoever can
+  rewrite the repository or the binary. Full specification in
+  `INTEGRITY.md`
 - `exit` builtin: `(exit)` / `(exit status)` ends the process with the
   given status (`0` by default), like Clojure's `System/exit`. It stops
   before the interpreter echoes a script's final value, so a program run

--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -6,6 +6,12 @@ This document is both the user guide and the specification the
 implementation is held to (`lib/integrity/mode.go`, `state.go`;
 enforced by `lib/integrity/mode_test.go` and `command/integrity_test.go`).
 
+Runnable mini-examples of every concept below — basic verification,
+the require cascade, signed refs, the state store, and what each
+failure looks like — live in
+[examples-integrity/](./examples-integrity/), with a `demo.sh` that
+replays all of them in throwaway repositories.
+
 ## Purpose and threat model
 
 The goal is **operational assurance for the operator launching a
@@ -60,6 +66,12 @@ any check. Point 2 is what makes the **same `--integrity <ref>` valid
 across restarts** no matter how many state commits have accumulated:
 the operator keeps launching with the release ref (or signed tag) and
 never needs to chase state-commit hashes.
+
+Concepts 1–2 and 4–6 are demonstrated by
+[examples-integrity/01-basic](./examples-integrity/01-basic) and
+[02-requires](./examples-integrity/02-requires); concept 3 by
+[03-signed](./examples-integrity/03-signed); the state paths of 2 and
+6 by [04-state](./examples-integrity/04-state).
 
 ## CLI
 

--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -1,0 +1,166 @@
+# Integrity mode
+
+`lisp --integrity <ref>` runs a script *if and only if* the code being
+executed matches what is committed in its Git repository at `<ref>`.
+This document is both the user guide and the specification the
+implementation is held to (`lib/integrity/mode.go`, `state.go`;
+enforced by `lib/integrity/mode_test.go` and `command/integrity_test.go`).
+
+## Purpose and threat model
+
+The goal is **operational assurance for the operator launching a
+script**: what runs is exactly what was committed (and, with
+signatures, exactly what a trusted key released) — no accidental
+drift, no uncommitted edits, no locally patched copy.
+
+It is **not a security boundary** against an attacker who can already
+write to the repository, the signers file or the `lisp` binary. The
+interpreter cannot protect itself from whoever controls what it reads;
+that separation belongs to the operating system (see
+[Deployment](#deployment-hardening-the-assurance-into-a-boundary)).
+
+## The invariant
+
+Definitions:
+
+- **ref** — the argument of `--integrity`: a commit hash, tag or
+  branch name, resolved in the repository enclosing the script.
+  A commit hash is immutable and therefore the strongest choice; a
+  signed tag is equivalent when `--integrity-signers` is used.
+- **code file** — any file evaluated as code: the script, every module
+  loaded through `require`, and every file loaded through `load-file` /
+  `load-file-once` (which read via the `slurp-source` builtin).
+- **state path** — any path under `.state/` at the repository root.
+
+At startup (`--integrity <ref>`):
+
+1. The script must lie inside a Git repository; `<ref>` must resolve
+   to a commit `C` in it.
+2. `HEAD` must be `C`, **or** a descendant of `C` through a linear
+   chain of commits each touching only state paths (the commits
+   `state-save` creates). Anything else fails.
+3. With `--integrity-signers FILE`: the ref must carry an SSH
+   signature by one of the public keys in `FILE` — the tag signature
+   if the ref is an annotated tag, the commit signature otherwise.
+4. The script must byte-match its blob in `C`'s tree.
+
+At runtime, while the mode is active:
+
+5. Every code file, when loaded, must lie inside the verified
+   repository and byte-match its blob in `C`'s tree. A code file
+   resolving outside the repository (an `-i` include dir elsewhere,
+   `~/.config/lisp/`, `/usr/local/share/lisp/`) is refused.
+6. Every state file, when read through `state-load`, must byte-match
+   its blob at the **current** `HEAD` (the commit the last
+   `state-save` created). Missing-but-committed, present-but-
+   uncommitted, and differing files all fail closed.
+
+Uncommitted repository files that are never interpreted do not affect
+any check. Point 2 is what makes the **same `--integrity <ref>` valid
+across restarts** no matter how many state commits have accumulated:
+the operator keeps launching with the release ref (or signed tag) and
+never needs to chase state-commit hashes.
+
+## CLI
+
+```bash
+lisp --integrity v1.4.2 service.lisp
+lisp --integrity 9fceb02d service.lisp
+lisp --integrity v1.4.2 --integrity-signers /etc/lisp/release-keys service.lisp
+```
+
+- `--integrity REF` — enable the mode. Requires a script file;
+  incompatible with `-e`, `--test`, `--fmt`, `--debug`, stdin (`-`)
+  and the DAP/LSP server modes.
+- `--integrity-signers FILE` — additionally require the ref to be
+  SSH-signed by a key listed in FILE. authorized_keys format, one
+  public key per line (`ssh-ed25519 AAAA… comment`), the same format
+  `git-verify-commit` takes. Requires `--integrity`.
+
+On success one structured JSON line is logged to stderr for the audit
+trail: `{"msg":"integrity verified","ref":…,"commit":…,"signer":…}`
+(`signer` only when signers were required).
+
+## Builtins
+
+| Builtin | Behaviour |
+|---|---|
+| `(assert-integrity)` | Throws unless running under `--integrity`; returns the verified commit hash. Committed code uses it to demand the mode — effective as long as operators know the program is supposed to carry it. |
+| `(state-save name value)` | Writes `value` as canonical lisp data to `.state/name.lisp` and **commits it in the same operation** (message `state: name`); returns the commit hash. Works with or without the mode; requires a Git repository. |
+| `(state-load name)` / `(state-load name default)` | Reads the state back as pure data (READ, never EVAL — state cannot smuggle code). Returns `default`, or throws without one, when the state does not exist. Under the mode, enforces invariant 6. |
+| `(slurp-source path)` | `slurp` for files about to be evaluated: identical, plus invariant 5 under the mode. `load-file` builds on it. |
+
+## The state store
+
+`.state/` sits at the repository root, sibling of `.lisp/`. It is the
+sanctioned way for a verified program to persist state (a database as
+a hash-map, counters, checkpoints) without stepping outside the
+integrity envelope:
+
+- **Canonical form** — values are printed readably and passed through
+  the formatter, so state files diff cleanly and hash
+  deterministically. Values the reader cannot round-trip (live
+  handles, functions) are rejected at save time. State is data only.
+- **Commit protocol** — write file → `git add` → `git commit`, all
+  inside `state-save`. Committed state is therefore always the product
+  of a completed save. State commits are authored `state-save
+  <state-save@lisp>` and unsigned (v1).
+- **Crash recovery** — a save interrupted between write and commit
+  leaves the file differing from `HEAD`; the next `state-load` under
+  the mode fails closed and the operator resolves it (commit the
+  orphan or check it out). There is deliberately no auto-repair.
+- **Concurrency** — one writer process per repository (in-process
+  saves are serialized; git itself rejects concurrent index writes
+  from other processes).
+- `slurp` and `spit` remain available for plain data files, but for
+  state that must be trustworthy they are **discouraged** in favour of
+  `state-load`/`state-save`: they participate in no invariant.
+
+## Signatures and trust anchors
+
+Without `--integrity-signers` the trust anchor is the local repository
+state: the mode proves consistency ("matches what is committed here"),
+which stops drift but not history rewriting by whoever can write to
+the repository.
+
+With `--integrity-signers` the anchor becomes the key list plus the
+binary: the ref must be signed by a trusted key, so verification
+survives cloning the repository onto other machines and re-tagging by
+someone without the key. Keep the signers file outside the repository
+and outside the process user's write reach.
+
+## Deployment: hardening the assurance into a boundary
+
+The mode becomes a real boundary only when the OS guarantees the
+attacker cannot write to what the interpreter reads:
+
+- repository checkout, signers file and `lisp` binary owned by `root`
+  (or a dedicated `deploy` user);
+- the process running as an unprivileged user with **no write access**
+  to any of the three;
+- if `state-save` is used, grant the process user write access to
+  `.state/` and `.git` only — or accept that state (unlike code) is
+  writable by the process by design;
+- binary provenance (signed releases, package manager verification) is
+  outside the interpreter's scope but completes the chain.
+
+## Known limitations
+
+- `eval` over strings obtained by other means (`slurp`, network) is
+  not covered — the verified code that chooses to do that is
+  responsible for it.
+- Preamble placeholders (`-P`) inject operator-supplied expressions;
+  the operator is the trusted party in this model.
+- A self-verifying binary is deliberately **not** attempted: an
+  attacker who can replace the binary can also remove the check.
+
+## Future revisions (not implemented)
+
+- **Signed state commits** — sign `state-save` commits with a machine
+  or process key (distinct from release keys) and verify membership on
+  load, giving state authenticity, not just consistency.
+- **Keys baked into the binary** — accept allowed signers via
+  `-ldflags -X` at build time, shrinking the trust anchor to the
+  binary alone.
+- **Data-repository variant** — keep state in a separate repository
+  for multi-writer or high-churn scenarios.

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -298,6 +298,7 @@ Reading and writing files and stdin.
 | `read-password` | `[prompt]` | Prints prompt (to stderr) and reads a line with terminal echo disabled; falls back to a plain read when input is not a terminal. Returns nil on end of input. |
 | `readline` | `[prompt]` | Prints prompt and reads a line from input. |
 | `slurp` | `[filename]` | Reads a file and returns its contents as a string. |
+| `slurp-source` | `[filename]` | Reads a source file like slurp and, under --integrity, verifies it against the pinned commit; load-file builds on it. |
 | `spit` | `[filename s & opts]` | Writes string s to a file, creating or truncating it; with :append true, appends instead. |
 
 ### core — runtime variables
@@ -456,6 +457,8 @@ Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integr
 | `ed25519-verify` | `[public s signature]` | Reports whether the base64 signature of string s verifies against the base64 Ed25519 public key. |
 | `fmt` | `[s]` | Formats lisp source s into its canonical form (as lisp --fmt does); errors if s does not parse. |
 | `sha2-256` | `[s]` | SHA2-256 digest of string s, as lowercase hex. |
+| `state-load` | `[name & [default]]` | Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under --integrity the file must match its committed version at HEAD. |
+| `state-save` | `[name value]` | Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. Under --integrity the commit keeps the verified ref valid. |
 
 ### web
 

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -446,10 +446,11 @@ Command-line option parsing (clojure/tools.cli style).
 
 ### integrity
 
-Attest and verify lisp source (formatting, hashing, Ed25519 signatures).
+Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integrity mode).
 
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
+| `assert-integrity` | `[]` | Throws unless the interpreter runs under --integrity; returns the verified commit hash. |
 | `ed25519-generate` | `[]` | Generates an Ed25519 key pair, as a map {:public :private} of base64 strings. |
 | `ed25519-sign` | `[private s]` | Signs string s with a base64 Ed25519 private key; returns the base64 signature (deterministic). |
 | `ed25519-verify` | `[public s signature]` | Reports whether the base64 signature of string s verifies against the base64 Ed25519 public key. |

--- a/README.md
+++ b/README.md
@@ -454,7 +454,9 @@ other means (`slurp`, network) is not covered; uncommitted files that
 are never interpreted do not affect the check.
 
 The full specification — invariants, state commit protocol, crash
-recovery, deployment recipe — lives in [INTEGRITY.md](./INTEGRITY.md).
+recovery, deployment recipe — lives in [INTEGRITY.md](./INTEGRITY.md);
+runnable mini-examples of each concept (and each failure mode) in
+[examples-integrity/](./examples-integrity/).
 
 ### Preamble placeholders (-P/--preamble)
 

--- a/README.md
+++ b/README.md
@@ -401,10 +401,12 @@ it matches what is committed in its Git repository at `REF` (a commit
 hash, tag or branch — an immutable commit hash is the strongest
 choice):
 
-- `HEAD` must be exactly the commit `REF` resolves to,
+- `HEAD` must be exactly the commit `REF` resolves to (or a
+  state-only descendant of it, see below),
 - the script must byte-match the blob committed at `REF`, and
-- the check cascades to `require`: every module must resolve inside
-  the same repository and match its committed blob; modules resolving
+- the check cascades to every file evaluated as code: `require`
+  modules and `load-file`/`load-file-once` targets must resolve inside
+  the same repository and match their committed blobs; files resolving
   outside it (e.g. `~/.config/lisp/`) are refused.
 
 ```bash
@@ -434,12 +436,25 @@ which survives cloning the repository onto other machines:
 lisp --integrity v1.4.2 --integrity-signers /etc/lisp/release-keys service.lisp
 ```
 
+A verified program persists state through the `.state/` store instead
+of raw file writes: `(state-save "db" value)` writes
+`.state/db.lisp` (canonical lisp data, at the repository root next to
+`.lisp/`) and commits it in the same operation; `(state-load "db")`
+reads it back as pure data and, under `--integrity`, requires it to
+match its committed version at `HEAD`. State commits keep the original
+`--integrity REF` valid across restarts: the startup check accepts
+`HEAD` being a linear chain of state-only commits above `REF`.
+
 Scope: this is an operational assurance for the operator — no
 accidental drift, no uncommitted edits — not a security boundary
 against someone who can rewrite the repository, the keys file or the
-binary. Files loaded outside the `require` mechanism (`load-file`,
-`slurp` + `eval`) are not covered; other uncommitted files in the
-repository do not affect the check.
+binary (that separation belongs to the OS: root-owned checkout, keys
+and binary; unprivileged process). `eval` over strings obtained by
+other means (`slurp`, network) is not covered; uncommitted files that
+are never interpreted do not affect the check.
+
+The full specification — invariants, state commit protocol, crash
+recovery, deployment recipe — lives in [INTEGRITY.md](./INTEGRITY.md).
 
 ### Preamble placeholders (-P/--preamble)
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Changes respect to [kanaka/mal](https://github.com/kanaka/mal):
 - `spit`, the write counterpart of `slurp` (Clojure-style): `(spit filename s)` creates or truncates, `(spit filename s :append true)` appends
 - `*FILE*` holds the absolute path of the script being executed (cf. Clojure's `*file*`), so a script can read its own source; unset in the REPL and `-e`
 - `cli` library for command-line option parsing, modelled on [clojure/tools.cli](https://github.com/clojure/tools.cli) — `(cli-parse-opts *ARGV* specs)`. See [./lib/cli/README.md](./lib/cli/README.md)
-- `integrity` library to attest and verify lisp source: `fmt` (canonical formatting, as `lisp --fmt`), `sha2-256`, and deterministic Ed25519 signatures (`ed25519-generate`, `ed25519-sign`, `ed25519-verify`). See [./lib/integrity/README.md](./lib/integrity/README.md)
+- `integrity` library to attest and verify lisp source: `fmt` (canonical formatting, as `lisp --fmt`), `sha2-256`, and deterministic Ed25519 signatures (`ed25519-generate`, `ed25519-sign`, `ed25519-verify`); plus the interpreter's integrity mode (`--integrity`, with the `assert-integrity` builtin). See [./lib/integrity/README.md](./lib/integrity/README.md)
 
 ## Embed jig/lisp in Go code
 
@@ -393,6 +393,53 @@ Hello Args:  (first-arg second-arg)
 evaled to (first-arg second-arg)
 42
 ```
+
+### Run only committed code (--integrity)
+
+`--integrity REF` makes the interpreter run a script *if and only if*
+it matches what is committed in its Git repository at `REF` (a commit
+hash, tag or branch — an immutable commit hash is the strongest
+choice):
+
+- `HEAD` must be exactly the commit `REF` resolves to,
+- the script must byte-match the blob committed at `REF`, and
+- the check cascades to `require`: every module must resolve inside
+  the same repository and match its committed blob; modules resolving
+  outside it (e.g. `~/.config/lisp/`) are refused.
+
+```bash
+lisp --integrity v1.4.2 service.lisp
+lisp --integrity 9fceb02d service.lisp
+```
+
+A script can demand the flag with the `assert-integrity` builtin,
+which throws unless the run is verified (and returns the verified
+commit hash), so a committed program cannot silently be run
+unverified — as long as the operator knows it is supposed to carry
+that call:
+
+```lisp
+(def release (assert-integrity))
+```
+
+With `--integrity-signers FILE`, `REF` must additionally carry an SSH
+signature by one of the public keys listed in `FILE`
+(authorized_keys format, one key per line — the same format
+`git-verify-commit` takes). For an annotated tag the tag's signature
+is checked; otherwise the commit's. This upgrades the guarantee from
+"matches the local repository" to "matches what a trusted key signed",
+which survives cloning the repository onto other machines:
+
+```bash
+lisp --integrity v1.4.2 --integrity-signers /etc/lisp/release-keys service.lisp
+```
+
+Scope: this is an operational assurance for the operator — no
+accidental drift, no uncommitted edits — not a security boundary
+against someone who can rewrite the repository, the keys file or the
+binary. Files loaded outside the `require` mechanism (`load-file`,
+`slurp` + `eval`) are not covered; other uncommitted files in the
+repository do not affect the check.
 
 ### Preamble placeholders (-P/--preamble)
 

--- a/command/command.go
+++ b/command/command.go
@@ -17,24 +17,26 @@ import (
 
 // args represents command line arguments for the Lisp interpreter
 type args struct {
-	Version   bool     `arg:"-v,--version" help:"show version information"`
-	Test      string   `arg:"-t,--test" help:"run the test suite from a directory or a single test file" placeholder:"DIR|FILE"`
-	TestJSON  string   `arg:"--test-json" help:"with --test, also write a JSON report to the given file" placeholder:"FILE"`
-	Coverage  string   `arg:"--coverage" help:"write an lcov coverage report of the executed lisp code (requires -tags debugger)" placeholder:"FILE"`
-	Debug     bool     `arg:"--debug" help:"enable DEBUG-EVAL support (requires -tags debugger)"`
-	Eval      string   `arg:"-e,--eval" help:"evaluate expression and exit" placeholder:"EXPR"`
-	Fmt       bool     `arg:"--fmt" help:"format lisp source (files given as arguments, or stdin) and print the result"`
-	Write     bool     `arg:"-w,--write" help:"with --fmt, rewrite each file in place instead of printing"`
-	Include   []string `arg:"-i,--include,separate" help:"add include directory for require (needs the require library loaded)" placeholder:"DIR"`
-	Preamble  []string `arg:"-P,--preamble,separate" help:"define a preamble placeholder for the script, e.g. -P '$NAME <expr>'" placeholder:"ASSIGN"`
-	DAP       bool     `arg:"--dap" help:"start a Debug Adapter Protocol server on stdio (requires -tags debugger)"`
-	DAPListen string   `arg:"--dap-listen" help:"start a DAP server on the given TCP address (requires -tags debugger)" placeholder:"HOST:PORT"`
-	RunTest   string   `arg:"--run-test" help:"with --dap, run the named deftest after loading the script (used by the editor's Debug Test)" placeholder:"NAME"`
-	LSP       bool     `arg:"--lsp" help:"start a Language Server Protocol server on stdio (requires -tags debugger)"`
-	LSPListen string   `arg:"--lsp-listen" help:"start an LSP server on the given TCP address (requires -tags debugger)" placeholder:"HOST:PORT"`
-	BatSyntax bool     `arg:"--install-bat-syntax" help:"install the jig/lisp syntax into bat (writes to bat's config dir and rebuilds its cache)"`
-	Script    string   `arg:"positional" help:"lisp script to execute"`
-	Args      []string `arg:"positional" help:"arguments to pass to the script"`
+	Version          bool     `arg:"-v,--version" help:"show version information"`
+	Test             string   `arg:"-t,--test" help:"run the test suite from a directory or a single test file" placeholder:"DIR|FILE"`
+	TestJSON         string   `arg:"--test-json" help:"with --test, also write a JSON report to the given file" placeholder:"FILE"`
+	Coverage         string   `arg:"--coverage" help:"write an lcov coverage report of the executed lisp code (requires -tags debugger)" placeholder:"FILE"`
+	Debug            bool     `arg:"--debug" help:"enable DEBUG-EVAL support (requires -tags debugger)"`
+	Eval             string   `arg:"-e,--eval" help:"evaluate expression and exit" placeholder:"EXPR"`
+	Fmt              bool     `arg:"--fmt" help:"format lisp source (files given as arguments, or stdin) and print the result"`
+	Write            bool     `arg:"-w,--write" help:"with --fmt, rewrite each file in place instead of printing"`
+	Include          []string `arg:"-i,--include,separate" help:"add include directory for require (needs the require library loaded)" placeholder:"DIR"`
+	Integrity        string   `arg:"--integrity" help:"run the script only if it and its repo-local requires match Git REF and HEAD is at REF" placeholder:"REF"`
+	IntegritySigners string   `arg:"--integrity-signers" help:"with --integrity, additionally require REF to be SSH-signed by a key listed in FILE (authorized_keys format)" placeholder:"FILE"`
+	Preamble         []string `arg:"-P,--preamble,separate" help:"define a preamble placeholder for the script, e.g. -P '$NAME <expr>'" placeholder:"ASSIGN"`
+	DAP              bool     `arg:"--dap" help:"start a Debug Adapter Protocol server on stdio (requires -tags debugger)"`
+	DAPListen        string   `arg:"--dap-listen" help:"start a DAP server on the given TCP address (requires -tags debugger)" placeholder:"HOST:PORT"`
+	RunTest          string   `arg:"--run-test" help:"with --dap, run the named deftest after loading the script (used by the editor's Debug Test)" placeholder:"NAME"`
+	LSP              bool     `arg:"--lsp" help:"start a Language Server Protocol server on stdio (requires -tags debugger)"`
+	LSPListen        string   `arg:"--lsp-listen" help:"start an LSP server on the given TCP address (requires -tags debugger)" placeholder:"HOST:PORT"`
+	BatSyntax        bool     `arg:"--install-bat-syntax" help:"install the jig/lisp syntax into bat (writes to bat's config dir and rebuilds its cache)"`
+	Script           string   `arg:"positional" help:"lisp script to execute"`
+	Args             []string `arg:"positional" help:"arguments to pass to the script"`
 }
 
 func (args) Description() string {
@@ -98,6 +100,12 @@ func Execute(cmdArgs []string, repl_env types.EnvType) error {
 
 	if parsedArgs.Eval != "" && (parsedArgs.Version || parsedArgs.Test != "") {
 		return fmt.Errorf("-e cannot be used with --version or --test")
+	}
+
+	// Integrity mode verifies the script (and, in cascade, its
+	// repo-local requires) against a Git ref before anything runs.
+	if err := setupIntegrity(parsedArgs); err != nil {
+		return err
 	}
 
 	// Formatting is a standalone text transformation; it loads no libraries

--- a/command/integrity.go
+++ b/command/integrity.go
@@ -1,0 +1,43 @@
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jig/lisp/lib/integrity"
+	"github.com/jig/lisp/lib/require"
+)
+
+// setupIntegrity validates the --integrity flags and enables integrity
+// mode: the script is verified against the given Git ref before it
+// runs, and the require loader is hooked so every module in the same
+// repository is verified before it is evaluated (modules outside it are
+// refused). No-op when --integrity was not given.
+func setupIntegrity(a args) error {
+	if a.Integrity == "" {
+		if a.IntegritySigners != "" {
+			return fmt.Errorf("--integrity-signers requires --integrity")
+		}
+		return nil
+	}
+	if a.Script == "" || a.Script == "-" {
+		return fmt.Errorf("--integrity requires a script file")
+	}
+	if a.Eval != "" || a.Test != "" || a.Fmt || a.Version || a.BatSyntax ||
+		a.DAP || a.DAPListen != "" || a.LSP || a.LSPListen != "" {
+		return fmt.Errorf("--integrity only runs a script file; it cannot be combined with --eval, --test, --fmt or the server modes")
+	}
+	signers := ""
+	if a.IntegritySigners != "" {
+		b, err := os.ReadFile(a.IntegritySigners)
+		if err != nil {
+			return fmt.Errorf("--integrity-signers: %w", err)
+		}
+		signers = string(b)
+	}
+	if err := integrity.Enable(a.Script, a.Integrity, signers); err != nil {
+		return err
+	}
+	require.VerifyModule = integrity.VerifyFile
+	return nil
+}

--- a/command/integrity.go
+++ b/command/integrity.go
@@ -2,17 +2,19 @@ package command
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
+	"github.com/jig/lisp/lib/core"
 	"github.com/jig/lisp/lib/integrity"
 	"github.com/jig/lisp/lib/require"
 )
 
 // setupIntegrity validates the --integrity flags and enables integrity
 // mode: the script is verified against the given Git ref before it
-// runs, and the require loader is hooked so every module in the same
-// repository is verified before it is evaluated (modules outside it are
-// refused). No-op when --integrity was not given.
+// runs, and the require and load-file loaders are hooked so every file
+// evaluated as code in the same repository is verified first (files
+// outside it are refused). No-op when --integrity was not given.
 func setupIntegrity(a args) error {
 	if a.Integrity == "" {
 		if a.IntegritySigners != "" {
@@ -23,9 +25,9 @@ func setupIntegrity(a args) error {
 	if a.Script == "" || a.Script == "-" {
 		return fmt.Errorf("--integrity requires a script file")
 	}
-	if a.Eval != "" || a.Test != "" || a.Fmt || a.Version || a.BatSyntax ||
+	if a.Eval != "" || a.Test != "" || a.Fmt || a.Version || a.BatSyntax || a.Debug ||
 		a.DAP || a.DAPListen != "" || a.LSP || a.LSPListen != "" {
-		return fmt.Errorf("--integrity only runs a script file; it cannot be combined with --eval, --test, --fmt or the server modes")
+		return fmt.Errorf("--integrity only runs a script file; it cannot be combined with --eval, --test, --fmt, --debug or the server modes")
 	}
 	signers := ""
 	if a.IntegritySigners != "" {
@@ -39,5 +41,13 @@ func setupIntegrity(a args) error {
 		return err
 	}
 	require.VerifyModule = integrity.VerifyFile
+	core.VerifySource = integrity.VerifyFile
+
+	// One structured line to stderr for the operator's audit trail.
+	logAttrs := []any{"ref", integrity.Ref(), "commit", integrity.CommitHash()}
+	if signers != "" {
+		logAttrs = append(logAttrs, "signer", integrity.Signer())
+	}
+	slog.New(slog.NewJSONHandler(os.Stderr, nil)).Info("integrity verified", logAttrs...)
 	return nil
 }

--- a/command/integrity_test.go
+++ b/command/integrity_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core"
 	"github.com/jig/lisp/lib/core/nscore"
 	"github.com/jig/lisp/lib/coreextended/nscoreextended"
 	"github.com/jig/lisp/lib/integrity"
@@ -51,8 +52,11 @@ func gitRepoWithScript(t *testing.T) (dir, hash string) {
 		}
 		return strings.TrimSpace(string(out))
 	}
-	script := "(require \"util\")\n(str (assert-integrity) \" \" (util/hello))\n"
+	script := "(require \"util\")\n(load-file \"extra.lisp\")\n(str (assert-integrity) \" \" (util/hello) \" \" extra-val)\n"
 	if err := os.WriteFile(filepath.Join(dir, "script.lisp"), []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "extra.lisp"), []byte(`(def extra-val "extra")`+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Mkdir(filepath.Join(dir, ".lisp"), 0o755); err != nil {
@@ -70,6 +74,7 @@ func gitRepoWithScript(t *testing.T) (dir, hash string) {
 	t.Cleanup(func() {
 		integrity.Disable()
 		require.VerifyModule = nil
+		core.VerifySource = nil
 	})
 	return dir, hash
 }
@@ -83,8 +88,22 @@ func TestExecuteIntegrityRunsVerifiedScript(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if !strings.Contains(out, hash) || !strings.Contains(out, "hola") {
-		t.Fatalf("output %q: want the commit hash and the module's value", out)
+	if !strings.Contains(out, hash) || !strings.Contains(out, "hola") || !strings.Contains(out, "extra") {
+		t.Fatalf("output %q: want the commit hash, the module's and the load-file's values", out)
+	}
+}
+
+func TestExecuteIntegrityRejectsTamperedLoadFile(t *testing.T) {
+	dir, hash := gitRepoWithScript(t)
+	if err := os.WriteFile(filepath.Join(dir, "extra.lisp"), []byte(`(def extra-val "evil")`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ns := newIntegrityEnv(t)
+	_, err := captureStdout(t, func() error {
+		return Execute([]string{"lisp", "--integrity", hash, "script.lisp"}, ns)
+	})
+	if err == nil || !strings.Contains(err.Error(), "integrity") {
+		t.Fatalf("Execute with tampered load-file target = %v, want integrity error", err)
 	}
 }
 
@@ -122,6 +141,7 @@ func TestExecuteIntegrityFlagValidation(t *testing.T) {
 		{"lisp", "--integrity-signers", "keys.txt", "x.lisp"},    // signers alone
 		{"lisp", "--integrity", "HEAD", "--fmt", "x.lisp"},       // fmt
 		{"lisp", "--integrity", "HEAD", "--test", ".", "x.lisp"}, // test
+		{"lisp", "--integrity", "HEAD", "--debug", "x.lisp"},     // debugger hook
 	} {
 		if err := Execute(cmdline, ns); err == nil {
 			t.Errorf("Execute(%v) did not fail", cmdline)

--- a/command/integrity_test.go
+++ b/command/integrity_test.go
@@ -1,0 +1,130 @@
+package command
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/coreextended/nscoreextended"
+	"github.com/jig/lisp/lib/integrity"
+	"github.com/jig/lisp/lib/integrity/nsintegrity"
+	"github.com/jig/lisp/lib/require"
+	"github.com/jig/lisp/lib/require/nsrequire"
+	"github.com/jig/lisp/types"
+)
+
+// newIntegrityEnv loads the namespaces an --integrity script needs:
+// core, coreextended, require and integrity.
+func newIntegrityEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	for _, load := range []func(types.EnvType) error{
+		nscore.Load, nscore.LoadInput, nscoreextended.Load,
+		nsrequire.Load("lisp"), nsintegrity.Load,
+	} {
+		if err := load(ns); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return ns
+}
+
+// gitRepoWithScript builds a repository containing script.lisp (which
+// requires .lisp/util.lisp and asserts integrity) and returns its dir
+// and HEAD hash. It uses the git CLI, chdirs into the repo (so require
+// resolves `.lisp/` there) and registers cleanup of the integrity
+// globals the Execute call under test mutates.
+func gitRepoWithScript(t *testing.T) (dir, hash string) {
+	t.Helper()
+	dir = t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-c", "user.name=Test", "-c", "user.email=test@example.com"}, args...)...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	script := "(require \"util\")\n(str (assert-integrity) \" \" (util/hello))\n"
+	if err := os.WriteFile(filepath.Join(dir, "script.lisp"), []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, ".lisp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lisp", "util.lisp"), []byte(`(def hello (fn [] "hola"))`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("init", "-q")
+	git("add", "-A")
+	git("commit", "-q", "-m", "first")
+	hash = git("rev-parse", "HEAD")
+
+	t.Chdir(dir)
+	t.Cleanup(func() {
+		integrity.Disable()
+		require.VerifyModule = nil
+	})
+	return dir, hash
+}
+
+func TestExecuteIntegrityRunsVerifiedScript(t *testing.T) {
+	_, hash := gitRepoWithScript(t)
+	ns := newIntegrityEnv(t)
+	out, err := captureStdout(t, func() error {
+		return Execute([]string{"lisp", "--integrity", hash, "script.lisp"}, ns)
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, hash) || !strings.Contains(out, "hola") {
+		t.Fatalf("output %q: want the commit hash and the module's value", out)
+	}
+}
+
+func TestExecuteIntegrityRejectsTamperedModule(t *testing.T) {
+	dir, hash := gitRepoWithScript(t)
+	if err := os.WriteFile(filepath.Join(dir, ".lisp", "util.lisp"), []byte(`(def hello (fn [] "evil"))`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ns := newIntegrityEnv(t)
+	_, err := captureStdout(t, func() error {
+		return Execute([]string{"lisp", "--integrity", hash, "script.lisp"}, ns)
+	})
+	if err == nil || !strings.Contains(err.Error(), "integrity") {
+		t.Fatalf("Execute with tampered module = %v, want integrity error", err)
+	}
+}
+
+func TestExecuteAssertIntegrityWithoutFlag(t *testing.T) {
+	gitRepoWithScript(t)
+	ns := newIntegrityEnv(t)
+	_, err := captureStdout(t, func() error {
+		return Execute([]string{"lisp", "script.lisp"}, ns)
+	})
+	if err == nil || !strings.Contains(err.Error(), "assert-integrity") {
+		t.Fatalf("Execute without --integrity = %v, want assert-integrity throw", err)
+	}
+}
+
+func TestExecuteIntegrityFlagValidation(t *testing.T) {
+	ns := newIntegrityEnv(t)
+	for _, cmdline := range [][]string{
+		{"lisp", "--integrity", "HEAD"},                          // no script
+		{"lisp", "--integrity", "HEAD", "-"},                     // stdin
+		{"lisp", "--integrity", "HEAD", "-e", "1", "x.lisp"},     // eval
+		{"lisp", "--integrity-signers", "keys.txt", "x.lisp"},    // signers alone
+		{"lisp", "--integrity", "HEAD", "--fmt", "x.lisp"},       // fmt
+		{"lisp", "--integrity", "HEAD", "--test", ".", "x.lisp"}, // test
+	} {
+		if err := Execute(cmdline, ns); err == nil {
+			t.Errorf("Execute(%v) did not fail", cmdline)
+		}
+	}
+}

--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -57,7 +57,7 @@ var sectionBlurb = map[string]struct{ title, desc string }{
 	"require":             {"require", "Module loading by name through a search path."},
 	"sql":                 {"sql", "SQL database access."},
 	"cli":                 {"cli", "Command-line option parsing (clojure/tools.cli style)."},
-	"integrity":           {"integrity", "Attest and verify lisp source (formatting, hashing, Ed25519 signatures)."},
+	"integrity":           {"integrity", "Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integrity mode)."},
 }
 
 // entry is one documented symbol.

--- a/examples-integrity/01-basic/service.lisp
+++ b/examples-integrity/01-basic/service.lisp
@@ -1,0 +1,5 @@
+;; Minimal integrity-mode program: assert-integrity throws unless the
+;; interpreter runs under --integrity, and returns the verified commit
+;; hash — so this line both demands the mode and logs the release.
+(println "running release:" (assert-integrity))
+(println "hello from verified code")

--- a/examples-integrity/02-requires/.lisp/util.lisp
+++ b/examples-integrity/02-requires/.lisp/util.lisp
@@ -1,0 +1,1 @@
+(def greet (fn [who] (str "hello, " who " — this module is verified too")))

--- a/examples-integrity/02-requires/service.lisp
+++ b/examples-integrity/02-requires/service.lisp
@@ -1,0 +1,7 @@
+;; The integrity check cascades to code loaded at runtime: this require
+;; resolves to .lisp/util.lisp in the same repository, which must
+;; byte-match its committed blob too. Editing util.lisp without
+;; committing makes this program refuse to start.
+(require "util")
+(assert-integrity)
+(println (util/greet "operator"))

--- a/examples-integrity/03-signed/service.lisp
+++ b/examples-integrity/03-signed/service.lisp
@@ -1,0 +1,4 @@
+;; With --integrity-signers, the ref must carry an SSH signature by a
+;; trusted key: the trust anchor becomes the key list, not the local
+;; repository state. See the README for creating the signed tag.
+(println "running release signed by a trusted key:" (assert-integrity))

--- a/examples-integrity/04-state/service.lisp
+++ b/examples-integrity/04-state/service.lisp
@@ -1,0 +1,12 @@
+;; The .state/ store: state-save writes canonical lisp data and commits
+;; it in the same operation; state-load reads it back as pure data and,
+;; under --integrity, requires it to match its committed version at
+;; HEAD. The state commits do not invalidate the code ref: every
+;; restart uses the same --integrity argument.
+(assert-integrity)
+
+(def db (state-load "db" {:visits 0}))
+(def db (assoc db :visits (+ 1 (get db :visits))))
+(state-save "db" db)
+
+(println "visit number" (get db :visits))

--- a/examples-integrity/README.md
+++ b/examples-integrity/README.md
@@ -1,0 +1,100 @@
+# Integrity mode examples
+
+Mini-examples for the concepts in [INTEGRITY.md](../INTEGRITY.md), one
+directory per concept. Each is a complete program plus the shell
+commands that take it from "files on disk" to "verified run".
+
+**The examples must run in their own repository.** `--integrity`
+verifies against the Git repository *enclosing the script* — run in
+place, that would be jig/lisp itself. Copy an example into a fresh
+directory and follow its steps, or run the whole tour non-interactively:
+
+```bash
+./demo.sh                 # uses `lisp` from PATH
+LISP=/path/to/lisp ./demo.sh
+```
+
+`demo.sh` replays every walkthrough below in throwaway repositories,
+including the failure cases, and is kept runnable as a living check of
+this documentation.
+
+## 01-basic — verify a script against a ref
+
+`assert-integrity` makes the program refuse to run unverified.
+
+```bash
+cp 01-basic/service.lisp /tmp/demo && cd /tmp/demo
+git init && git add -A && git commit -m "release" && git tag v1
+
+lisp --integrity v1 service.lisp     # ✓ runs, prints the commit hash
+lisp service.lisp                    # ✗ assert-integrity throws
+echo ";; patched" >> service.lisp
+lisp --integrity v1 service.lisp     # ✗ differs from its committed version
+```
+
+A commit hash works exactly like the tag: `lisp --integrity $(git
+rev-parse v1) service.lisp`.
+
+## 02-requires — the check cascades to required modules
+
+`require` resolves `util` to `.lisp/util.lisp` in the same repository;
+under `--integrity` the module must match its committed blob too, and
+modules resolving *outside* the repository are refused.
+
+```bash
+cp -r 02-requires/. /tmp/demo && cd /tmp/demo
+git init && git add -A && git commit -m "release" && git tag v1
+
+lisp --integrity v1 service.lisp     # ✓ script and module verified
+echo "(def evil 1)" >> .lisp/util.lisp
+lisp --integrity v1 service.lisp     # ✗ util.lisp differs
+```
+
+The same cascade covers `load-file`/`load-file-once` targets.
+
+## 03-signed — trust a key, not the local repository
+
+An SSH-signed tag plus `--integrity-signers` upgrades the guarantee
+from "matches this repository" to "matches what a trusted key
+released" — it survives cloning the repository elsewhere.
+
+```bash
+cp 03-signed/service.lisp /tmp/demo && cd /tmp/demo
+git init && git add -A && git commit -m "release"
+
+ssh-keygen -t ed25519 -f release-key -N "" -C "release@example.com"
+git -c gpg.format=ssh -c user.signingkey=./release-key tag -s v1 -m "signed release"
+
+# The signers file is authorized_keys format — the .pub file as is.
+# In production it lives OUTSIDE the repository (e.g. /etc/lisp/).
+lisp --integrity v1 --integrity-signers release-key.pub service.lisp   # ✓
+
+ssh-keygen -t ed25519 -f other-key -N ""
+lisp --integrity v1 --integrity-signers other-key.pub service.lisp     # ✗ no allowed key matches
+git tag -d v1 && git tag v1                                            # re-tag, unsigned
+lisp --integrity v1 --integrity-signers release-key.pub service.lisp   # ✗ tag is not signed
+```
+
+## 04-state — persistent state inside the integrity envelope
+
+`state-save` writes `.state/db.lisp` as canonical lisp data and
+commits it in the same operation; `state-load` reads it back as pure
+data and requires it to match `HEAD`. The state commits are accepted
+by the startup check, so **every restart uses the same ref**:
+
+```bash
+cp 04-state/service.lisp /tmp/demo && cd /tmp/demo
+git init && git add -A && git commit -m "release" && git tag v1
+
+lisp --integrity v1 service.lisp     # visit number 1
+lisp --integrity v1 service.lisp     # visit number 2  (same ref!)
+lisp --integrity v1 service.lisp     # visit number 3
+git log --oneline                    # release + three "state: db" commits
+
+echo "{:visits 999}" > .state/db.lisp
+lisp --integrity v1 service.lisp     # ✗ differs from its committed version at HEAD
+git checkout .state/db.lisp          # operator resolves; runs again
+```
+
+A commit touching anything outside `.state/` after the ref invalidates
+the run — code changes always require a new release ref.

--- a/examples-integrity/demo.sh
+++ b/examples-integrity/demo.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Replays every walkthrough of README.md in throwaway repositories,
+# failure cases included. A living check that the examples work as
+# documented. Usage: ./demo.sh  (or LISP=/path/to/lisp ./demo.sh)
+set -euo pipefail
+
+LISP=${LISP:-lisp}
+HERE=$(cd "$(dirname "$0")" && pwd)
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+step() { printf '\n\033[1m== %s ==\033[0m\n' "$*"; }
+ok()   { printf '✓ %s\n' "$*"; }
+must_fail() { # must_fail <description> -- <command...>
+	local desc=$1; shift 2
+	if "$@" >/dev/null 2>&1; then
+		printf '✗ expected failure but succeeded: %s\n' "$desc" >&2; exit 1
+	fi
+	ok "refused as expected: $desc"
+}
+
+repo() { # repo <example-dir> → sets up $WORK/<example-dir> as a fresh tagged repo and cds into it
+	local dir="$WORK/$1"
+	mkdir -p "$dir"
+	cp -r "$HERE/$1/." "$dir/"
+	cd "$dir"
+	git init -q
+	git add -A
+	git -c user.name=Demo -c user.email=demo@example.com commit -qm "release"
+	git tag v1
+}
+
+step "01-basic: verify a script against a ref"
+repo 01-basic
+$LISP --integrity v1 service.lisp
+$LISP --integrity "$(git rev-parse v1)" service.lisp >/dev/null
+ok "a commit hash works like the tag"
+must_fail "running without --integrity (assert-integrity throws)" -- $LISP service.lisp
+echo ";; patched" >> service.lisp
+must_fail "script modified after the release" -- $LISP --integrity v1 service.lisp
+
+step "02-requires: the check cascades to required modules"
+repo 02-requires
+$LISP --integrity v1 service.lisp
+echo "(def evil 1)" >> .lisp/util.lisp
+must_fail "module modified after the release" -- $LISP --integrity v1 service.lisp
+
+step "03-signed: trust a key, not the local repository"
+repo 03-signed
+git tag -d v1 >/dev/null
+ssh-keygen -q -t ed25519 -f release-key -N "" -C "release@example.com"
+git -c user.name=Demo -c user.email=demo@example.com \
+    -c gpg.format=ssh -c user.signingkey=./release-key tag -s v1 -m "signed release"
+$LISP --integrity v1 --integrity-signers release-key.pub service.lisp
+ssh-keygen -q -t ed25519 -f other-key -N ""
+must_fail "signed by a key not in the signers file" -- \
+	$LISP --integrity v1 --integrity-signers other-key.pub service.lisp
+git tag -d v1 >/dev/null && git tag v1
+must_fail "unsigned tag with --integrity-signers" -- \
+	$LISP --integrity v1 --integrity-signers release-key.pub service.lisp
+
+step "04-state: persistent state inside the integrity envelope"
+repo 04-state
+$LISP --integrity v1 service.lisp
+$LISP --integrity v1 service.lisp
+$LISP --integrity v1 service.lisp
+[ "$(git log --oneline | grep -c 'state: db')" -eq 3 ] && ok "three state commits, same ref throughout"
+echo "{:visits 999}" > .state/db.lisp
+must_fail "state file edited out of band" -- $LISP --integrity v1 service.lisp
+git checkout -- .state/db.lisp
+$LISP --integrity v1 service.lisp >/dev/null
+ok "operator restored the state; runs again"
+
+step "all examples behaved as documented"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alexflint/go-arg v1.6.1
 	github.com/chzyer/readline v1.5.1
 	github.com/davecgh/go-spew v1.1.1
+	github.com/go-git/go-billy/v6 v6.0.0-alpha.1
 	github.com/go-git/go-git/v6 v6.0.0-alpha.4
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
@@ -27,7 +28,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg/v2 v2.0.2 // indirect
-	github.com/go-git/go-billy/v6 v6.0.0-alpha.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -299,6 +299,7 @@ func drop_last(n int, arg MalType) (MalType, error) {
 
 func LoadInput(env EnvType) {
 	call.Call(env, slurp)
+	call.Call(env, slurp_source)
 	call.Call(env, spit, 2, 4)
 	call.Call(env, readLine)
 	call.CallOverrideFN(env, "read-password", readPassword)
@@ -494,6 +495,33 @@ func println(a ...MalType) (MalType, error) {
 func printNoNewline(a ...MalType) (MalType, error) {
 	fmt.Print(printer.Pr_list(a, false, "", "", " "))
 	return nil, nil
+}
+
+// VerifySource, when non-nil, vets a source file before load-file (via
+// slurp-source) evaluates it; a non-nil error aborts the load. The
+// command package installs it when running under --integrity, so code
+// loaded at runtime is verified like the script and its requires.
+// slurp itself is never hooked: it reads data, not code.
+var VerifySource func(absPath string, content []byte) error
+
+// slurp_source is slurp for files that will be evaluated as code:
+// identical, except that under --integrity the content is verified
+// against the pinned commit. load-file builds on it.
+func slurp_source(fileName string) (MalType, error) {
+	v, err := slurp(fileName)
+	if err != nil {
+		return nil, err
+	}
+	if VerifySource != nil {
+		abs, err := filepath.Abs(fileName)
+		if err != nil {
+			return nil, err
+		}
+		if err := VerifySource(abs, []byte(v.(string))); err != nil {
+			return nil, err
+		}
+	}
+	return v, nil
 }
 
 func slurp(fileName string) (MalType, error) {

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -28,6 +28,7 @@ func loadInputDocs(env EnvType) {
 
 var inputDocs = []struct{ name, arglist, doc string }{
 	{"slurp", "[filename]", "Reads a file and returns its contents as a string."},
+	{"slurp-source", "[filename]", "Reads a source file like slurp and, under --integrity, verifies it against the pinned commit; load-file builds on it."},
 	{"spit", "[filename s & opts]", "Writes string s to a file, creating or truncating it; with :append true, appends instead."},
 	{"readline", "[prompt]", "Prints prompt and reads a line from input."},
 	{"read-password", "[prompt]", "Prints prompt (to stderr) and reads a line with terminal echo disabled; falls back to a plain read when input is not a terminal. Returns nil on end of input."},

--- a/lib/core/header-load-file.lisp
+++ b/lib/core/header-load-file.lisp
@@ -3,7 +3,7 @@
 (defn load-file
     "Reads and evaluates the lisp file at file-path in the current environment; returns the value of its last form."
     [file-path]
-    (eval (read-program (slurp file-path) file-path)))
+    (eval (read-program (slurp-source file-path) file-path)))
 
 ;; load-file-once is registered in Go by nscore.LoadInput: its seen-set
 ;; needs mutable state, and atoms live in the concurrent library, which

--- a/lib/git/sign.go
+++ b/lib/git/sign.go
@@ -177,30 +177,47 @@ func gitVerifyTag(rv MalType, name string, allowedKeys string) (MalType, error) 
 
 // VerifyCommitSSH checks that commit c carries an SSH signature made by
 // one of the allowed public keys (authorized_keys-format lines, as
-// git-verify-commit). Exported for the integrity mode of the CLI.
-func VerifyCommitSSH(c *object.Commit, allowedKeys string) error {
+// git-verify-commit) and returns the matching key's comment. Exported
+// for the integrity mode of the CLI.
+func VerifyCommitSSH(c *object.Commit, allowedKeys string) (signer string, err error) {
 	armored := c.SignatureSHA256
 	if armored == "" {
 		armored = c.Signature
 	}
 	if armored == "" {
-		return fmt.Errorf("commit %s is not signed", c.Hash)
+		return "", fmt.Errorf("commit %s is not signed", c.Hash)
 	}
-	_, err := verifySignature(c, armored, allowedKeys)
-	return err
+	v, err := verifySignature(c, armored, allowedKeys)
+	if err != nil {
+		return "", err
+	}
+	return signerOf(v), nil
 }
 
 // VerifyTagSSH is VerifyCommitSSH for annotated tag objects.
-func VerifyTagSSH(tag *object.Tag, allowedKeys string) error {
+func VerifyTagSSH(tag *object.Tag, allowedKeys string) (signer string, err error) {
 	armored := tag.SignatureSHA256
 	if armored == "" {
 		armored = tag.Signature
 	}
 	if armored == "" {
-		return fmt.Errorf("tag %q is not signed", tag.Name)
+		return "", fmt.Errorf("tag %q is not signed", tag.Name)
 	}
-	_, err := verifySignature(tag, armored, allowedKeys)
-	return err
+	v, err := verifySignature(tag, armored, allowedKeys)
+	if err != nil {
+		return "", err
+	}
+	return signerOf(v), nil
+}
+
+// signerOf extracts the :signer comment from a verifySignature result.
+func signerOf(v MalType) string {
+	m, ok := v.(HashMap)
+	if !ok {
+		return ""
+	}
+	s, _ := m.Val[NewKeyword("signer")].(string)
+	return s
 }
 
 // verifySignature checks the armored SSH signature of a commit or tag

--- a/lib/git/sign.go
+++ b/lib/git/sign.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/hiddeco/sshsig"
 	gossh "golang.org/x/crypto/ssh"
 
@@ -172,6 +173,34 @@ func gitVerifyTag(rv MalType, name string, allowedKeys string) (MalType, error) 
 		return nil, fmt.Errorf("git-verify-tag: tag %q is not signed", name)
 	}
 	return verifySignature(tag, armored, allowedKeys)
+}
+
+// VerifyCommitSSH checks that commit c carries an SSH signature made by
+// one of the allowed public keys (authorized_keys-format lines, as
+// git-verify-commit). Exported for the integrity mode of the CLI.
+func VerifyCommitSSH(c *object.Commit, allowedKeys string) error {
+	armored := c.SignatureSHA256
+	if armored == "" {
+		armored = c.Signature
+	}
+	if armored == "" {
+		return fmt.Errorf("commit %s is not signed", c.Hash)
+	}
+	_, err := verifySignature(c, armored, allowedKeys)
+	return err
+}
+
+// VerifyTagSSH is VerifyCommitSSH for annotated tag objects.
+func VerifyTagSSH(tag *object.Tag, allowedKeys string) error {
+	armored := tag.SignatureSHA256
+	if armored == "" {
+		armored = tag.Signature
+	}
+	if armored == "" {
+		return fmt.Errorf("tag %q is not signed", tag.Name)
+	}
+	_, err := verifySignature(tag, armored, allowedKeys)
+	return err
 }
 
 // verifySignature checks the armored SSH signature of a commit or tag

--- a/lib/integrity/README.md
+++ b/lib/integrity/README.md
@@ -18,6 +18,8 @@ mode](#integrity-mode---integrity) (`lisp --integrity <ref>`).
 | `(ed25519-sign private s)` | base64 signature of `s` |
 | `(ed25519-verify public s signature)` | `true` or `false` |
 | `(assert-integrity)` | the verified commit hash; **throws** unless running under `--integrity` |
+| `(state-save name value)` | writes `value` as canonical lisp data to `.state/name.lisp` and commits it; returns the commit hash |
+| `(state-load name & [default])` | the state read back as pure data (READ, never EVAL); `default` (or throws) when absent |
 
 Ed25519 signing is deterministic: the same key and message always yield
 the same signature bytes, so signatures are reproducible and
@@ -41,15 +43,21 @@ diff-friendly.
 if* it matches what is committed in its enclosing Git repository at
 `<ref>` (a commit hash, tag or branch):
 
-1. `HEAD` must be exactly the commit `<ref>` resolves to;
+1. `HEAD` must be exactly the commit `<ref>` resolves to, or a linear
+   chain of `.state/`-only commits above it (the ones `state-save`
+   creates), so the same ref stays valid across restarts;
 2. the script must byte-match the blob committed at `<ref>`;
-3. in cascade, every module loaded with `require` must resolve inside
-   the same repository and byte-match its committed blob — a module
-   resolving outside the repository (an `-i` directory elsewhere,
+3. in cascade, every file evaluated as code — `require` modules and
+   `load-file`/`load-file-once` targets — must resolve inside the same
+   repository and byte-match its committed blob; a file resolving
+   outside the repository (an `-i` directory elsewhere,
    `~/.config/lisp/`, …) is refused.
 
 `(assert-integrity)` lets committed code demand the mode: it throws
 unless the run is verified, and returns the verified commit hash.
+`state-save`/`state-load` give a verified program a way to persist
+state without leaving the integrity envelope (see
+[INTEGRITY.md](../../INTEGRITY.md), the full specification).
 
 With `--integrity-signers FILE` the ref must additionally carry an SSH
 signature made by one of the public keys in `FILE` (authorized_keys
@@ -62,9 +70,9 @@ What integrity mode is — and is not: it is an operational assurance
 for the operator launching the script (no accidental drift, no
 uncommitted edits, optionally "signed by a trusted key"). It is not a
 security boundary against an attacker who can rewrite the repository,
-the signers file or the `lisp` binary. Files the verified code loads
-outside `require` (`load-file`, `slurp` + `eval`) are not covered, and
-uncommitted files that are never interpreted do not affect the check.
+the signers file or the `lisp` binary. `eval` over strings obtained by
+other means (`slurp`, network) is not covered, and uncommitted files
+that are never interpreted do not affect the check.
 
 ## Loading
 

--- a/lib/integrity/README.md
+++ b/lib/integrity/README.md
@@ -5,6 +5,9 @@ hashing and digital signatures. Typical use: compute a stable digest of
 a `.lisp` file (formatting first, so cosmetic layout differences do not
 change the digest) and sign or verify it.
 
+The package also implements the interpreter's [integrity
+mode](#integrity-mode---integrity) (`lisp --integrity <ref>`).
+
 ## Functions
 
 | Function | Returns |
@@ -14,6 +17,7 @@ change the digest) and sign or verify it.
 | `(ed25519-generate)` | key pair `{:public "…" :private "…"}`, base64 |
 | `(ed25519-sign private s)` | base64 signature of `s` |
 | `(ed25519-verify public s signature)` | `true` or `false` |
+| `(assert-integrity)` | the verified commit hash; **throws** unless running under `--integrity` |
 
 Ed25519 signing is deterministic: the same key and message always yield
 the same signature bytes, so signatures are reproducible and
@@ -31,6 +35,37 @@ diff-friendly.
 (ed25519-verify (get keys :public) digest signature) ;; => true
 ```
 
+## Integrity mode (--integrity)
+
+`lisp --integrity <ref> script.lisp` runs `script.lisp` *if and only
+if* it matches what is committed in its enclosing Git repository at
+`<ref>` (a commit hash, tag or branch):
+
+1. `HEAD` must be exactly the commit `<ref>` resolves to;
+2. the script must byte-match the blob committed at `<ref>`;
+3. in cascade, every module loaded with `require` must resolve inside
+   the same repository and byte-match its committed blob — a module
+   resolving outside the repository (an `-i` directory elsewhere,
+   `~/.config/lisp/`, …) is refused.
+
+`(assert-integrity)` lets committed code demand the mode: it throws
+unless the run is verified, and returns the verified commit hash.
+
+With `--integrity-signers FILE` the ref must additionally carry an SSH
+signature made by one of the public keys in `FILE` (authorized_keys
+format, one key per line, as `git-verify-commit`): the tag signature
+for annotated tags, the commit signature otherwise. The trust anchor
+then becomes the key list instead of the local repository state, so
+verification survives cloning the repository elsewhere.
+
+What integrity mode is — and is not: it is an operational assurance
+for the operator launching the script (no accidental drift, no
+uncommitted edits, optionally "signed by a trusted key"). It is not a
+security boundary against an attacker who can rewrite the repository,
+the signers file or the `lisp` binary. Files the verified code loads
+outside `require` (`load-file`, `slurp` + `eval`) are not covered, and
+uncommitted files that are never interpreted do not affect the check.
+
 ## Loading
 
 Go embedders load the namespace with:
@@ -41,5 +76,7 @@ import "github.com/jig/lisp/lib/integrity/nsintegrity"
 nsintegrity.Load(env)
 ```
 
-The library has no dependencies beyond `core` (the example above uses
-`slurp` and `get` from core). The `lisp` binary loads it by default.
+The lisp-level functions have no dependencies beyond `core` (the
+example above uses `slurp` and `get` from core); the integrity mode
+machinery builds on go-git and `lib/git`'s SSH signature verification.
+The `lisp` binary loads the namespace by default.

--- a/lib/integrity/integrity.go
+++ b/lib/integrity/integrity.go
@@ -9,6 +9,12 @@
 // produce the same signature bytes, so signatures are reproducible and
 // diff-friendly. Keys and signatures are exchanged as standard base64
 // strings; digests as lowercase hex.
+//
+// The package also implements the interpreter's integrity mode
+// (`lisp --integrity <ref>`, see mode.go), which runs a script if and
+// only if it — and, in cascade, its repo-local requires — match what is
+// committed in its Git repository at <ref>; the (assert-integrity)
+// builtin lets a script demand that mode.
 package integrity
 
 import (
@@ -32,6 +38,7 @@ func Load(env EnvType) {
 	call.Call(env, ed25519_generate)
 	call.Call(env, ed25519_sign)
 	call.Call(env, ed25519_verify)
+	call.Call(env, assert_integrity)
 
 	call.Doc(env, "fmt", "[s]",
 		"Formats lisp source s into its canonical form (as lisp --fmt does); errors if s does not parse.")
@@ -43,6 +50,15 @@ func Load(env EnvType) {
 		"Signs string s with a base64 Ed25519 private key; returns the base64 signature (deterministic).")
 	call.Doc(env, "ed25519-verify", "[public s signature]",
 		"Reports whether the base64 signature of string s verifies against the base64 Ed25519 public key.")
+	call.Doc(env, "assert-integrity", "[]",
+		"Throws unless the interpreter runs under --integrity; returns the verified commit hash.")
+}
+
+func assert_integrity() (string, error) {
+	if !Active() {
+		return "", fmt.Errorf("assert-integrity: source integrity is not verified (run with --integrity <ref>)")
+	}
+	return CommitHash(), nil
 }
 
 func fmtSource(s string) (string, error) {

--- a/lib/integrity/integrity.go
+++ b/lib/integrity/integrity.go
@@ -39,6 +39,8 @@ func Load(env EnvType) {
 	call.Call(env, ed25519_sign)
 	call.Call(env, ed25519_verify)
 	call.Call(env, assert_integrity)
+	call.Call(env, state_save)
+	call.Call(env, state_load, 1, 2)
 
 	call.Doc(env, "fmt", "[s]",
 		"Formats lisp source s into its canonical form (as lisp --fmt does); errors if s does not parse.")
@@ -52,6 +54,10 @@ func Load(env EnvType) {
 		"Reports whether the base64 signature of string s verifies against the base64 Ed25519 public key.")
 	call.Doc(env, "assert-integrity", "[]",
 		"Throws unless the interpreter runs under --integrity; returns the verified commit hash.")
+	call.Doc(env, "state-save", "[name value]",
+		"Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. Under --integrity the commit keeps the verified ref valid.")
+	call.Doc(env, "state-load", "[name & [default]]",
+		"Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under --integrity the file must match its committed version at HEAD.")
 }
 
 func assert_integrity() (string, error) {

--- a/lib/integrity/mode.go
+++ b/lib/integrity/mode.go
@@ -36,8 +36,10 @@ import (
 
 // modeState is the pinned verification context of an --integrity run.
 type modeState struct {
+	repo     *gogit.Repository
 	repoRoot string
 	ref      string
+	signer   string
 	commit   *object.Commit
 	tree     *object.Tree
 }
@@ -56,6 +58,23 @@ func CommitHash() string {
 		return ""
 	}
 	return mode.commit.Hash.String()
+}
+
+// Ref returns the ref --integrity was given, or "" when inactive.
+func Ref() string {
+	if mode == nil {
+		return ""
+	}
+	return mode.ref
+}
+
+// Signer returns the comment of the allowed key that signed the
+// verified ref, or "" when inactive or no signers were required.
+func Signer() string {
+	if mode == nil {
+		return ""
+	}
+	return mode.signer
 }
 
 // Disable turns integrity mode off. Exported for tests.
@@ -103,11 +122,18 @@ func Enable(scriptPath, ref, allowedSigners string) error {
 		return fmt.Errorf("integrity: %w", err)
 	}
 	if head.Hash() != commit.Hash {
-		return fmt.Errorf("integrity: HEAD is at %s, not at %q (%s)", head.Hash(), ref, commit.Hash)
+		// HEAD may sit above the ref: state-save commits its writes,
+		// moving HEAD, and the code ref stays valid across restarts as
+		// long as every commit in between touches only .state/.
+		if err := verifyStateOnlyDescent(repo, head.Hash(), commit.Hash); err != nil {
+			return fmt.Errorf("integrity: HEAD is at %s, not at %q (%s): %w", head.Hash(), ref, commit.Hash, err)
+		}
 	}
 
+	signer := ""
 	if allowedSigners != "" {
-		if err := verifyRefSignature(repo, ref, tag, commit, allowedSigners); err != nil {
+		signer, err = verifyRefSignature(repo, ref, tag, commit, allowedSigners)
+		if err != nil {
 			return fmt.Errorf("integrity: %w", err)
 		}
 	}
@@ -116,7 +142,7 @@ func Enable(scriptPath, ref, allowedSigners string) error {
 	if err != nil {
 		return fmt.Errorf("integrity: %w", err)
 	}
-	m := &modeState{repoRoot: root, ref: ref, commit: commit, tree: tree}
+	m := &modeState{repo: repo, repoRoot: root, ref: ref, signer: signer, commit: commit, tree: tree}
 	content, err := os.ReadFile(abs)
 	if err != nil {
 		return fmt.Errorf("integrity: %w", err)
@@ -130,8 +156,9 @@ func Enable(scriptPath, ref, allowedSigners string) error {
 
 // verifyRefSignature requires ref to be SSH-signed by an allowed key:
 // the tag signature when ref is an annotated tag, the commit signature
-// otherwise (plain commits, branches and lightweight tags).
-func verifyRefSignature(repo *gogit.Repository, ref string, tag *object.Tag, commit *object.Commit, allowedSigners string) error {
+// otherwise (plain commits, branches and lightweight tags). It returns
+// the signing key's comment.
+func verifyRefSignature(repo *gogit.Repository, ref string, tag *object.Tag, commit *object.Commit, allowedSigners string) (string, error) {
 	if tag == nil {
 		// ResolveRevision may already have peeled an annotated tag
 		// named ref to its commit; look the tag object up explicitly
@@ -146,6 +173,46 @@ func verifyRefSignature(repo *gogit.Repository, ref string, tag *object.Tag, com
 		return libgit.VerifyTagSSH(tag, allowedSigners)
 	}
 	return libgit.VerifyCommitSSH(commit, allowedSigners)
+}
+
+// verifyStateOnlyDescent checks that ref is an ancestor of head through
+// a linear chain of commits that touch only .state/ paths — the commits
+// state-save creates. Any other divergence is an error.
+func verifyStateOnlyDescent(repo *gogit.Repository, head, ref plumbing.Hash) error {
+	cur, err := repo.CommitObject(head)
+	if err != nil {
+		return err
+	}
+	for cur.Hash != ref {
+		if cur.NumParents() != 1 {
+			return fmt.Errorf("commit %s is not part of a linear state-only descent from the ref", cur.Hash)
+		}
+		parent, err := cur.Parent(0)
+		if err != nil {
+			return err
+		}
+		curTree, err := cur.Tree()
+		if err != nil {
+			return err
+		}
+		parentTree, err := parent.Tree()
+		if err != nil {
+			return err
+		}
+		changes, err := object.DiffTree(parentTree, curTree)
+		if err != nil {
+			return err
+		}
+		for _, ch := range changes {
+			for _, name := range []string{ch.From.Name, ch.To.Name} {
+				if name != "" && !strings.HasPrefix(name, stateDir+"/") {
+					return fmt.Errorf("commit %s modifies %s outside %s/", cur.Hash, name, stateDir)
+				}
+			}
+		}
+		cur = parent
+	}
+	return nil
 }
 
 // VerifyFile checks that absPath lies inside the verified repository

--- a/lib/integrity/mode.go
+++ b/lib/integrity/mode.go
@@ -1,0 +1,179 @@
+package integrity
+
+// This file implements integrity mode (`lisp --integrity <ref>`): the
+// interpreter runs a script if and only if it matches what is committed
+// in its Git repository at <ref>.
+//
+// Enable pins <ref> (a commit hash, tag or branch), requires HEAD to be
+// exactly that commit, and byte-compares the script against the blob
+// committed at it. The command package then installs VerifyFile as the
+// require loader's vetting hook, so the check cascades: every module a
+// verified script requires must live in the same repository and match
+// its committed blob too; anything outside the repository is refused.
+// With an allowed-signers file, Enable additionally requires <ref> to
+// carry an SSH signature by one of the listed keys (the tag's signature
+// for annotated tags, the commit's otherwise), turning the guarantee
+// from "matches the local repository" into "matches what a trusted key
+// released".
+//
+// This is an operational assurance for the operator launching the
+// script — no accidental drift, no uncommitted edits — not a security
+// boundary against an attacker who can already write to the repository
+// or replace the binary. Code the verified script chooses to load
+// outside the require mechanism (load-file, slurp+eval) is not covered.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	gogit "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	libgit "github.com/jig/lisp/lib/git"
+)
+
+// modeState is the pinned verification context of an --integrity run.
+type modeState struct {
+	repoRoot string
+	ref      string
+	commit   *object.Commit
+	tree     *object.Tree
+}
+
+// mode is nil when the interpreter does not run under --integrity. It
+// is written once by Enable before any lisp code is evaluated and only
+// read afterwards.
+var mode *modeState
+
+// Active reports whether the interpreter runs under --integrity.
+func Active() bool { return mode != nil }
+
+// CommitHash returns the verified commit hash, or "" when inactive.
+func CommitHash() string {
+	if mode == nil {
+		return ""
+	}
+	return mode.commit.Hash.String()
+}
+
+// Disable turns integrity mode off. Exported for tests.
+func Disable() { mode = nil }
+
+// Enable verifies scriptPath against ref in its enclosing Git
+// repository and turns integrity mode on. allowedSigners, when
+// non-empty, holds authorized_keys-format public keys and makes Enable
+// additionally require ref to be SSH-signed by one of them.
+func Enable(scriptPath, ref, allowedSigners string) error {
+	abs, err := filepath.Abs(scriptPath)
+	if err != nil {
+		return fmt.Errorf("integrity: %w", err)
+	}
+	repo, err := gogit.PlainOpenWithOptions(filepath.Dir(abs), &gogit.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		return fmt.Errorf("integrity: %s is not inside a git repository", abs)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		return fmt.Errorf("integrity: %w", err)
+	}
+	root := wt.Filesystem().Root()
+
+	hash, err := repo.ResolveRevision(plumbing.Revision(ref))
+	if err != nil {
+		return fmt.Errorf("integrity: cannot resolve %q: %w", ref, err)
+	}
+	// An annotated tag resolves to the tag object; peel it to its
+	// target commit and keep it for the signature check.
+	tag, err := repo.TagObject(*hash)
+	commitHash := *hash
+	if err == nil {
+		commitHash = tag.Target
+	} else {
+		tag = nil
+	}
+	commit, err := repo.CommitObject(commitHash)
+	if err != nil {
+		return fmt.Errorf("integrity: %q does not resolve to a commit: %w", ref, err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		return fmt.Errorf("integrity: %w", err)
+	}
+	if head.Hash() != commit.Hash {
+		return fmt.Errorf("integrity: HEAD is at %s, not at %q (%s)", head.Hash(), ref, commit.Hash)
+	}
+
+	if allowedSigners != "" {
+		if err := verifyRefSignature(repo, ref, tag, commit, allowedSigners); err != nil {
+			return fmt.Errorf("integrity: %w", err)
+		}
+	}
+
+	tree, err := commit.Tree()
+	if err != nil {
+		return fmt.Errorf("integrity: %w", err)
+	}
+	m := &modeState{repoRoot: root, ref: ref, commit: commit, tree: tree}
+	content, err := os.ReadFile(abs)
+	if err != nil {
+		return fmt.Errorf("integrity: %w", err)
+	}
+	if err := m.verify(abs, content); err != nil {
+		return err
+	}
+	mode = m
+	return nil
+}
+
+// verifyRefSignature requires ref to be SSH-signed by an allowed key:
+// the tag signature when ref is an annotated tag, the commit signature
+// otherwise (plain commits, branches and lightweight tags).
+func verifyRefSignature(repo *gogit.Repository, ref string, tag *object.Tag, commit *object.Commit, allowedSigners string) error {
+	if tag == nil {
+		// ResolveRevision may already have peeled an annotated tag
+		// named ref to its commit; look the tag object up explicitly
+		// so its signature — not the commit's — is what gets checked.
+		if tref, err := repo.Reference(plumbing.NewTagReferenceName(ref), true); err == nil {
+			if t, err := repo.TagObject(tref.Hash()); err == nil {
+				tag = t
+			}
+		}
+	}
+	if tag != nil {
+		return libgit.VerifyTagSSH(tag, allowedSigners)
+	}
+	return libgit.VerifyCommitSSH(commit, allowedSigners)
+}
+
+// VerifyFile checks that absPath lies inside the verified repository
+// and that content matches the blob committed at the pinned ref. It is
+// a no-op when integrity mode is off; the command package installs it
+// as the require loader's vetting hook.
+func VerifyFile(absPath string, content []byte) error {
+	if mode == nil {
+		return nil
+	}
+	return mode.verify(absPath, content)
+}
+
+func (m *modeState) verify(absPath string, content []byte) error {
+	rel, err := filepath.Rel(m.repoRoot, absPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("integrity: %s is outside the verified repository %s", absPath, m.repoRoot)
+	}
+	f, err := m.tree.File(filepath.ToSlash(rel))
+	if err != nil {
+		return fmt.Errorf("integrity: %s is not committed at %q (%s)", absPath, m.ref, m.commit.Hash)
+	}
+	committed, err := f.Contents()
+	if err != nil {
+		return fmt.Errorf("integrity: %w", err)
+	}
+	if committed != string(content) {
+		return fmt.Errorf("integrity: %s differs from its committed version at %q (%s)", absPath, m.ref, m.commit.Hash)
+	}
+	return nil
+}

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -1,0 +1,260 @@
+package integrity_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/git/nsgit"
+	"github.com/jig/lisp/lib/integrity"
+	"github.com/jig/lisp/lib/integrity/nsintegrity"
+	"github.com/jig/lisp/types"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+const author = `{:name "Test" :email "test@example.com"}`
+
+// newGitEnv loads core plus the git and integrity namespaces.
+func newGitEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	for _, load := range []func(types.EnvType) error{nscore.Load, nscore.LoadInput, nsgit.Load, nsintegrity.Load} {
+		if err := load(ns); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return ns
+}
+
+func evalLisp(t *testing.T, ns types.EnvType, src string) types.MalType {
+	t.Helper()
+	ast, err := lisp.READ(src, types.NewCursorFile(t.Name()), ns)
+	if err != nil {
+		t.Fatalf("READ %s: %v", src, err)
+	}
+	v, err := lisp.EVAL(context.Background(), ast, ns)
+	if err != nil {
+		t.Fatalf("EVAL %s: %v", src, err)
+	}
+	return v
+}
+
+// testKey generates an ed25519 key pair, returning the OpenSSH private
+// key PEM and the authorized_keys line.
+func testKey(t *testing.T, comment string) (privPEM, authorized string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := gossh.MarshalPrivateKey(priv, comment)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sshPub, err := gossh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := strings.TrimSpace(string(gossh.MarshalAuthorizedKey(sshPub)))
+	if comment != "" {
+		line += " " + comment
+	}
+	return string(pem.EncodeToMemory(block)), line
+}
+
+// setupRepo creates a repository holding script.lisp and .lisp/util.lisp,
+// commits both (with commitOpts merged into the git-commit options) and
+// returns the repo dir and the commit hash. The lisp variable r remains
+// bound to the open repo.
+func setupRepo(t *testing.T, ns types.EnvType, commitOpts string) (dir, hash string) {
+	t.Helper()
+	dir = t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "script.lisp"), []byte("(assert-integrity)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, ".lisp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lisp", "util.lisp"), []byte(`(def hello (fn [] "hola"))`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	evalLisp(t, ns, fmt.Sprintf(`(def r (git-init %q))`, dir))
+	evalLisp(t, ns, `(git-add r "script.lisp")`)
+	evalLisp(t, ns, `(git-add r ".lisp/util.lisp")`)
+	h, ok := evalLisp(t, ns, `(get (git-commit r "first" {:author `+author+` `+commitOpts+`}) :hash)`).(string)
+	if !ok {
+		t.Fatal("git-commit did not return a hash")
+	}
+	return dir, h
+}
+
+// enable calls integrity.Enable and registers cleanup of the global mode.
+func enable(t *testing.T, script, ref, signers string) error {
+	t.Helper()
+	t.Cleanup(integrity.Disable)
+	return integrity.Enable(script, ref, signers)
+}
+
+func TestEnableAndVerify(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, hash := setupRepo(t, ns, "")
+	script := filepath.Join(dir, "script.lisp")
+
+	if err := enable(t, script, hash, ""); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+	if !integrity.Active() {
+		t.Fatal("Active() = false after Enable")
+	}
+	if got := integrity.CommitHash(); got != hash {
+		t.Fatalf("CommitHash() = %q, want %q", got, hash)
+	}
+
+	module := filepath.Join(dir, ".lisp", "util.lisp")
+	content, err := os.ReadFile(module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := integrity.VerifyFile(module, content); err != nil {
+		t.Fatalf("VerifyFile(committed module): %v", err)
+	}
+	if err := integrity.VerifyFile(module, append(content, "(def evil 1)\n"...)); err == nil {
+		t.Fatal("VerifyFile(modified module) did not fail")
+	}
+	if err := integrity.VerifyFile(filepath.Join(t.TempDir(), "out.lisp"), nil); err == nil ||
+		!strings.Contains(err.Error(), "outside") {
+		t.Fatalf("VerifyFile(outside repo) = %v, want 'outside' error", err)
+	}
+	if err := integrity.VerifyFile(filepath.Join(dir, "other.lisp"), nil); err == nil ||
+		!strings.Contains(err.Error(), "not committed") {
+		t.Fatalf("VerifyFile(uncommitted file) = %v, want 'not committed' error", err)
+	}
+}
+
+func TestVerifyFileNoOpWhenInactive(t *testing.T) {
+	if err := integrity.VerifyFile("/nowhere/x.lisp", []byte("whatever")); err != nil {
+		t.Fatalf("VerifyFile with mode off: %v", err)
+	}
+}
+
+func TestEnableTagRef(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, _ := setupRepo(t, ns, "")
+	evalLisp(t, ns, `(git-tag r "v1")`)
+	if err := enable(t, filepath.Join(dir, "script.lisp"), "v1", ""); err != nil {
+		t.Fatalf("Enable with lightweight tag: %v", err)
+	}
+}
+
+func TestEnableModifiedScript(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, hash := setupRepo(t, ns, "")
+	script := filepath.Join(dir, "script.lisp")
+	if err := os.WriteFile(script, []byte("(assert-integrity) (def evil 1)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := enable(t, script, hash, ""); err == nil || !strings.Contains(err.Error(), "differs") {
+		t.Fatalf("Enable(modified script) = %v, want 'differs' error", err)
+	}
+	if integrity.Active() {
+		t.Fatal("Active() = true after failed Enable")
+	}
+}
+
+func TestEnableHeadMoved(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, hash := setupRepo(t, ns, "")
+	if err := os.WriteFile(filepath.Join(dir, "later.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	evalLisp(t, ns, `(git-add r "later.txt")`)
+	evalLisp(t, ns, `(git-commit r "second" {:author `+author+`})`)
+	err := enable(t, filepath.Join(dir, "script.lisp"), hash, "")
+	if err == nil || !strings.Contains(err.Error(), "HEAD") {
+		t.Fatalf("Enable(old ref) = %v, want HEAD mismatch error", err)
+	}
+}
+
+func TestEnableOutsideRepo(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "script.lisp")
+	if err := os.WriteFile(script, []byte("1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := enable(t, script, "HEAD", ""); err == nil ||
+		!strings.Contains(err.Error(), "not inside a git repository") {
+		t.Fatalf("Enable(no repo) = %v, want 'not inside a git repository'", err)
+	}
+}
+
+func TestEnableSignedCommit(t *testing.T) {
+	ns := newGitEnv(t)
+	privPEM, authorized := testKey(t, "alice")
+	_, otherAuthorized := testKey(t, "mallory")
+	dir, hash := setupRepo(t, ns, fmt.Sprintf(`:sign {:key %q}`, privPEM))
+	script := filepath.Join(dir, "script.lisp")
+
+	if err := enable(t, script, hash, authorized); err != nil {
+		t.Fatalf("Enable(signed commit, allowed key): %v", err)
+	}
+	integrity.Disable()
+	if err := enable(t, script, hash, otherAuthorized); err == nil {
+		t.Fatal("Enable(signed commit, wrong key) did not fail")
+	}
+}
+
+func TestEnableSignedTag(t *testing.T) {
+	ns := newGitEnv(t)
+	privPEM, authorized := testKey(t, "alice")
+	dir, _ := setupRepo(t, ns, "")
+	script := filepath.Join(dir, "script.lisp")
+	evalLisp(t, ns, fmt.Sprintf(`(git-tag r "v1" {:message "release" :tagger `+author+` :sign {:key %q}})`, privPEM))
+
+	if err := enable(t, script, "v1", authorized); err != nil {
+		t.Fatalf("Enable(signed tag, allowed key): %v", err)
+	}
+	integrity.Disable()
+
+	// An unsigned annotated tag must be rejected when signers are required.
+	evalLisp(t, ns, `(git-tag r "v2" {:message "release" :tagger `+author+`})`)
+	if err := enable(t, script, "v2", authorized); err == nil ||
+		!strings.Contains(err.Error(), "not signed") {
+		t.Fatalf("Enable(unsigned tag with signers) = %v, want 'not signed'", err)
+	}
+}
+
+func TestEnableUnsignedCommitWithSigners(t *testing.T) {
+	ns := newGitEnv(t)
+	_, authorized := testKey(t, "alice")
+	dir, hash := setupRepo(t, ns, "")
+	if err := enable(t, filepath.Join(dir, "script.lisp"), hash, authorized); err == nil ||
+		!strings.Contains(err.Error(), "not signed") {
+		t.Fatalf("Enable(unsigned commit with signers) = %v, want 'not signed'", err)
+	}
+}
+
+func TestAssertIntegrityBuiltin(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, hash := setupRepo(t, ns, "")
+
+	// Without --integrity the builtin throws (catchable).
+	if got := evalLisp(t, ns, `(try (assert-integrity) (catch e "caught"))`); got != "caught" {
+		t.Fatalf("assert-integrity without mode = %v, want caught throw", got)
+	}
+
+	if err := enable(t, filepath.Join(dir, "script.lisp"), hash, ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := evalLisp(t, ns, `(assert-integrity)`); got != hash {
+		t.Fatalf("assert-integrity = %v, want %q", got, hash)
+	}
+}

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -242,6 +242,100 @@ func TestEnableUnsignedCommitWithSigners(t *testing.T) {
 	}
 }
 
+// evalErr evaluates src and requires a (catchable) lisp error.
+func evalErr(t *testing.T, ns types.EnvType, src string) error {
+	t.Helper()
+	ast, err := lisp.READ(src, types.NewCursorFile(t.Name()), ns)
+	if err != nil {
+		t.Fatalf("READ %s: %v", src, err)
+	}
+	_, err = lisp.EVAL(context.Background(), ast, ns)
+	if err == nil {
+		t.Fatalf("%s did not throw", src)
+	}
+	return err
+}
+
+// expectTrue evaluates src and requires the result to be true.
+func expectTrue(t *testing.T, ns types.EnvType, src string) {
+	t.Helper()
+	if v := evalLisp(t, ns, src); v != true {
+		t.Fatalf("%s = %v, want true", src, v)
+	}
+}
+
+func TestStateSaveLoadWithoutIntegrity(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, _ := setupRepo(t, ns, "")
+	t.Chdir(dir)
+
+	hash, ok := evalLisp(t, ns, `(state-save "db" {:n 1 :who "operador"})`).(string)
+	if !ok || hash == "" {
+		t.Fatalf("state-save did not return a commit hash")
+	}
+	expectTrue(t, ns, `(= 1 (get (state-load "db") :n))`)
+	expectTrue(t, ns, `(= "operador" (get (state-load "db") :who))`)
+	expectTrue(t, ns, `(= 42 (state-load "missing" 42))`)
+	evalErr(t, ns, `(state-load "missing")`)
+	evalErr(t, ns, `(state-save "../evil" 1)`)
+	evalErr(t, ns, `(state-save ".hidden" 1)`)
+
+	// The state commit is a real commit at HEAD touching only .state/.
+	expectTrue(t, ns, fmt.Sprintf(`(= %q (get (git-show r "HEAD") :hash))`, hash))
+	expectTrue(t, ns, `(= "state: db" (get (git-show r "HEAD") :message))`)
+}
+
+func TestStateUnderIntegrity(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, hash := setupRepo(t, ns, "")
+	script := filepath.Join(dir, "script.lisp")
+	if err := enable(t, script, hash, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	evalLisp(t, ns, `(state-save "db" {:n 1})`)
+	evalLisp(t, ns, `(state-save "db" {:n 2})`)
+	expectTrue(t, ns, `(= 2 (get (state-load "db") :n))`)
+
+	// The original code ref stays valid across state commits: a restart
+	// with the same --integrity ref must verify.
+	integrity.Disable()
+	if err := integrity.Enable(script, hash, ""); err != nil {
+		t.Fatalf("Enable after state commits: %v", err)
+	}
+
+	// An out-of-band edit of the state file fails closed.
+	stateFile := filepath.Join(dir, ".state", "db.lisp")
+	if err := os.WriteFile(stateFile, []byte("{:n 999}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := evalErr(t, ns, `(state-load "db")`); !strings.Contains(err.Error(), "differs") {
+		t.Fatalf("state-load after tamper = %v, want 'differs'", err)
+	}
+
+	// An uncommitted state file (interrupted save) fails closed too.
+	if err := os.WriteFile(filepath.Join(dir, ".state", "orphan.lisp"), []byte("{:n 1}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := evalErr(t, ns, `(state-load "orphan")`); !strings.Contains(err.Error(), "not committed") {
+		t.Fatalf("state-load of orphan = %v, want 'not committed'", err)
+	}
+}
+
+func TestEnableRejectsCodeCommitAfterRef(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, hash := setupRepo(t, ns, "")
+	if err := os.WriteFile(filepath.Join(dir, "script.lisp"), []byte("(assert-integrity) 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	evalLisp(t, ns, `(git-add r "script.lisp")`)
+	evalLisp(t, ns, `(git-commit r "code change" {:author `+author+`})`)
+	err := enable(t, filepath.Join(dir, "script.lisp"), hash, "")
+	if err == nil || !strings.Contains(err.Error(), "outside .state/") {
+		t.Fatalf("Enable(ref below code commit) = %v, want 'outside .state/'", err)
+	}
+}
+
 func TestAssertIntegrityBuiltin(t *testing.T) {
 	ns := newGitEnv(t)
 	dir, hash := setupRepo(t, ns, "")

--- a/lib/integrity/state.go
+++ b/lib/integrity/state.go
@@ -1,0 +1,192 @@
+package integrity
+
+// This file implements the .state/ store: state-save writes a value as
+// canonical lisp data under <repo-root>/.state/<name>.lisp and commits
+// it in the same operation, so committed state is always the product of
+// a completed save; state-load reads it back as pure data (READ, never
+// EVAL). Under --integrity, state-load additionally requires the file
+// to byte-match its blob at the current HEAD — the commit the last
+// state-save created — so out-of-band edits fail closed. The mode's
+// startup check accepts these state-only commits above the code ref
+// (see verifyStateOnlyDescent), which keeps the original --integrity
+// ref valid across restarts.
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	gogit "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/jig/lisp/format"
+	"github.com/jig/lisp/printer"
+	"github.com/jig/lisp/reader"
+	. "github.com/jig/lisp/types"
+)
+
+const stateDir = ".state"
+
+// stateMu serializes state-save operations within the process (git
+// itself rejects concurrent index writes from other processes).
+var stateMu sync.Mutex
+
+// stateRepo returns the repository and worktree root the state store
+// lives in: the verified repository under --integrity, the repository
+// enclosing the working directory otherwise.
+func stateRepo(fnName string) (*gogit.Repository, string, error) {
+	if mode != nil {
+		return mode.repo, mode.repoRoot, nil
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil, "", fmt.Errorf("%s: %w", fnName, err)
+	}
+	repo, err := gogit.PlainOpenWithOptions(wd, &gogit.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		return nil, "", fmt.Errorf("%s: not inside a git repository", fnName)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		return nil, "", fmt.Errorf("%s: %w", fnName, err)
+	}
+	return repo, wt.Filesystem().Root(), nil
+}
+
+// statePath validates name (relative slash-separated segments, no
+// hidden or dot-dot parts, as require module names) and returns the
+// state file's repo-relative slash path.
+func statePath(fnName, name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("%s: empty state name", fnName)
+	}
+	if strings.ContainsAny(name, " \\:@") || strings.HasPrefix(name, "/") {
+		return "", fmt.Errorf("%s: invalid state name %q", fnName, name)
+	}
+	for part := range strings.SplitSeq(name, "/") {
+		if part == "" || strings.HasPrefix(part, ".") {
+			return "", fmt.Errorf("%s: invalid state name %q", fnName, name)
+		}
+	}
+	return stateDir + "/" + name + ".lisp", nil
+}
+
+func state_save(name string, value MalType) (MalType, error) {
+	stateMu.Lock()
+	defer stateMu.Unlock()
+
+	rel, err := statePath("state-save", name)
+	if err != nil {
+		return nil, err
+	}
+	repo, root, err := stateRepo("state-save")
+	if err != nil {
+		return nil, err
+	}
+
+	// Canonical form: print readably and run the formatter, so state
+	// files diff cleanly and hash deterministically. A value the reader
+	// cannot round-trip (a live handle, a function) fails here.
+	printed := printer.Pr_str(value, true)
+	canon, err := format.Source([]byte(printed))
+	if err != nil {
+		return nil, fmt.Errorf("state-save: value is not serializable lisp data: %w", err)
+	}
+	if _, err := reader.Read_str(string(canon), NewCursorFile(rel), nil); err != nil {
+		return nil, fmt.Errorf("state-save: value is not readable lisp data: %w", err)
+	}
+
+	abs := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return nil, fmt.Errorf("state-save: %w", err)
+	}
+	if err := os.WriteFile(abs, canon, 0o644); err != nil {
+		return nil, fmt.Errorf("state-save: %w", err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		return nil, fmt.Errorf("state-save: %w", err)
+	}
+	if _, err := wt.Add(rel); err != nil {
+		return nil, fmt.Errorf("state-save: %w", err)
+	}
+	hash, err := wt.Commit("state: "+name, &gogit.CommitOptions{
+		Author: &object.Signature{Name: "state-save", Email: "state-save@lisp", When: time.Now()},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("state-save: %w", err)
+	}
+	return hash.String(), nil
+}
+
+func state_load(name string, defaultValue ...MalType) (MalType, error) {
+	rel, err := statePath("state-load", name)
+	if err != nil {
+		return nil, err
+	}
+	_, root, err := stateRepo("state-load")
+	if err != nil {
+		return nil, err
+	}
+	abs := filepath.Join(root, filepath.FromSlash(rel))
+	content, err := os.ReadFile(abs)
+	missing := errors.Is(err, fs.ErrNotExist)
+	if err != nil && !missing {
+		return nil, fmt.Errorf("state-load: %w", err)
+	}
+
+	if mode != nil {
+		committed, atHead, err := headStateBlob(rel)
+		if err != nil {
+			return nil, fmt.Errorf("state-load: %w", err)
+		}
+		switch {
+		case missing && atHead:
+			return nil, fmt.Errorf("state-load: %s is committed at HEAD but missing from the worktree", rel)
+		case !missing && !atHead:
+			return nil, fmt.Errorf("state-load: %s is not committed at HEAD (interrupted state-save?)", rel)
+		case !missing && committed != string(content):
+			return nil, fmt.Errorf("state-load: %s differs from its committed version at HEAD", rel)
+		}
+	}
+
+	if missing {
+		if len(defaultValue) == 1 {
+			return defaultValue[0], nil
+		}
+		return nil, fmt.Errorf("state-load: state %q not found (%s)", name, rel)
+	}
+	return reader.Read_str(string(content), NewCursorFile(abs), nil)
+}
+
+// headStateBlob returns the contents of rel at the current HEAD of the
+// verified repository, and whether it exists there.
+func headStateBlob(rel string) (string, bool, error) {
+	head, err := mode.repo.Head()
+	if err != nil {
+		return "", false, err
+	}
+	commit, err := mode.repo.CommitObject(head.Hash())
+	if err != nil {
+		return "", false, err
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return "", false, err
+	}
+	f, err := tree.File(rel)
+	if err != nil {
+		return "", false, nil
+	}
+	contents, err := f.Contents()
+	if err != nil {
+		return "", false, err
+	}
+	return contents, true, nil
+}

--- a/lib/require/require.go
+++ b/lib/require/require.go
@@ -87,6 +87,12 @@ func load(rootEnv types.EnvType, cfg Config) error {
 	return nil
 }
 
+// VerifyModule, when non-nil, vets every module file before it is
+// evaluated; a non-nil error aborts the require. The command package
+// installs it when running under --integrity, so the verification of
+// the script cascades to its requires.
+var VerifyModule func(absPath string, content []byte) error
+
 // moduleLoader evaluates modules once and exposes their top-level
 // definitions in the root environment under qualified names.
 type moduleLoader struct {
@@ -203,6 +209,11 @@ func (l *moduleLoader) evalModule(ctx context.Context, absPath string) (types.En
 	content, err := os.ReadFile(absPath)
 	if err != nil {
 		return nil, fmt.Errorf("require: %w", err)
+	}
+	if VerifyModule != nil {
+		if err := VerifyModule(absPath, content); err != nil {
+			return nil, err
+		}
 	}
 	// Register the module so the debugger maps its cursors back to the
 	// on-disk file. Dead code in release builds.


### PR DESCRIPTION
## Summary

Runs a script **if and only if** it matches what is committed in its Git repository at a given ref, with an optional SSH-signature layer and a git-backed state store.

- **\`--integrity REF\`** — HEAD must be exactly REF (or a linear chain of \`.state/\`-only commits above it); the script and, in cascade, every file evaluated as code (\`require\` modules, \`load-file\` targets via the new \`slurp-source\` builtin) must byte-match their committed blobs; files resolving outside the repository are refused.
- **\`--integrity-signers FILE\`** — REF must additionally carry an SSH signature by a key in FILE (authorized_keys format); reuses lib/git's verification (\`VerifyCommitSSH\`/\`VerifyTagSSH\` exported, now returning the signer). A JSON audit line is logged on successful verification.
- **\`(assert-integrity)\`** — throws unless verified; returns the verified commit hash.
- **\`(state-save name value)\` / \`(state-load name & [default])\`** — program state as canonical lisp data under \`.state/\`, committed by the save operation itself and read back as pure data (READ, never EVAL), verified against HEAD under the mode. State commits keep the original REF valid across restarts.
- \`--debug\` is refused under \`--integrity\`; validation also rejects \`-e\`, \`--test\`, \`--fmt\`, stdin and the server modes.
- **INTEGRITY.md** — user guide + specification (6 numbered invariants, state commit protocol, crash recovery, deployment hardening recipe, future revisions). **examples-integrity/** — runnable mini-examples of every concept and failure mode, with a \`demo.sh\` that replays them in throwaway repositories.

Documented explicitly as an operational assurance (drift, uncommitted edits), not a security boundary against whoever can rewrite the repository or the binary.

## Test plan

- \`lib/integrity/mode_test.go\`: hash/tag refs, modified script, HEAD moved, uncommitted files, outside-repo files, signed commit/tag with allowed/wrong/missing keys, state save/load round-trip, out-of-band state edits, interrupted saves, state-only descent (same ref after state commits), code commits after ref rejected, assert-integrity builtin.
- \`command/integrity_test.go\`: end-to-end Execute runs (verified script + require + load-file), tampered module and load-file targets, assert-integrity without the flag, flag validation matrix.
- Full suite green with and without \`-tags debugger\`; \`examples-integrity/demo.sh\` run end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
