### PR TITLE
feat(integrity): support signed state commits

### DIFF
--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -109,7 +109,7 @@ whole run is already verified.
 | Builtin | Behaviour |
 |---|---|
 | `(assert-integrity)` | Throws unless running under `--integrity`; returns the verified commit hash. Committed code uses it to demand the mode — effective as long as operators know the program is supposed to carry it. |
-| `(state-save name value)` | Writes `value` as canonical lisp data to `.state/name.lisp` and **commits it in the same operation** (message `state: name`); returns the commit hash. Works with or without the mode; requires a Git repository. |
+| `(state-save name value)` / `(state-save name value options)` | Writes `value` as canonical lisp data to `.state/name.lisp` and **commits it in the same operation** (message `state: name`); returns the commit hash. `options` may contain `{:sign {:key OPENSSH-PRIVATE-KEY :passphrase STRING}}`, using the same SSH signing format as `git-commit`. Works with or without the mode; requires a Git repository. |
 | `(state-load name)` / `(state-load name default)` | Reads the state back as pure data (READ, never EVAL — state cannot smuggle code). Returns `default`, or throws without one, when the state does not exist. Under the mode, enforces invariant 6. |
 | `(slurp-source path)` | `slurp` for files about to be evaluated: identical, plus invariant 5 under the mode. `load-file` builds on it. |
 
