### PR TITLE
fix(integrity): verify the script bytes runScript evaluates (preamble TOCTOU)

### DIFF
--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -167,6 +167,15 @@ attacker cannot write to what the interpreter reads:
   the operator is the trusted party in this model.
 - A self-verifying binary is deliberately **not** attempted: an
   attacker who can replace the binary can also remove the check.
+- Verification compares the **worktree bytes** against the **raw
+  committed blob**. A repository that applies EOL normalization or a
+  clean/smudge filter (`.gitattributes`: `text eol=crlf`, `filter=…`)
+  to a verified file makes the two differ, so verification fails
+  closed — it is not a bypass, but such repositories must keep their
+  `.lisp` and `.state/` files unfiltered. On case-insensitive or
+  unicode-normalizing filesystems (macOS), a committed path and the
+  on-disk path that resolves to it must match exactly; a mismatch
+  fails closed rather than verifying the wrong file.
 
 ## Future revisions (not implemented)
 

--- a/command/integrity_test.go
+++ b/command/integrity_test.go
@@ -34,6 +34,19 @@ func newIntegrityEnv(t *testing.T) types.EnvType {
 	return ns
 }
 
+// runGit runs a git command in dir and returns its trimmed output,
+// failing the test on error. Shared by the integrity tests.
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-c", "user.name=Test", "-c", "user.email=test@example.com"}, args...)...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
 // gitRepoWithScript builds a repository containing script.lisp (which
 // requires .lisp/util.lisp and asserts integrity) and returns its dir
 // and HEAD hash. It uses the git CLI, chdirs into the repo (so require
