### PR TITLE
fix(integrity): external review follow-ups (keys format, module names, audit wording)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,10 +159,12 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   the script must byte-match its committed blob, and the check
   cascades to every file evaluated as code — `require` modules and
   `load-file` targets — resolved inside the same repository (files
-  resolving outside it are refused). `--integrity-signers FILE`
+  resolving outside it are refused). `--integrity-keys FILE`
   additionally requires REF to be SSH-signed by a key listed in FILE
-  (authorized_keys format, as `git-verify-commit`); a JSON audit line
-  is logged on successful verification. New builtins:
+  (authorized_keys / `.pub` format, as `git-verify-commit` — not git's
+  `allowed_signers`; a principal-first line is rejected, keys are
+  matched by key with no expiry); a JSON audit line is logged on
+  successful verification. New builtins:
   `(assert-integrity)` throws unless the run is verified — so
   committed code can demand the flag — and returns the verified commit
   hash; `(state-save name value)` / `(state-load name & [default])`

--- a/INTEGRITY-REVIEW.md
+++ b/INTEGRITY-REVIEW.md
@@ -20,7 +20,7 @@ verified** — including the startup audit line and a successful
 
 Declared non-goals — findings here are not interesting:
 
-- An attacker who can rewrite the repository/refs, the signers file or
+- An attacker who can rewrite the repository/refs, the keys file or
   the `lisp` binary, or who controls the operator's command line
   (including `-P` preamble injection).
 - Verified code that *chooses* to evaluate unverified input

--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -22,7 +22,7 @@ signatures, exactly what a trusted key released) — no accidental
 drift, no uncommitted edits, no locally patched copy.
 
 It is **not a security boundary** against an attacker who can already
