### PR TITLE
test: de-flake TestTimeoutOnTryCatch

### DIFF
--- a/timeout_test.go
+++ b/timeout_test.go
@@ -76,7 +76,15 @@ func TestTimeoutOnTryCatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	// `try` reserves 20% of the deadline for the catch/finally handlers
+	// (mal.go: 80% goes to the try body). The handler here is a trivial
+	// string concat, but on a loaded CI runner the scheduling jitter
+	// between the try body's timeout firing and the handler running can
+	// exceed a too-small 20% slice — then the top-of-loop ctx check
+	// re-fires the (now expired) deadline outside the try, uncatchably.
+	// A comfortable deadline keeps that 20% (~400ms) far larger than any
+	// realistic jitter, so the timeout is caught deterministically.
+	ctx, cancel := context.WithTimeout(context.Background(), 2000*time.Millisecond)
 	defer cancel()
 	res, err := EVAL(ctx, ast, ns)
 	if err != nil {


### PR DESCRIPTION
## Summary

`TestTimeoutOnTryCatch` flaked on the macOS CI runner (it failed on develop's merge commit for #117, though the PR branch checks were green — the merge-commit push CI is a separate run).

Root cause: the test wraps `(sleep 10000)` in a `try/catch` under a **500ms** deadline and asserts the timeout is caught. `try` reserves 20% of the deadline for the catch/finally handlers (80% goes to the try body, see `mal.go`), leaving the handler only ~100ms. On a loaded runner the scheduling jitter between the try body's timeout firing and the handler running exceeded that slice, so the top-of-loop `ctx.Done()` check re-fired the now-expired deadline **outside** the try, uncatchably — surfacing as `unexpected error caught`.

Fix: widen the deadline to **2s** so the 20% catch slice (~400ms) dwarfs any realistic jitter. No EVAL semantics change; the 80/20 split is pre-existing.

## Test plan

- `go test -tags debugger -run TestTimeoutOnTryCatch -count=40` under full CPU load (8 `yes` processes saturating all cores): all pass.
- All timeout tests pass with and without `-tags debugger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