@@ -42,16 +55,7 @@ func newIntegrityEnv(t *testing.T) types.EnvType {
 func gitRepoWithScript(t *testing.T) (dir, hash string) {
 	t.Helper()
 	dir = t.TempDir()
-	git := func(args ...string) string {
-		t.Helper()
-		cmd := exec.Command("git", append([]string{"-c", "user.name=Test", "-c", "user.email=test@example.com"}, args...)...)
-		cmd.Dir = dir
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
-		return strings.TrimSpace(string(out))
-	}
+	git := func(args ...string) string { return runGit(t, dir, args...) }
 	script := "(require \"util\")\n(load-file \"extra.lisp\")\n(str (assert-integrity) \" \" (util/hello) \" \" extra-val)\n"
 	if err := os.WriteFile(filepath.Join(dir, "script.lisp"), []byte(script), 0o644); err != nil {
 		t.Fatal(err)

--- a/command/integrity_toctou_test.go
+++ b/command/integrity_toctou_test.go
@@ -1,0 +1,85 @@
+package command
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jig/lisp/lib/core"
+	"github.com/jig/lisp/lib/integrity"
+	"github.com/jig/lisp/lib/require"
+	"github.com/jig/lisp/types"
+)
+
+// TestRunScriptPreambleTOCTOU is a regression test for the double-read
+// TOCTOU on runScript's in-file preamble branch: integrity.Enable reads
+// and verifies the script once, then runScript reads it again and — on
+// the preamble branch — evaluates that second buffer directly. If the
+// file changes between the two reads (a worktree write, in scope), the
+// evaluated bytes must still be verified, or a "verified" run executes
+// non-committed code.
+//
+// The window is modelled deterministically, without a filesystem race:
+// enable the mode on the committed script, then overwrite the file with
+// non-committed bytes before calling runScript. The run must fail closed.
+func TestRunScriptPreambleTOCTOU(t *testing.T) {
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "script.lisp")
+
+	// A leading ;; $WHO line forces the preamble branch (not the
+	// load-file fast path, which reads and verifies the same bytes).
+	committed := ";; $WHO \"world\"\n(println \"hello\" $WHO)\n"
+	payload := ";; $WHO \"world\"\n(println \"PWNED: non-committed code\")\n"
+
+	if err := os.WriteFile(scriptPath, []byte(committed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hash := gitInitCommit(t, dir)
+	t.Chdir(dir)
+	t.Cleanup(func() {
+		integrity.Disable()
+		require.VerifyModule = nil
+		core.VerifySource = nil
+	})
+
+	// Enable verifies the committed script; wire the hooks exactly as
+	// setupIntegrity does.
+	if err := integrity.Enable(scriptPath, hash, ""); err != nil {
+		t.Fatalf("Enable: %v", err)
+	}
+	require.VerifyModule = integrity.VerifyFile
+	core.VerifySource = integrity.VerifyFile
+
+	// The attacker swaps the file after verification, before evaluation.
+	if err := os.WriteFile(scriptPath, []byte(payload), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ns := newIntegrityEnv(t)
+	out, err := captureStdout(t, func() error {
+		_, e := runScript(context.Background(), ns, "script.lisp", nil, types.NewCursorFile("script.lisp"))
+		return e
+	})
+	if strings.Contains(out, "PWNED") {
+		t.Fatalf("non-committed code executed under a verified run: %q", out)
+	}
+	if err == nil || !strings.Contains(err.Error(), "integrity") {
+		t.Fatalf("preamble TOCTOU: got err=%v, want a fail-closed integrity error", err)
+	}
+}
+
+// gitInitCommit initialises a repo in dir, commits everything and
+// returns the HEAD hash. Uses the git CLI like the other tests here.
+func gitInitCommit(t *testing.T, dir string) string {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"add", "-A"},
+		{"-c", "user.name=T", "-c", "user.email=t@e", "commit", "-qm", "release"},
+	} {
+		runGit(t, dir, args...)
+	}
+	return strings.TrimSpace(runGit(t, dir, "rev-parse", "HEAD"))
+}

--- a/command/preamble.go
+++ b/command/preamble.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/jig/lisp"
+	"github.com/jig/lisp/lib/integrity"
 	"github.com/jig/lisp/reader"
 	"github.com/jig/lisp/types"
 )
@@ -83,6 +84,17 @@ func runScript(ctx context.Context, env types.EnvType, fileName string, preamble
 
 	contentBytes, err := os.ReadFile(fileName)
 	if err != nil {
+		return nil, err
+	}
+	// Under --integrity, verify the exact bytes about to be evaluated.
+	// integrity.Enable verified the script from an earlier, independent
+	// read; the preamble branch below evaluates *this* buffer directly
+	// (not through load-file/slurp-source), so without this check the
+	// two reads could diverge — a worktree file swapped for a FIFO fed
+	// concurrently runs unverified code under a "verified" run. No-op
+	// when integrity mode is off. The load-file fast path re-verifies
+	// through slurp-source, so the check there is merely redundant.
+	if err := integrity.VerifyFile(abs, contentBytes); err != nil {
 		return nil, err
 	}
 	content := string(contentBytes)

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -497,11 +497,11 @@ func printNoNewline(a ...MalType) (MalType, error) {
 	return nil, nil
 }
 
-// VerifySource, when non-nil, vets a source file before load-file (via
-// slurp-source) evaluates it; a non-nil error aborts the load. The
-// command package installs it when running under --integrity, so code
-// loaded at runtime is verified like the script and its requires.
-// slurp itself is never hooked: it reads data, not code.
+// VerifySource is an optional hook that vets a source file before
+// load-file (via slurp-source) evaluates it; a non-nil error aborts the
+// load. The command package installs it when running under --integrity,
+// so code loaded at runtime is verified like the script and its
+// requires. slurp itself is never hooked: it reads data, not code.
 var VerifySource func(absPath string, content []byte) error
 
 // slurp_source is slurp for files that will be evaluated as code:

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -276,9 +276,9 @@ func TestStateSaveLoadWithoutIntegrity(t *testing.T) {
 	expectTrue(t, ns, `(= 1 (get (state-load "db") :n))`)
 	expectTrue(t, ns, `(= "operador" (get (state-load "db") :who))`)
 	expectTrue(t, ns, `(= 42 (state-load "missing" 42))`)
-	evalErr(t, ns, `(state-load "missing")`)
-	evalErr(t, ns, `(state-save "../evil" 1)`)
-	evalErr(t, ns, `(state-save ".hidden" 1)`)
+	_ = evalErr(t, ns, `(state-load "missing")`)
+	_ = evalErr(t, ns, `(state-save "../evil" 1)`)
+	_ = evalErr(t, ns, `(state-save ".hidden" 1)`)
 
 	// The state commit is a real commit at HEAD touching only .state/.
 	expectTrue(t, ns, fmt.Sprintf(`(= %q (get (git-show r "HEAD") :hash))`, hash))

--- a/lib/require/require.go
+++ b/lib/require/require.go
@@ -87,10 +87,10 @@ func load(rootEnv types.EnvType, cfg Config) error {
 	return nil
 }
 
-// VerifyModule, when non-nil, vets every module file before it is
-// evaluated; a non-nil error aborts the require. The command package
-// installs it when running under --integrity, so the verification of
-// the script cascades to its requires.
+// VerifyModule is an optional hook that vets every module file before
+// it is evaluated; a non-nil error aborts the require. The command
+// package installs it when running under --integrity, so the
+// verification of the script cascades to its requires.
 var VerifyModule func(absPath string, content []byte) error
 
 // moduleLoader evaluates modules once and exposes their top-level


### PR DESCRIPTION
## Summary

Fixes a **confirmed integrity-mode bypass** found by the adversarial review ([INTEGRITY-REVIEW.md](https://github.com/jig/lisp/blob/develop/INTEGRITY-REVIEW.md)).

The script was read twice: `integrity.Enable` read and verified it once, then `runScript` read it again and — on the in-file `;; $` preamble branch — evaluated that second buffer directly via `Read_program` + `EVAL` **without any verification hook**. (The `load-file` fast path self-verifies through `slurp-source`; only the preamble branch bypassed it.) A worktree file whose two reads diverge — e.g. replaced by a FIFO fed concurrently, both in the declared threat model — thus ran **non-committed code under a run reported as verified** (successful `assert-integrity`, audit line, exit 0), violating invariant 4.

`runScript` now calls `integrity.VerifyFile` on the exact bytes it is about to evaluate, before scanning for the preamble, so the branch verifies and evaluates the same buffer. No-op when integrity mode is off.

Also documents two limitations confirmed during the review as **fail-closed** (not bypasses): `.gitattributes` EOL/clean-smudge filters (worktree bytes vs raw blob), and case-insensitive/unicode-normalizing filesystems.

## Test plan

- New `command/integrity_toctou_test.go` models the window deterministically (no race): enable the mode on the committed script, overwrite the file, then `runScript` must fail closed. Verified it **fails without the fix** (`non-committed code executed under a verified run: PWNED…`) and **passes with it**.
- Full suite green with and without `-tags debugger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