@@ -127,7 +127,8 @@ integrity envelope:
 - **Commit protocol** — write file → `git add` → `git commit`, all
   inside `state-save`. Committed state is therefore always the product
   of a completed save. State commits are authored `state-save
-  <state-save@lisp>` and unsigned (v1).
+  <state-save@lisp>` and are unsigned by default; the explicit `:sign`
+  option creates a Git-compatible SSH-signed commit.
 - **Crash recovery** — a save interrupted between write and commit
   leaves the file differing from `HEAD`; the next `state-load` under
   the mode fails closed and the operator resolves it (commit the
@@ -188,9 +189,10 @@ attacker cannot write to what the interpreter reads:
 
 ## Future revisions (not implemented)
 
-- **Signed state commits** — sign `state-save` commits with a machine
-  or process key (distinct from release keys) and verify membership on
-  load, giving state authenticity, not just consistency.
+- **Enforced signed state chain** — `state-save` can create SSH-signed
+  commits, but integrity startup does not yet require every state commit
+  to be signed. A future state-key policy can verify membership on load,
+  giving state authenticity rather than auditability alone.
 - **Keys baked into the binary** — accept allowed signers via
   `-ldflags -X` at build time, shrinking the trust anchor to the
   binary alone.

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -458,7 +458,7 @@ Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integr
 | `fmt` | `[s]` | Formats lisp source s into its canonical form (as lisp --fmt does); errors if s does not parse. |
 | `sha2-256` | `[s]` | SHA2-256 digest of string s, as lowercase hex. |
 | `state-load` | `[name & [default]]` | Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under --integrity the file must match its committed version at HEAD. |
-| `state-save` | `[name value]` | Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. Under --integrity the commit keeps the verified ref valid. |
+| `state-save` | `[name value & [options]]` | Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. options may contain :sign {:key OPENSSH-PRIVATE-KEY :passphrase STRING}. Under --integrity the commit keeps the verified ref valid. |
 
 ### web
 

--- a/examples-integrity/04-state/service.lisp
+++ b/examples-integrity/04-state/service.lisp
@@ -3,6 +3,8 @@
 ;; under --integrity, requires it to match its committed version at
 ;; HEAD. The state commits do not invalidate the code ref: every
 ;; restart uses the same --integrity argument.
+;; Pass {:sign {:key (slurp "/path/to/key")}} as state-save's third
+;; argument when the state commit itself should carry an SSH signature.
 (assert-integrity)
 
 (def db (state-load "db" {:visits 0}))

--- a/internal/gogitutil/nosign.go
+++ b/internal/gogitutil/nosign.go
@@ -1,0 +1,11 @@
+package gogitutil
+
+import "io"
+
+// NoSign explicitly opts out of go-git's commit.gpgSign auto-signing.
+// Returning an empty signature leaves the object without a gpgsig header.
+type NoSign struct{}
+
+func (NoSign) Sign(io.Reader) ([]byte, error) {
+	return nil, nil
+}

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -30,6 +30,7 @@ import (
 
 	_ "embed"
 
+	"github.com/jig/lisp/internal/gogitutil"
 	"github.com/jig/lisp/lib/call"
 	. "github.com/jig/lisp/types"
 )
@@ -292,6 +293,7 @@ func gitCommit(rv MalType, msg string, params ...MalType) (MalType, error) {
 		All:               optBool(o, "all"),
 		AllowEmptyCommits: optBool(o, "allow-empty"),
 		Amend:             optBool(o, "amend"),
+		Signer:            gogitutil.NoSign{},
 	}
 	if commitOpts.Author, err = optSignature(o, "author"); err != nil {
 		return nil, err
@@ -594,7 +596,7 @@ func gitTag(rv MalType, name string, params ...MalType) (MalType, error) {
 	}
 	var tagOpts *gogit.CreateTagOptions
 	if annotated {
-		tagOpts = &gogit.CreateTagOptions{Message: message}
+		tagOpts = &gogit.CreateTagOptions{Message: message, Signer: gogitutil.NoSign{}}
 		if tagOpts.Tagger, err = optSignature(o, "tagger"); err != nil {
 			return nil, err
 		}

--- a/lib/git/git_test.go
+++ b/lib/git/git_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	gogit "github.com/go-git/go-git/v6"
+	gitconfig "github.com/go-git/go-git/v6/config"
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/env"
 	"github.com/jig/lisp/lib/core/nscore"
@@ -107,6 +109,7 @@ func TestInitAddCommitLog(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hola\n"), 0o644); err != nil {
 				t.Fatal(err)
 			}
+
 			eval(t, ns, `(git-add r "a.txt")`)
 			eval(t, ns, `(def c (git-commit r "first" {:author `+author+`}))`)
 			expectTrue(t, ns, `(= false (get c :signed))`)
@@ -125,6 +128,34 @@ func TestInitAddCommitLog(t *testing.T) {
 			eval(t, ns, `(git-close r)`)
 		})
 	}
+}
+
+func TestCommitIgnoresConfigAutoSign(t *testing.T) {
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+
+	ns := newEnv(t)
+	dir := t.TempDir()
+	eval(t, ns, fmt.Sprintf(`(def r (git-init %q))`, dir))
+
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := repo.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Commit.GpgSign = gitconfig.OptBoolTrue
+	if err := repo.SetConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hola\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	eval(t, ns, `(git-add r "a.txt")`)
+	eval(t, ns, `(def c (git-commit r "unsigned" {:author `+author+`}))`)
+	expectTrue(t, ns, `(= false (get c :signed))`)
 }
 
 func TestSignedCommitVerify(t *testing.T) {

--- a/lib/git/sign.go
+++ b/lib/git/sign.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	gogit "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/hiddeco/sshsig"
@@ -40,6 +41,12 @@ func optSigner(o map[string]MalType) (gossh.Signer, error) {
 		return gossh.ParsePrivateKeyWithPassphrase([]byte(key), []byte(passphrase))
 	}
 	return gossh.ParsePrivateKey([]byte(key))
+}
+
+// SSHSignerFromOptions parses the same {:sign {:key :passphrase}} options
+// accepted by git-commit and git-tag.
+func SSHSignerFromOptions(options HashMap) (gossh.Signer, error) {
+	return optSigner(options.Val)
 }
 
 // payloadEncoder is the part of commits and tags that reproduces the exact
@@ -82,6 +89,7 @@ func resignCommit(r *Repo, hash plumbing.Hash, signer gossh.Signer) (plumbing.Ha
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
+
 	armored, err := armorSign(c, signer)
 	if err != nil {
 		return plumbing.ZeroHash, err
@@ -105,6 +113,16 @@ func resignCommit(r *Repo, hash plumbing.Hash, signer gossh.Signer) (plumbing.Ha
 	}
 	ref := plumbing.NewHashReference(head.Name(), signedHash)
 	return signedHash, r.repo.Storer.SetReference(ref)
+}
+
+// SignCommitSSH rewrites hash with a Git-compatible SSH signature and moves
+// HEAD to the signed commit, preserving the repository's object format.
+func SignCommitSSH(repo *gogit.Repository, hash plumbing.Hash, signer gossh.Signer) (plumbing.Hash, error) {
+	r, err := newRepo(repo, "")
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+	return resignCommit(r, hash, signer)
 }
 
 // resignTag is resignCommit for annotated tags: it re-creates the tag

--- a/lib/git/sign_internal_test.go
+++ b/lib/git/sign_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-git/go-git/v6/plumbing/object"
 	gossh "golang.org/x/crypto/ssh"
 
+	"github.com/jig/lisp/internal/gogitutil"
 	. "github.com/jig/lisp/types"
 )
 
@@ -53,7 +54,7 @@ func signedCommit(t *testing.T, signer gossh.Signer) (*Repo, *object.Commit) {
 		t.Fatal(err)
 	}
 	who := &object.Signature{Name: "T", Email: "t@x", When: time.Now()}
-	hash, err := wt.Commit("one", &gogit.CommitOptions{Author: who})
+	hash, err := wt.Commit("one", &gogit.CommitOptions{Author: who, Signer: gogitutil.NoSign{}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/integrity/integrity.go
+++ b/lib/integrity/integrity.go
@@ -39,7 +39,7 @@ func Load(env EnvType) {
 	call.Call(env, ed25519_sign)
 	call.Call(env, ed25519_verify)
 	call.Call(env, assert_integrity)
-	call.Call(env, state_save)
+	call.Call(env, state_save, 2, 3)
 	call.Call(env, state_load, 1, 2)
 
 	call.Doc(env, "fmt", "[s]",
@@ -54,8 +54,8 @@ func Load(env EnvType) {
 		"Reports whether the base64 signature of string s verifies against the base64 Ed25519 public key.")
 	call.Doc(env, "assert-integrity", "[]",
 		"Throws unless the interpreter runs under --integrity; returns the verified commit hash.")
-	call.Doc(env, "state-save", "[name value]",
-		"Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. Under --integrity the commit keeps the verified ref valid.")
+	call.Doc(env, "state-save", "[name value & [options]]",
+		"Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. options may contain :sign {:key OPENSSH-PRIVATE-KEY :passphrase STRING}. Under --integrity the commit keeps the verified ref valid.")
 	call.Doc(env, "state-load", "[name & [default]]",
 		"Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under --integrity the file must match its committed version at HEAD.")
 }

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -355,7 +355,21 @@ func TestStateSaveSignedCommit(t *testing.T) {
 					t.Fatalf("state commit author = %s <%s>", commit.Author.Name, commit.Author.Email)
 				}
 			}
-			expectTrue(t, ns, `(get (git-status r) :clean)`)
+			repo, err := gogit.PlainOpen(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wt, err := repo.Worktree()
+			if err != nil {
+				t.Fatal(err)
+			}
+			status, err := wt.Status()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !status.IsClean() {
+				t.Fatalf("state worktree is dirty: %v", status)
+			}
 		})
 	}
 }

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -11,9 +11,13 @@ import (
 	"strings"
 	"testing"
 
+	gogit "github.com/go-git/go-git/v6"
+	gitconfig "github.com/go-git/go-git/v6/config"
+	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/env"
 	"github.com/jig/lisp/lib/core/nscore"
+	libgit "github.com/jig/lisp/lib/git"
 	"github.com/jig/lisp/lib/git/nsgit"
 	"github.com/jig/lisp/lib/integrity"
 	"github.com/jig/lisp/lib/integrity/nsintegrity"
@@ -273,6 +277,7 @@ func TestStateSaveLoadWithoutIntegrity(t *testing.T) {
 	if !ok || hash == "" {
 		t.Fatalf("state-save did not return a commit hash")
 	}
+
 	expectTrue(t, ns, `(= 1 (get (state-load "db") :n))`)
 	expectTrue(t, ns, `(= "operador" (get (state-load "db") :who))`)
 	expectTrue(t, ns, `(= 42 (state-load "missing" 42))`)
@@ -283,6 +288,76 @@ func TestStateSaveLoadWithoutIntegrity(t *testing.T) {
 	// The state commit is a real commit at HEAD touching only .state/.
 	expectTrue(t, ns, fmt.Sprintf(`(= %q (get (git-show r "HEAD") :hash))`, hash))
 	expectTrue(t, ns, `(= "state: db" (get (git-show r "HEAD") :message))`)
+}
+
+func TestStateSaveIgnoresCommitGPGSign(t *testing.T) {
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+
+	ns := newGitEnv(t)
+	dir, _ := setupRepo(t, ns, "")
+	t.Chdir(dir)
+
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := repo.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Commit.GpgSign = gitconfig.OptBoolTrue
+	if err := repo.SetConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	hash := evalLisp(t, ns, `(state-save "db" {:n 1})`).(string)
+	commit, err := repo.CommitObject(plumbing.NewHash(hash))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if commit.Signature != "" || commit.SignatureSHA256 != "" {
+		t.Fatal("state-save commit must remain unsigned")
+	}
+}
+
+func TestStateSaveSignedCommit(t *testing.T) {
+	for _, format := range []string{"sha1", "sha256"} {
+		t.Run(format, func(t *testing.T) {
+			ns := newGitEnv(t)
+			privPEM, authorized := testKey(t, "state-writer")
+			dir := t.TempDir()
+			t.Chdir(dir)
+			evalLisp(t, ns, fmt.Sprintf(
+				`(def r (git-init %q {:object-format %q}))`,
+				dir,
+				format,
+			))
+
+			for n := 1; n <= 2; n++ {
+				hash := evalLisp(t, ns, fmt.Sprintf(
+					`(state-save "db" {:n %d} {:sign {:key %q}})`,
+					n,
+					privPEM,
+				)).(string)
+				repo, err := gogit.PlainOpen(dir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				commit, err := repo.CommitObject(plumbing.NewHash(hash))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := libgit.VerifyCommitSSH(commit, authorized); err != nil {
+					t.Fatalf("verify signed state commit: %v", err)
+				}
+				if commit.Author.Name != "state-save" || commit.Author.Email != "state-save@lisp" {
+					t.Fatalf("state commit author = %s <%s>", commit.Author.Name, commit.Author.Email)
+				}
+			}
+			expectTrue(t, ns, `(get (git-status r) :clean)`)
+		})
+	}
 }
 
 func TestStateUnderIntegrity(t *testing.T) {

--- a/lib/integrity/state.go
+++ b/lib/integrity/state.go
@@ -24,6 +24,8 @@ import (
 	gogit "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/jig/lisp/format"
+	"github.com/jig/lisp/internal/gogitutil"
+	libgit "github.com/jig/lisp/lib/git"
 	"github.com/jig/lisp/printer"
 	"github.com/jig/lisp/reader"
 	. "github.com/jig/lisp/types"
@@ -76,9 +78,26 @@ func statePath(fnName, name string) (string, error) {
 	return stateDir + "/" + name + ".lisp", nil
 }
 
-func state_save(name string, value MalType) (MalType, error) {
+func state_save(name string, value MalType, params ...MalType) (MalType, error) {
 	stateMu.Lock()
 	defer stateMu.Unlock()
+
+	options := HashMap{Val: map[string]MalType{}}
+	switch len(params) {
+	case 0:
+	case 1:
+		var ok bool
+		options, ok = params[0].(HashMap)
+		if !ok {
+			return nil, fmt.Errorf("state-save: options must be a map, got %T", params[0])
+		}
+	default:
+		return nil, fmt.Errorf("state-save: expected one options map, got %d arguments", len(params))
+	}
+	signer, err := libgit.SSHSignerFromOptions(options)
+	if err != nil {
+		return nil, fmt.Errorf("state-save: %w", err)
+	}
 
 	rel, err := statePath("state-save", name)
 	if err != nil {
@@ -118,9 +137,16 @@ func state_save(name string, value MalType) (MalType, error) {
 	}
 	hash, err := wt.Commit("state: "+name, &gogit.CommitOptions{
 		Author: &object.Signature{Name: "state-save", Email: "state-save@lisp", When: time.Now()},
+		Signer: gogitutil.NoSign{},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("state-save: %w", err)
+	}
+	if signer != nil {
+		hash, err = libgit.SignCommitSSH(repo, hash, signer)
+		if err != nil {
+			return nil, fmt.Errorf("state-save: sign commit: %w", err)
+		}
 	}
 	return hash.String(), nil
 }

--- a/lib/integrity/state.go
+++ b/lib/integrity/state.go
@@ -132,7 +132,10 @@ func state_save(name string, value MalType, params ...MalType) (MalType, error) 
 	if err != nil {
 		return nil, fmt.Errorf("state-save: %w", err)
 	}
-	if _, err := wt.Add(rel); err != nil {
+	if err := wt.AddWithOptions(&gogit.AddOptions{
+		Path:       rel,
+		SkipStatus: true,
+	}); err != nil {
 		return nil, fmt.Errorf("state-save: %w", err)
 	}
 	hash, err := wt.Commit("state: "+name, &gogit.CommitOptions{


### PR DESCRIPTION
## Summary

- add optional Git-compatible SSH signing to `state-save`
- preserve unsigned state commits by default and ignore ambient `commit.gpgSign` / `tag.gpgSign`
- share the explicit no-sign behavior with `git-commit` and `git-tag`
- document that state signatures are auditable but not yet required by integrity startup

## API

```lisp
(state-save "db" value
  {:sign {:key openssh-private-key
          :passphrase optional}})
```

## Validation

- `go test ./lib/git ./lib/integrity ./command`
- signed state commits verified in SHA-1 and SHA-256 repositories
- end-to-end `pking/lisp` demo with unsigned hash-only and SSH-signed flows