-write to the repository, the signers file or the `lisp` binary. The
+write to the repository, the keys file or the `lisp` binary. The
 interpreter cannot protect itself from whoever controls what it reads;
 that separation belongs to the operating system (see
 [Deployment](#deployment-hardening-the-assurance-into-a-boundary)).
@@ -34,7 +34,7 @@ Definitions:
 - **ref** — the argument of `--integrity`: a commit hash, tag or
   branch name, resolved in the repository enclosing the script.
   A commit hash is immutable and therefore the strongest choice; a
-  signed tag is equivalent when `--integrity-signers` is used.
+  signed tag is equivalent when `--integrity-keys` is used.
 - **code file** — any file evaluated as code: the script, every module
   loaded through `require`, and every file loaded through `load-file` /
   `load-file-once` (which read via the `slurp-source` builtin).
@@ -47,7 +47,7 @@ At startup (`--integrity <ref>`):
 2. `HEAD` must be `C`, **or** a descendant of `C` through a linear
    chain of commits each touching only state paths (the commits
    `state-save` creates). Anything else fails.
-3. With `--integrity-signers FILE`: the ref must carry an SSH
+3. With `--integrity-keys FILE`: the ref must carry an SSH
    signature by one of the public keys in `FILE` — the tag signature
    if the ref is an annotated tag, the commit signature otherwise.
 4. The script must byte-match its blob in `C`'s tree.
@@ -80,20 +80,29 @@ Concepts 1–2 and 4–6 are demonstrated by
 ```bash
 lisp --integrity v1.4.2 service.lisp
 lisp --integrity 9fceb02d service.lisp
-lisp --integrity v1.4.2 --integrity-signers /etc/lisp/release-keys service.lisp
+lisp --integrity v1.4.2 --integrity-keys /etc/lisp/release-keys service.lisp
 ```
 
 - `--integrity REF` — enable the mode. Requires a script file;
   incompatible with `-e`, `--test`, `--fmt`, `--debug`, stdin (`-`)
   and the DAP/LSP server modes.
-- `--integrity-signers FILE` — additionally require the ref to be
-  SSH-signed by a key listed in FILE. authorized_keys format, one
-  public key per line (`ssh-ed25519 AAAA… comment`), the same format
-  `git-verify-commit` takes. Requires `--integrity`.
+- `--integrity-keys FILE` — additionally require the ref to be
+  SSH-signed by a key listed in FILE. **authorized_keys / `.pub`
+  format**: one public key per line, `<type> <base64> [comment]`
+  (e.g. `ssh-ed25519 AAAA… alice`), blank lines and `#` comments
+  skipped — the same format `git-verify-commit` takes. This is **not**
+  git's `allowed_signers` format (which puts the principal first); such
+  a line is rejected, not silently accepted, so the trust anchor is the
+  set of keys, matched by key — no principal or validity constraints
+  (rotate keys by editing the file, not by expiry). Requires
+  `--integrity`.
 
 On success one structured JSON line is logged to stderr for the audit
-trail: `{"msg":"integrity verified","ref":…,"commit":…,"signer":…}`
-(`signer` only when signers were required).
+trail: `{"msg":"integrity: entry script and ref verified","ref":…,"commit":…,"signer":…}`
+(`signer` only when keys were required). It attests the pinned ref and
+the entry script; each cascaded `require` / `load-file` is verified as
+it loads and aborts the run on mismatch, so the line does not mean the
+whole run is already verified.
 
 ## Builtins
 
@@ -132,15 +141,15 @@ integrity envelope:
 
 ## Signatures and trust anchors
 
-Without `--integrity-signers` the trust anchor is the local repository
+Without `--integrity-keys` the trust anchor is the local repository
 state: the mode proves consistency ("matches what is committed here"),
 which stops drift but not history rewriting by whoever can write to
 the repository.
 
-With `--integrity-signers` the anchor becomes the key list plus the
+With `--integrity-keys` the anchor becomes the key list plus the
 binary: the ref must be signed by a trusted key, so verification
 survives cloning the repository onto other machines and re-tagging by
-someone without the key. Keep the signers file outside the repository
+someone without the key. Keep the keys file outside the repository
 and outside the process user's write reach.
 
 ## Deployment: hardening the assurance into a boundary
@@ -148,7 +157,7 @@ and outside the process user's write reach.
 The mode becomes a real boundary only when the OS guarantees the
 attacker cannot write to what the interpreter reads:
 
-- repository checkout, signers file and `lisp` binary owned by `root`
+- repository checkout, keys file and `lisp` binary owned by `root`
   (or a dedicated `deploy` user);
 - the process running as an unprivileged user with **no write access**
   to any of the three;

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ that call:
 (def release (assert-integrity))
 ```
 
-With `--integrity-signers FILE`, `REF` must additionally carry an SSH
+With `--integrity-keys FILE`, `REF` must additionally carry an SSH
 signature by one of the public keys listed in `FILE`
 (authorized_keys format, one key per line — the same format
 `git-verify-commit` takes). For an annotated tag the tag's signature
@@ -433,7 +433,7 @@ is checked; otherwise the commit's. This upgrades the guarantee from
 which survives cloning the repository onto other machines:
 
 ```bash
-lisp --integrity v1.4.2 --integrity-signers /etc/lisp/release-keys service.lisp
+lisp --integrity v1.4.2 --integrity-keys /etc/lisp/release-keys service.lisp
 ```
 
 A verified program persists state through the `.state/` store instead

--- a/command/command.go
+++ b/command/command.go
@@ -17,26 +17,26 @@ import (
 
 // args represents command line arguments for the Lisp interpreter
 type args struct {
-	Version          bool     `arg:"-v,--version" help:"show version information"`
-	Test             string   `arg:"-t,--test" help:"run the test suite from a directory or a single test file" placeholder:"DIR|FILE"`
-	TestJSON         string   `arg:"--test-json" help:"with --test, also write a JSON report to the given file" placeholder:"FILE"`
-	Coverage         string   `arg:"--coverage" help:"write an lcov coverage report of the executed lisp code (requires -tags debugger)" placeholder:"FILE"`
-	Debug            bool     `arg:"--debug" help:"enable DEBUG-EVAL support (requires -tags debugger)"`
-	Eval             string   `arg:"-e,--eval" help:"evaluate expression and exit" placeholder:"EXPR"`
-	Fmt              bool     `arg:"--fmt" help:"format lisp source (files given as arguments, or stdin) and print the result"`
-	Write            bool     `arg:"-w,--write" help:"with --fmt, rewrite each file in place instead of printing"`
-	Include          []string `arg:"-i,--include,separate" help:"add include directory for require (needs the require library loaded)" placeholder:"DIR"`
-	Integrity        string   `arg:"--integrity" help:"run the script only if it and its repo-local requires match Git REF and HEAD is at REF" placeholder:"REF"`
-	IntegritySigners string   `arg:"--integrity-signers" help:"with --integrity, additionally require REF to be SSH-signed by a key listed in FILE (authorized_keys format)" placeholder:"FILE"`
-	Preamble         []string `arg:"-P,--preamble,separate" help:"define a preamble placeholder for the script, e.g. -P '$NAME <expr>'" placeholder:"ASSIGN"`
-	DAP              bool     `arg:"--dap" help:"start a Debug Adapter Protocol server on stdio (requires -tags debugger)"`
-	DAPListen        string   `arg:"--dap-listen" help:"start a DAP server on the given TCP address (requires -tags debugger)" placeholder:"HOST:PORT"`
-	RunTest          string   `arg:"--run-test" help:"with --dap, run the named deftest after loading the script (used by the editor's Debug Test)" placeholder:"NAME"`
-	LSP              bool     `arg:"--lsp" help:"start a Language Server Protocol server on stdio (requires -tags debugger)"`
-	LSPListen        string   `arg:"--lsp-listen" help:"start an LSP server on the given TCP address (requires -tags debugger)" placeholder:"HOST:PORT"`
-	BatSyntax        bool     `arg:"--install-bat-syntax" help:"install the jig/lisp syntax into bat (writes to bat's config dir and rebuilds its cache)"`
-	Script           string   `arg:"positional" help:"lisp script to execute"`
-	Args             []string `arg:"positional" help:"arguments to pass to the script"`
+	Version       bool     `arg:"-v,--version" help:"show version information"`
+	Test          string   `arg:"-t,--test" help:"run the test suite from a directory or a single test file" placeholder:"DIR|FILE"`
+	TestJSON      string   `arg:"--test-json" help:"with --test, also write a JSON report to the given file" placeholder:"FILE"`
+	Coverage      string   `arg:"--coverage" help:"write an lcov coverage report of the executed lisp code (requires -tags debugger)" placeholder:"FILE"`
+	Debug         bool     `arg:"--debug" help:"enable DEBUG-EVAL support (requires -tags debugger)"`
+	Eval          string   `arg:"-e,--eval" help:"evaluate expression and exit" placeholder:"EXPR"`
+	Fmt           bool     `arg:"--fmt" help:"format lisp source (files given as arguments, or stdin) and print the result"`
+	Write         bool     `arg:"-w,--write" help:"with --fmt, rewrite each file in place instead of printing"`
+	Include       []string `arg:"-i,--include,separate" help:"add include directory for require (needs the require library loaded)" placeholder:"DIR"`
+	Integrity     string   `arg:"--integrity" help:"run the script only if it and its repo-local requires match Git REF and HEAD is at REF" placeholder:"REF"`
+	IntegrityKeys string   `arg:"--integrity-keys" help:"with --integrity, additionally require REF to be SSH-signed by a key listed in FILE (authorized_keys/.pub format, one key per line)" placeholder:"FILE"`
+	Preamble      []string `arg:"-P,--preamble,separate" help:"define a preamble placeholder for the script, e.g. -P '$NAME <expr>'" placeholder:"ASSIGN"`
+	DAP           bool     `arg:"--dap" help:"start a Debug Adapter Protocol server on stdio (requires -tags debugger)"`
+	DAPListen     string   `arg:"--dap-listen" help:"start a DAP server on the given TCP address (requires -tags debugger)" placeholder:"HOST:PORT"`
+	RunTest       string   `arg:"--run-test" help:"with --dap, run the named deftest after loading the script (used by the editor's Debug Test)" placeholder:"NAME"`
+	LSP           bool     `arg:"--lsp" help:"start a Language Server Protocol server on stdio (requires -tags debugger)"`
+	LSPListen     string   `arg:"--lsp-listen" help:"start an LSP server on the given TCP address (requires -tags debugger)" placeholder:"HOST:PORT"`
+	BatSyntax     bool     `arg:"--install-bat-syntax" help:"install the jig/lisp syntax into bat (writes to bat's config dir and rebuilds its cache)"`
+	Script        string   `arg:"positional" help:"lisp script to execute"`
+	Args          []string `arg:"positional" help:"arguments to pass to the script"`
 }
 
 func (args) Description() string {

--- a/command/integrity.go
+++ b/command/integrity.go
@@ -17,8 +17,8 @@ import (
 // outside it are refused). No-op when --integrity was not given.
 func setupIntegrity(a args) error {
 	if a.Integrity == "" {
-		if a.IntegritySigners != "" {
-			return fmt.Errorf("--integrity-signers requires --integrity")
+		if a.IntegrityKeys != "" {
+			return fmt.Errorf("--integrity-keys requires --integrity")
 		}
 		return nil
 	}
@@ -29,25 +29,28 @@ func setupIntegrity(a args) error {
 		a.DAP || a.DAPListen != "" || a.LSP || a.LSPListen != "" {
 		return fmt.Errorf("--integrity only runs a script file; it cannot be combined with --eval, --test, --fmt, --debug or the server modes")
 	}
-	signers := ""
-	if a.IntegritySigners != "" {
-		b, err := os.ReadFile(a.IntegritySigners)
+	keys := ""
+	if a.IntegrityKeys != "" {
+		b, err := os.ReadFile(a.IntegrityKeys)
 		if err != nil {
-			return fmt.Errorf("--integrity-signers: %w", err)
+			return fmt.Errorf("--integrity-keys: %w", err)
 		}
-		signers = string(b)
+		keys = string(b)
 	}
-	if err := integrity.Enable(a.Script, a.Integrity, signers); err != nil {
+	if err := integrity.Enable(a.Script, a.Integrity, keys); err != nil {
 		return err
 	}
 	require.VerifyModule = integrity.VerifyFile
 	core.VerifySource = integrity.VerifyFile
 
-	// One structured line to stderr for the operator's audit trail.
+	// One structured line to stderr for the operator's audit trail. It
+	// attests the pinned ref and the entry script only; each require /
+	// load-file is verified as it loads and aborts the run on mismatch,
+	// so a green line here does not mean the whole run is pre-verified.
 	logAttrs := []any{"ref", integrity.Ref(), "commit", integrity.CommitHash()}
-	if signers != "" {
+	if keys != "" {
 		logAttrs = append(logAttrs, "signer", integrity.Signer())
 	}
-	slog.New(slog.NewJSONHandler(os.Stderr, nil)).Info("integrity verified", logAttrs...)
+	slog.New(slog.NewJSONHandler(os.Stderr, nil)).Info("integrity: entry script and ref verified", logAttrs...)
 	return nil
 }

--- a/command/integrity_test.go
+++ b/command/integrity_test.go
@@ -142,7 +142,7 @@ func TestExecuteIntegrityFlagValidation(t *testing.T) {
 		{"lisp", "--integrity", "HEAD"},                          // no script
 		{"lisp", "--integrity", "HEAD", "-"},                     // stdin
 		{"lisp", "--integrity", "HEAD", "-e", "1", "x.lisp"},     // eval
-		{"lisp", "--integrity-signers", "keys.txt", "x.lisp"},    // signers alone
+		{"lisp", "--integrity-keys", "keys.txt", "x.lisp"},       // keys alone
 		{"lisp", "--integrity", "HEAD", "--fmt", "x.lisp"},       // fmt
 		{"lisp", "--integrity", "HEAD", "--test", ".", "x.lisp"}, // test
 		{"lisp", "--integrity", "HEAD", "--debug", "x.lisp"},     // debugger hook

--- a/examples-integrity/03-signed/service.lisp
+++ b/examples-integrity/03-signed/service.lisp
@@ -1,4 +1,4 @@
-;; With --integrity-signers, the ref must carry an SSH signature by a
+;; With --integrity-keys, the ref must carry an SSH signature by a
 ;; trusted key: the trust anchor becomes the key list, not the local
 ;; repository state. See the README for creating the signed tag.
 (println "running release signed by a trusted key:" (assert-integrity))

--- a/examples-integrity/README.md
+++ b/examples-integrity/README.md
@@ -54,7 +54,7 @@ The same cascade covers `load-file`/`load-file-once` targets.
 
 ## 03-signed — trust a key, not the local repository
 
-An SSH-signed tag plus `--integrity-signers` upgrades the guarantee
+An SSH-signed tag plus `--integrity-keys` upgrades the guarantee
 from "matches this repository" to "matches what a trusted key
 released" — it survives cloning the repository elsewhere.
 
@@ -65,14 +65,15 @@ git init && git add -A && git commit -m "release"
 ssh-keygen -t ed25519 -f release-key -N "" -C "release@example.com"
 git -c gpg.format=ssh -c user.signingkey=./release-key tag -s v1 -m "signed release"
 
-# The signers file is authorized_keys format — the .pub file as is.
+# The keys file is authorized_keys / .pub format — the .pub file as is,
+# NOT git's allowed_signers (a principal-first line would be rejected).
 # In production it lives OUTSIDE the repository (e.g. /etc/lisp/).
-lisp --integrity v1 --integrity-signers release-key.pub service.lisp   # ✓
+lisp --integrity v1 --integrity-keys release-key.pub service.lisp   # ✓
 
 ssh-keygen -t ed25519 -f other-key -N ""
-lisp --integrity v1 --integrity-signers other-key.pub service.lisp     # ✗ no allowed key matches
+lisp --integrity v1 --integrity-keys other-key.pub service.lisp     # ✗ no allowed key matches
 git tag -d v1 && git tag v1                                            # re-tag, unsigned
-lisp --integrity v1 --integrity-signers release-key.pub service.lisp   # ✗ tag is not signed
+lisp --integrity v1 --integrity-keys release-key.pub service.lisp   # ✗ tag is not signed
 ```
 
 ## 04-state — persistent state inside the integrity envelope

--- a/examples-integrity/demo.sh
+++ b/examples-integrity/demo.sh
@@ -51,13 +51,17 @@ git tag -d v1 >/dev/null
 ssh-keygen -q -t ed25519 -f release-key -N "" -C "release@example.com"
 git -c user.name=Demo -c user.email=demo@example.com \
     -c gpg.format=ssh -c user.signingkey=./release-key tag -s v1 -m "signed release"
-$LISP --integrity v1 --integrity-signers release-key.pub service.lisp
+$LISP --integrity v1 --integrity-keys release-key.pub service.lisp
 ssh-keygen -q -t ed25519 -f other-key -N ""
-must_fail "signed by a key not in the signers file" -- \
-	$LISP --integrity v1 --integrity-signers other-key.pub service.lisp
+must_fail "signed by a key not in the keys file" -- \
+	$LISP --integrity v1 --integrity-keys other-key.pub service.lisp
+# git allowed_signers format (principal-first) is refused, not misparsed.
+printf 'release@example.com %s\n' "$(cat release-key.pub)" > allowed_signers
+must_fail "allowed_signers format (principal-first) instead of .pub" -- \
+	$LISP --integrity v1 --integrity-keys allowed_signers service.lisp
 git tag -d v1 >/dev/null && git tag v1
-must_fail "unsigned tag with --integrity-signers" -- \
-	$LISP --integrity v1 --integrity-signers release-key.pub service.lisp
+must_fail "unsigned tag with --integrity-keys" -- \
+	$LISP --integrity v1 --integrity-keys release-key.pub service.lisp
 
 step "04-state: persistent state inside the integrity envelope"
 repo 04-state

--- a/lib/git/README.md
+++ b/lib/git/README.md
@@ -40,7 +40,7 @@ In sha256 repositories the commit signature is stored under the `gpgsig-sha256` 
 
 ## Verification — fail closed
 
-`git-verify-commit` and `git-verify-tag` take the allowed public keys as a string of authorized_keys-format lines (`ssh-ed25519 AAAA… comment`, one per line; blank lines and `#` comments are skipped — a `.pub` file or an `allowed_signers`-style list both work). They return a result map **only** when a listed key produced a valid signature over the object's exact payload; every other outcome — unsigned object, no matching key, altered content, corrupt signature — throws a catchable error. `git-verified?` and `git-tag-verified?` wrap them when only a boolean is wanted.
+`git-verify-commit` and `git-verify-tag` take the allowed public keys as a string of authorized_keys-format lines (`ssh-ed25519 AAAA… comment`, one per line; blank lines and `#` comments are skipped — a `.pub` file works as is). This is **not** git's `allowed_signers` format: a principal-first line (`alice@example.com ssh-ed25519 …`) is rejected rather than silently misparsed, since the principal would otherwise be read as an SSH option and dropped. Keys are matched by key, with no principal or validity constraints. They return a result map **only** when a listed key produced a valid signature over the object's exact payload; every other outcome — unsigned object, no matching key, altered content, corrupt signature — throws a catchable error. `git-verified?` and `git-tag-verified?` wrap them when only a boolean is wanted.
 
 ## Remotes and authentication
 

--- a/lib/git/git_test.go
+++ b/lib/git/git_test.go
@@ -183,6 +183,31 @@ func TestVerifyFailClosed(t *testing.T) {
 	eval(t, ns, `(git-close r)`)
 }
 
+// TestRejectAllowedSignersFormat verifies that a git allowed_signers
+// line (principal-first) is refused rather than silently misparsed:
+// ParseAuthorizedKey would read the principal as an SSH option and drop
+// it, verifying the key with no identity constraint. The very same key
+// verifies in authorized_keys format, so the rejection is about the
+// format, not the key.
+func TestRejectAllowedSignersFormat(t *testing.T) {
+	ns := newEnv(t)
+	dir := t.TempDir()
+	privPEM, authorized := testKey(t, "alice")
+	eval(t, ns, fmt.Sprintf(`(def r (git-init %q))`, dir))
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	eval(t, ns, `(git-add r "a.txt")`)
+	eval(t, ns, fmt.Sprintf(`(git-commit r "signed" {:author %s :sign {:key %q}})`, author, privPEM))
+
+	// authorized_keys format (key-first) verifies.
+	expectTrue(t, ns, fmt.Sprintf(`(get (git-verify-commit r "HEAD" %q) :valid)`, authorized))
+	// allowed_signers format (principal-first) with the SAME key is refused.
+	allowedSigners := "alice@example.com " + authorized
+	expectThrow(t, ns, fmt.Sprintf(`(git-verify-commit r "HEAD" %q)`, allowedSigners))
+	eval(t, ns, `(git-close r)`)
+}
+
 func TestBranchesTagsStatus(t *testing.T) {
 	ns := newEnv(t)
 	dir := t.TempDir()

--- a/lib/git/sign.go
+++ b/lib/git/sign.go
@@ -250,7 +250,14 @@ func verifySignature(obj payloadEncoder, armored, allowedKeys string) (MalType, 
 }
 
 // matchAllowedKey finds the allowed key (authorized_keys-format lines;
-// blank lines and # comments skipped) matching the signature's public key.
+// blank lines and # comments skipped) matching the signature's public
+// key. The format is authorized_keys / a `.pub` file — one key per line,
+// `<type> <base64> [comment]` — NOT git's allowed_signers (which puts
+// the principal first). A principal-first line is rejected rather than
+// silently misparsed: ParseAuthorizedKey would read the principal as an
+// SSH option and drop it, verifying the key with no identity or
+// validity constraint. Options are meaningless for signature checking,
+// so any line carrying them is refused.
 func matchAllowedKey(sig *sshsig.Signature, allowedKeys string) (gossh.PublicKey, string, error) {
 	want := sig.PublicKey.Marshal()
 	for line := range strings.SplitSeq(allowedKeys, "\n") {
@@ -258,9 +265,12 @@ func matchAllowedKey(sig *sshsig.Signature, allowedKeys string) (gossh.PublicKey
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		pub, comment, _, _, err := gossh.ParseAuthorizedKey([]byte(line))
+		pub, comment, options, _, err := gossh.ParseAuthorizedKey([]byte(line))
 		if err != nil {
-			return nil, "", fmt.Errorf("invalid allowed key %q: %w", line, err)
+			return nil, "", fmt.Errorf("invalid allowed key %q: %w (expected an authorized_keys / .pub line, not git allowed_signers)", line, err)
+		}
+		if len(options) > 0 {
+			return nil, "", fmt.Errorf("allowed key %q carries unsupported options %q; expected a plain authorized_keys / .pub line (git allowed_signers, principal-first, is not supported)", line, options)
 		}
 		if bytes.Equal(pub.Marshal(), want) {
 			return pub, comment, nil

--- a/lib/integrity/README.md
+++ b/lib/integrity/README.md
@@ -59,12 +59,13 @@ unless the run is verified, and returns the verified commit hash.
 state without leaving the integrity envelope (see
 [INTEGRITY.md](../../INTEGRITY.md), the full specification).
 
-With `--integrity-signers FILE` the ref must additionally carry an SSH
-signature made by one of the public keys in `FILE` (authorized_keys
-format, one key per line, as `git-verify-commit`): the tag signature
-for annotated tags, the commit signature otherwise. The trust anchor
-then becomes the key list instead of the local repository state, so
-verification survives cloning the repository elsewhere.
+With `--integrity-keys FILE` the ref must additionally carry an SSH
+signature made by one of the public keys in `FILE` (authorized_keys /
+`.pub` format, one key per line, as `git-verify-commit` — **not** git's
+`allowed_signers` format): the tag signature for annotated tags, the
+commit signature otherwise. The trust anchor then becomes the key list
+instead of the local repository state, so verification survives cloning
+the repository elsewhere.
 
 What integrity mode is — and is not: it is an operational assurance
 for the operator launching the script (no accidental drift, no

--- a/lib/require/require.go
+++ b/lib/require/require.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/env"
@@ -339,6 +340,13 @@ func resolve_require(module string) (string, error) {
 	module = strings.TrimSpace(module)
 	if module == "" {
 		return "", fmt.Errorf("require: empty module name")
+	}
+	// Control characters (newline, CR, tab, …) never belong in a module
+	// path: they could split the `;; $MODULE <path>` cursor prefix that
+	// loadModule prepends. Not a bypass — the module must still resolve
+	// to a committed file — but reject them outright.
+	if strings.ContainsFunc(module, unicode.IsControl) {
+		return "", fmt.Errorf("require: invalid module path %q (control characters)", module)
 	}
 	if strings.ContainsAny(module, " \\:@") {
 		return "", fmt.Errorf("require: invalid module path %q", module)

--- a/lib/require/require_test.go
+++ b/lib/require/require_test.go
@@ -294,6 +294,7 @@ func TestResolveRequire_RejectsInvalidNames(t *testing.T) {
 		"", " ", "/abs/path", "~/home", "../escape", "a/../b", "./x",
 		"a//b", ".hidden", "a/.hidden", "with space", "back\\slash",
 		"colon:name", "at@name",
+		"line\nbreak", "carriage\rreturn", "tab\there", "bell\x07",
 	} {
 		if _, err := resolve_require(bad); err == nil {
 			t.Errorf("expected error for module name %q", bad)


### PR DESCRIPTION
## Summary

Addresses the three non-bypass findings from the external adversarial review (which found **no exploitable bypass** of the six invariants).

**1. Keys file format (main priority).** The flag `--integrity-signers` and the docs evoked git's `allowed_signers` format, but the implementation (and the `git-verify-commit` builtin) use `authorized_keys`. A principal-first `allowed_signers` line was **silently misparsed** — `ParseAuthorizedKey` reads the principal as an SSH option and drops it, verifying the key with no identity constraint.
- Rename `--integrity-signers` → **`--integrity-keys`** (aligns with the builtin's `allowed-keys` parameter; drops the `allowed_signers` connotation). Pre-1.0, unreleased — clean rename, no alias.
- Harden `matchAllowedKey` (shared with `git-verify-commit`/`git-verify-tag`) to **reject** any line carrying options — i.e. `allowed_signers` format — with a clear error instead of silent principal-drop.
- Fix the contradictory docs (`lib/git/README` claimed an `allowed_signers`-style list "both work"); state everywhere it is authorized_keys/`.pub`, matched by key, no expiry (rotate by editing the file — per maintainer's call, no forced expiry).

**2. Control chars in module names.** `resolve_require` accepted `\n \r \t`, which could split the `;; $MODULE <path>` cursor prefix. Not a bypass (module must still resolve to a committed file), but rejected outright now.

**3. Audit message.** The startup line `integrity verified` could read as if the whole run were pre-verified. Reworded to `integrity: entry script and ref verified`, and documented that cascaded `require`/`load-file` are verified as they load and abort on mismatch.

## Test plan

- `lib/git`: an `allowed_signers` (principal-first) line is rejected while the **same key** verifies in `.pub` format.
- `lib/require`: control-char module names rejected.
- Flag rename threaded through tests; `examples-integrity/demo.sh` gains the `allowed_signers`-reject case and passes end to end.
- Full suite green with and without `-tags debugger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
