### PR TITLE
Make state files readable and deterministic

### DIFF
--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -273,11 +273,39 @@ func TestStateSaveLoadWithoutIntegrity(t *testing.T) {
 	dir, _ := setupRepo(t, ns, "")
 	t.Chdir(dir)
 
-	hash, ok := evalLisp(t, ns, `(state-save "db" {:n 1 :who "operador"})`).(string)
+	state := `{:z "last" :n 1 :who "operador" :entries [` +
+		`{:payload "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnop" :label "alpha"} ` +
+		`{:payload "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnop" :label "beta"}]}`
+	hash, ok := evalLisp(t, ns, `(state-save "db" `+state+`)`).(string)
 	if !ok || hash == "" {
 		t.Fatalf("state-save did not return a commit hash")
 	}
 
+	contentBytes, err := os.ReadFile(filepath.Join(dir, ".state", "db.lisp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(contentBytes)
+	keyIndexes := []int{
+		strings.Index(content, ":entries"),
+		strings.Index(content, ":n 1"),
+		strings.Index(content, ":who"),
+		strings.Index(content, ":z"),
+	}
+	for i, index := range keyIndexes {
+		if index < 0 || i > 0 && index <= keyIndexes[i-1] {
+			t.Fatalf("state keys are not in deterministic order: %q", content)
+		}
+	}
+	if !strings.Contains(content, "\n           {:label \"beta\"") ||
+		!strings.Contains(content, "\n            :payload ") {
+		t.Fatalf("nested state value is not multiline:\n%s", content)
+	}
+	if !strings.HasSuffix(content, "\n") || strings.HasSuffix(content, "\n\n") {
+		t.Fatalf("state file must have exactly one trailing newline: %q", content)
+	}
+
+	expectTrue(t, ns, `(= `+state+` (state-load "db"))`)
 	expectTrue(t, ns, `(= 1 (get (state-load "db") :n))`)
 	expectTrue(t, ns, `(= "operador" (get (state-load "db") :who))`)
 	expectTrue(t, ns, `(= 42 (state-load "missing" 42))`)

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -15,6 +15,7 @@ import (
 	gogit "github.com/go-git/go-git/v6"
 	gitconfig "github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/env"
 	"github.com/jig/lisp/lib/core/nscore"
@@ -444,6 +445,57 @@ func TestStateSaveSignedCommit(t *testing.T) {
 				t.Fatal("state differs between worktree, index, and HEAD")
 			}
 		})
+	}
+}
+
+// TestStateSaveIdempotentUnchanged verifies that saving a byte-identical
+// value is a no-op returning the existing commit, not an ErrEmptyCommit
+// failure. Deterministic serialization makes an unchanged value produce
+// an unchanged file, so without idempotence a repeated save would error.
+func TestStateSaveIdempotentUnchanged(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, _ := setupRepo(t, ns, "")
+	t.Chdir(dir)
+
+	first := evalLisp(t, ns, `(state-save "db" {:a 1 :b 2 :c 3})`).(string)
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	countState := func() int {
+		iter, err := repo.Log(&gogit.LogOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		n := 0
+		_ = iter.ForEach(func(c *object.Commit) error {
+			if strings.HasPrefix(c.Message, "state: ") {
+				n++
+			}
+			return nil
+		})
+		return n
+	}
+	if countState() != 1 {
+		t.Fatalf("expected 1 state commit, got %d", countState())
+	}
+
+	// Re-saving the identical value must not error and must not add a commit.
+	second := evalLisp(t, ns, `(state-save "db" {:a 1 :b 2 :c 3})`).(string)
+	if second != first {
+		t.Fatalf("idempotent save returned %q, want the existing commit %q", second, first)
+	}
+	if countState() != 1 {
+		t.Fatalf("idempotent save created a new commit: %d state commits", countState())
+	}
+
+	// A changed value still commits.
+	third := evalLisp(t, ns, `(state-save "db" {:a 1 :b 2 :c 4})`).(string)
+	if third == first {
+		t.Fatal("changed save should produce a new commit")
+	}
+	if countState() != 2 {
+		t.Fatalf("expected 2 state commits after a change, got %d", countState())
 	}
 }
 

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -387,16 +388,60 @@ func TestStateSaveSignedCommit(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			wt, err := repo.Worktree()
+
+			const statePath = ".state/db.lisp"
+			worktreeData, err := os.ReadFile(filepath.Join(dir, filepath.FromSlash(statePath)))
 			if err != nil {
 				t.Fatal(err)
 			}
-			status, err := wt.Status()
+			idx, err := repo.Storer.Index()
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !status.IsClean() {
-				t.Fatalf("state worktree is dirty: %v", status)
+			entry, err := idx.Entry(statePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			indexBlob, err := repo.BlobObject(entry.Hash)
+			if err != nil {
+				t.Fatal(err)
+			}
+			indexReader, err := indexBlob.Reader()
+			if err != nil {
+				t.Fatal(err)
+			}
+			indexData, err := io.ReadAll(indexReader)
+			if closeErr := indexReader.Close(); err == nil {
+				err = closeErr
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			head, err := repo.Head()
+			if err != nil {
+				t.Fatal(err)
+			}
+			headCommit, err := repo.CommitObject(head.Hash())
+			if err != nil {
+				t.Fatal(err)
+			}
+			headTree, err := headCommit.Tree()
+			if err != nil {
+				t.Fatal(err)
+			}
+			headFile, err := headTree.File(statePath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			headData, err := headFile.Contents()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// go-git v6 alpha.4 hashes racy worktree files with SHA-1 even
+			// in SHA-256 repositories, so Status can report a false change.
+			if string(worktreeData) != string(indexData) || string(worktreeData) != headData {
+				t.Fatal("state differs between worktree, index, and HEAD")
 			}
 		})
 	}

--- a/lib/integrity/state.go
+++ b/lib/integrity/state.go
@@ -144,6 +144,19 @@ func state_save(name string, value MalType, params ...MalType) (MalType, error) 
 		Signer: gogitutil.NoSign{},
 	})
 	if err != nil {
+		// Deterministic serialization means an unchanged value produces
+		// a byte-identical file, so re-saving the same state leaves the
+		// worktree clean. That is a no-op, not an error: the state is
+		// already committed, so return the existing HEAD commit. (A
+		// :sign option is ignored here — there is nothing new to sign;
+		// sign when the value actually changes.)
+		if errors.Is(err, gogit.ErrEmptyCommit) {
+			head, herr := repo.Head()
+			if herr != nil {
+				return nil, fmt.Errorf("state-save: %w", herr)
+			}
+			return head.Hash().String(), nil
+		}
 		return nil, fmt.Errorf("state-save: %w", err)
 	}
 	if signer != nil {

--- a/lib/integrity/state.go
+++ b/lib/integrity/state.go
@@ -108,10 +108,11 @@ func state_save(name string, value MalType, params ...MalType) (MalType, error) 
 		return nil, err
 	}
 
-	// Canonical form: print readably and run the formatter, so state
-	// files diff cleanly and hash deterministically. A value the reader
-	// cannot round-trip (a live handle, a function) fails here.
-	printed := printer.Pr_str(value, true)
+	// Canonical form: print readable data at a stable width and run the
+	// formatter, so state files diff cleanly and hash deterministically.
+	// A value the reader cannot round-trip (a live handle, a function)
+	// fails here.
+	printed := printer.Pr_data(value, 100)
 	canon, err := format.Source([]byte(printed))
 	if err != nil {
 		return nil, fmt.Errorf("state-save: value is not serializable lisp data: %w", err)

--- a/lib/integrity/state.go
+++ b/lib/integrity/state.go
@@ -23,7 +23,6 @@ import (
 
 	gogit "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing/object"
-	"github.com/jig/lisp/format"
 	"github.com/jig/lisp/internal/gogitutil"
 	libgit "github.com/jig/lisp/lib/git"
 	"github.com/jig/lisp/printer"
@@ -108,17 +107,16 @@ func state_save(name string, value MalType, params ...MalType) (MalType, error) 
 		return nil, err
 	}
 
-	// Canonical form: print readable data at a stable width and run the
-	// formatter, so state files diff cleanly and hash deterministically.
-	// A value the reader cannot round-trip (a live handle, a function)
-	// fails here.
-	printed := printer.Pr_data(value, 100)
-	canon, err := format.Source([]byte(printed))
-	if err != nil {
-		return nil, fmt.Errorf("state-save: value is not serializable lisp data: %w", err)
-	}
+	// Canonical form: Pr_data is the single source of truth for state
+	// layout — it prints readable data deterministically (sorted map/set
+	// keys) at a stable width, so state files diff cleanly and hash
+	// deterministically. The lisp source formatter is not run: on
+	// Pr_data output it only appends this trailing newline. Validate that
+	// the text round-trips — a value the reader cannot read back (a live
+	// handle, a function) fails here.
+	canon := []byte(printer.Pr_data(value, 100) + "\n")
 	if _, err := reader.Read_str(string(canon), NewCursorFile(rel), nil); err != nil {
-		return nil, fmt.Errorf("state-save: value is not readable lisp data: %w", err)
+		return nil, fmt.Errorf("state-save: value is not serializable lisp data: %w", err)
 	}
 
 	abs := filepath.Join(root, filepath.FromSlash(rel))

--- a/printer/data.go
+++ b/printer/data.go
@@ -1,0 +1,273 @@
+package printer
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/jig/lisp/marshaler"
+	"github.com/jig/lisp/types"
+)
+
+// Pr_data prints readable Lisp data deterministically, wrapping collections
+// at maxWidth rune columns. Scalar values are never split.
+func Pr_data(value types.MalType, maxWidth int) string {
+	if maxWidth < 1 {
+		maxWidth = 1
+	}
+	return dataPrinter{maxWidth: maxWidth}.render(value, 0)
+}
+
+type dataPrinter struct {
+	maxWidth int
+}
+
+func (p dataPrinter) render(value types.MalType, column int) string {
+	flat := p.flat(value)
+	if column+runeWidth(flat) <= p.maxWidth || isEmptyCollection(value) {
+		return flat
+	}
+
+	switch value := value.(type) {
+	case types.LispPrintable:
+		return flat
+	case types.List:
+		return p.renderList(value.Val, column)
+	case types.Vector:
+		return p.renderSequence(value.Val, column, "[", "]")
+	case marshaler.HashMap:
+		mapped, err := value.MarshalHashMap()
+		if err != nil {
+			return "{}"
+		}
+		if hashMap, ok := mapped.(types.HashMap); ok {
+			return p.renderMap(hashMap, column)
+		}
+		return flat
+	case types.HashMap:
+		return p.renderMap(value, column)
+	case types.Set:
+		return p.renderSet(value, column)
+	default:
+		if indirect, ok := indirectData(value); ok {
+			return p.render(indirect, column)
+		}
+		return flat
+	}
+}
+
+func (p dataPrinter) flat(value types.MalType) string {
+	switch value := value.(type) {
+	case types.LispPrintable:
+		return value.LispPrint(func(value types.MalType, _ bool) string {
+			return p.flat(value)
+		})
+	case types.List:
+		return p.flatSequence(value.Val, "(", ")")
+	case types.Vector:
+		return p.flatSequence(value.Val, "[", "]")
+	case marshaler.HashMap:
+		mapped, err := value.MarshalHashMap()
+		if err != nil {
+			return "{}"
+		}
+		if hashMap, ok := mapped.(types.HashMap); ok {
+			return p.flatMap(hashMap)
+		}
+		return Pr_str(value, true)
+	case types.HashMap:
+		return p.flatMap(value)
+	case types.Set:
+		entries := p.sortedSetEntries(value)
+		return "#{" + strings.Join(entries, " ") + "}"
+	default:
+		if indirect, ok := indirectData(value); ok {
+			return p.flat(indirect)
+		}
+		return Pr_str(value, true)
+	}
+}
+
+func (p dataPrinter) flatSequence(values []types.MalType, open, close string) string {
+	parts := make([]string, len(values))
+	for i, value := range values {
+		parts[i] = p.flat(value)
+	}
+	return open + strings.Join(parts, " ") + close
+}
+
+func (p dataPrinter) flatMap(value types.HashMap) string {
+	entries := p.sortedMapEntries(value)
+	parts := make([]string, 0, len(entries)*2)
+	for _, entry := range entries {
+		parts = append(parts, entry.keyFlat, p.flat(entry.value))
+	}
+	return "{" + strings.Join(parts, " ") + "}"
+}
+
+func (p dataPrinter) renderSequence(values []types.MalType, column int, open, close string) string {
+	if len(values) == 0 {
+		return open + close
+	}
+
+	childColumn := column + runeWidth(open)
+	var b strings.Builder
+	b.WriteString(open)
+	for i, value := range values {
+		if i > 0 {
+			b.WriteByte('\n')
+			b.WriteString(strings.Repeat(" ", childColumn))
+		}
+		b.WriteString(p.render(value, childColumn))
+	}
+	b.WriteString(close)
+	return b.String()
+}
+
+func (p dataPrinter) renderSet(value types.Set, column int) string {
+	entries := p.sortedSetEntries(value)
+	if len(entries) == 0 {
+		return "#{}"
+	}
+
+	childColumn := column + 2
+	var b strings.Builder
+	b.WriteString("#{")
+	for i, entry := range entries {
+		if i > 0 {
+			b.WriteByte('\n')
+			b.WriteString(strings.Repeat(" ", childColumn))
+		}
+		b.WriteString(entry)
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+func (p dataPrinter) renderMap(value types.HashMap, column int) string {
+	entries := p.sortedMapEntries(value)
+	if len(entries) == 0 {
+		return "{}"
+	}
+
+	childColumn := column + 1
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, entry := range entries {
+		if i > 0 {
+			b.WriteByte('\n')
+			b.WriteString(strings.Repeat(" ", childColumn))
+		}
+		b.WriteString(entry.keyFlat)
+		b.WriteByte(' ')
+		valueColumn := childColumn + runeWidth(entry.keyFlat) + 1
+		b.WriteString(p.render(entry.value, valueColumn))
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+func (p dataPrinter) renderList(values []types.MalType, column int) string {
+	if len(values) == 0 {
+		return "()"
+	}
+
+	childColumn := column + 2
+	var b strings.Builder
+	b.WriteByte('(')
+
+	lineColumn := column + 1
+	rendered := p.render(values[0], lineColumn)
+	b.WriteString(rendered)
+	lineColumn = columnAfter(lineColumn, rendered)
+
+	for i, value := range values[1:] {
+		flat := p.flat(value)
+		if lineColumn+1+runeWidth(flat) <= p.maxWidth {
+			b.WriteByte(' ')
+			b.WriteString(flat)
+			lineColumn += 1 + runeWidth(flat)
+			continue
+		}
+
+		if i == 0 {
+			rendered = p.render(value, lineColumn+1)
+			b.WriteByte(' ')
+			b.WriteString(rendered)
+			lineColumn = columnAfter(lineColumn+1, rendered)
+			continue
+		}
+
+		b.WriteByte('\n')
+		b.WriteString(strings.Repeat(" ", childColumn))
+		rendered = p.render(value, childColumn)
+		b.WriteString(rendered)
+		lineColumn = columnAfter(childColumn, rendered)
+	}
+	b.WriteByte(')')
+	return b.String()
+}
+
+type mapEntry struct {
+	keyFlat string
+	value   types.MalType
+}
+
+func (p dataPrinter) sortedMapEntries(value types.HashMap) []mapEntry {
+	entries := make([]mapEntry, 0, len(value.Val))
+	for key, item := range value.Val {
+		entries = append(entries, mapEntry{keyFlat: p.flat(key), value: item})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].keyFlat < entries[j].keyFlat
+	})
+	return entries
+}
+
+func (p dataPrinter) sortedSetEntries(value types.Set) []string {
+	entries := make([]string, 0, len(value.Val))
+	for entry := range value.Val {
+		entries = append(entries, p.flat(entry))
+	}
+	sort.Strings(entries)
+	return entries
+}
+
+func indirectData(value types.MalType) (types.MalType, bool) {
+	if _, ok := value.(fmt.Stringer); ok {
+		return nil, false
+	}
+	reflected := reflect.ValueOf(value)
+	if !reflected.IsValid() || reflected.Kind() != reflect.Pointer || reflected.IsNil() {
+		return nil, false
+	}
+	return reflect.Indirect(reflected).Interface(), true
+}
+
+func isEmptyCollection(value types.MalType) bool {
+	switch value := value.(type) {
+	case types.List:
+		return len(value.Val) == 0
+	case types.Vector:
+		return len(value.Val) == 0
+	case types.HashMap:
+		return len(value.Val) == 0
+	case types.Set:
+		return len(value.Val) == 0
+	default:
+		return false
+	}
+}
+
+func columnAfter(start int, value string) int {
+	if newline := strings.LastIndexByte(value, '\n'); newline >= 0 {
+		return runeWidth(value[newline+1:])
+	}
+	return start + runeWidth(value)
+}
+
+func runeWidth(value string) int {
+	return utf8.RuneCountInString(value)
+}

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jig/lisp/printer"
+	"github.com/jig/lisp/reader"
 	"github.com/jig/lisp/types"
 )
 
@@ -172,5 +173,60 @@ func TestPrStrHashMapMulti(t *testing.T) {
 		if !strings.Contains(got, part) {
 			t.Fatalf("%q missing %q", got, part)
 		}
+	}
+}
+
+func TestPrDataDeterministicMixedCollections(t *testing.T) {
+	value := types.HashMap{Val: map[string]types.MalType{
+		"ʞz": types.HashMap{Val: map[string]types.MalType{"ʞb": 2, "ʞa": 1}},
+		"a": types.List{Val: []types.MalType{
+			types.Symbol{Val: "quote"},
+			types.Vector{Val: []types.MalType{3, 2, 1}},
+		}},
+		"ʞa": types.Set{Val: map[string]struct{}{"beta": {}, "ʞalpha": {}, "alpha": {}}},
+		"z":  nil,
+	}}
+	want := `{"a" (quote [3 2 1]) "z" nil :a #{"alpha" "beta" :alpha} :z {:a 1 :b 2}}`
+
+	for range 20 {
+		if got := printer.Pr_data(value, 200); got != want {
+			t.Fatalf("Pr_data = %q, want %q", got, want)
+		}
+	}
+}
+
+func TestPrDataNestedWidthAwareLayout(t *testing.T) {
+	value := types.Vector{Val: []types.MalType{
+		types.HashMap{Val: map[string]types.MalType{
+			"ʞvalues": types.Vector{Val: []types.MalType{1, 2, 3, 4}},
+			"ʞname":   "alpha",
+		}},
+		types.HashMap{Val: map[string]types.MalType{
+			"ʞquoted": types.List{Val: []types.MalType{
+				types.Symbol{Val: "quote"},
+				types.Vector{Val: []types.MalType{10, 20, 30, 40}},
+			}},
+			"ʞname": "beta",
+		}},
+	}}
+	want := `[{:name "alpha"
+  :values [1 2 3 4]}
+ {:name "beta"
+  :quoted (quote [10
+                  20
+                  30
+                  40])}]`
+
+	got := printer.Pr_data(value, 24)
+	if got != want {
+		t.Fatalf("Pr_data:\n%s\nwant:\n%s", got, want)
+	}
+
+	roundTrip, err := reader.Read_str(got, types.NewCursorFile(t.Name()), nil)
+	if err != nil {
+		t.Fatalf("read Pr_data output: %v", err)
+	}
+	if roundTripPrinted := printer.Pr_data(roundTrip, 24); roundTripPrinted != want {
+		t.Fatalf("round-trip Pr_data:\n%s\nwant:\n%s", roundTripPrinted, want)
 	}
 }


### PR DESCRIPTION
## Summary

- serialize state with deterministic map and set ordering
- wrap nested collections at a stable 100-column width
- preserve readable round trips and exact committed-byte integrity

## Validation

- `go test ./printer ./lib/integrity`