### PR TITLE
feat(integrity): sign commits/tags/state via ssh-agent under --integrity-keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,7 +164,13 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   (authorized_keys / `.pub` format, as `git-verify-commit` — not git's
   `allowed_signers`; a principal-first line is rejected, keys are
   matched by key with no expiry); a JSON audit line is logged on
-  successful verification. New builtins:
+  successful verification. That same key set also **drives signing**:
+  while `--integrity-keys` is active, every `git-commit`, annotated
+  `git-tag` and `state-save` made during the run is SSH-signed with the
+  **ssh-agent** key listed there — no private key ever enters the
+  process, and it fails closed if no listed key is loaded in the agent.
+  (`git-commit`/`git-tag` therefore no longer take a `:sign {:key …}`
+  option — signing is agent-driven only.) New builtins:
   `(assert-integrity)` throws unless the run is verified — so
   committed code can demand the flag — and returns the verified commit
   hash; `(state-save name value)` / `(state-load name & [default])`

--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -94,7 +94,12 @@ lisp --integrity v1.4.2 --integrity-keys /etc/lisp/release-keys service.lisp
   git's `allowed_signers` format (which puts the principal first); such
   a line is rejected, not silently accepted, so the trust anchor is the
   set of keys, matched by key — no principal or validity constraints
-  (rotate keys by editing the file, not by expiry). Requires
+  (rotate keys by editing the file, not by expiry). This same key set
+  also **drives signing**: while `--integrity-keys` is active, every
+  `git-commit`, annotated `git-tag` and `state-save` made during the run
+  is SSH-signed with the **ssh-agent** key whose public key is listed
+  here (no private key ever enters the process; fails closed if no
+  listed key is loaded in the agent). Requires
   `--integrity`.
 
 On success one structured JSON line is logged to stderr for the audit
@@ -109,7 +114,7 @@ whole run is already verified.
 | Builtin | Behaviour |
 |---|---|
 | `(assert-integrity)` | Throws unless running under `--integrity`; returns the verified commit hash. Committed code uses it to demand the mode — effective as long as operators know the program is supposed to carry it. |
-| `(state-save name value)` / `(state-save name value options)` | Writes `value` as canonical lisp data to `.state/name.lisp` and **commits it in the same operation** (message `state: name`); returns the commit hash. `options` may contain `{:sign {:key OPENSSH-PRIVATE-KEY :passphrase STRING}}`, using the same SSH signing format as `git-commit`. Works with or without the mode; requires a Git repository. |
+| `(state-save name value)` | Writes `value` as canonical lisp data to `.state/name.lisp` and **commits it in the same operation** (message `state: name`); returns the commit hash. Under `--integrity-keys` the commit is SSH-signed with the ssh-agent key listed there (no per-call key). Saving an unchanged value is a no-op returning the current commit. Works with or without the mode; requires a Git repository. |
 | `(state-load name)` / `(state-load name default)` | Reads the state back as pure data (READ, never EVAL — state cannot smuggle code). Returns `default`, or throws without one, when the state does not exist. Under the mode, enforces invariant 6. |
 | `(slurp-source path)` | `slurp` for files about to be evaluated: identical, plus invariant 5 under the mode. `load-file` builds on it. |
 
@@ -127,8 +132,8 @@ integrity envelope:
 - **Commit protocol** — write file → `git add` → `git commit`, all
   inside `state-save`. Committed state is therefore always the product
   of a completed save. State commits are authored `state-save
-  <state-save@lisp>` and are unsigned by default; the explicit `:sign`
-  option creates a Git-compatible SSH-signed commit.
+  <state-save@lisp>`; they are Git-compatible SSH-signed when
+  `--integrity-keys` is active (ssh-agent key), unsigned otherwise.
 - **Crash recovery** — a save interrupted between write and commit
   leaves the file differing from `HEAD`; the next `state-load` under
   the mode fails closed and the operator resolves it (commit the
@@ -189,10 +194,11 @@ attacker cannot write to what the interpreter reads:
 
 ## Future revisions (not implemented)
 
-- **Enforced signed state chain** — `state-save` can create SSH-signed
-  commits, but integrity startup does not yet require every state commit
-  to be signed. A future state-key policy can verify membership on load,
-  giving state authenticity rather than auditability alone.
+- **Enforced signed state chain** — under `--integrity-keys` state
+  commits are SSH-signed, but integrity startup does not yet *require*
+  every state commit to be signed by a listed key. A future check on
+  load would verify that membership, giving state authenticity rather
+  than auditability alone.
 - **Keys baked into the binary** — accept allowed signers via
   `-ldflags -X` at build time, shrinking the trust anchor to the
   binary alone.

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -458,7 +458,7 @@ Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integr
 | `fmt` | `[s]` | Formats lisp source s into its canonical form (as lisp --fmt does); errors if s does not parse. |
 | `sha2-256` | `[s]` | SHA2-256 digest of string s, as lowercase hex. |
 | `state-load` | `[name & [default]]` | Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under --integrity the file must match its committed version at HEAD. |
-| `state-save` | `[name value & [options]]` | Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. options may contain :sign {:key OPENSSH-PRIVATE-KEY :passphrase STRING}. Under --integrity the commit keeps the verified ref valid. |
+| `state-save` | `[name value]` | Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there. Under --integrity the commit keeps the verified ref valid. |
 
 ### web
 
@@ -493,7 +493,7 @@ Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integr
 | `git-checkout` | `[repo ref & {:create :force}]` | Checks out a branch, tag or revision; :create true creates the branch first. |
 | `git-clone` | `[url path & {:auth :branch :depth :single-branch :bare}]` | Clones url into path and returns a handle; see git-push for the :auth map. |
 | `git-close` | `[repo]` | Closes a repository handle. |
-| `git-commit` | `[repo msg & {:author {:name :email} :committer :sign {:key :passphrase} :all :allow-empty :amend}]` | Commits staged changes and returns the commit map; :sign takes an OpenSSH private key (PEM string) and produces an SSH signature. |
+| `git-commit` | `[repo msg & {:author {:name :email} :committer :all :allow-empty :amend}]` | Commits staged changes and returns the commit map. Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there; otherwise it is unsigned (there is no per-call key option). |
 | `git-fetch` | `[repo & {:auth :remote :refspecs :depth :prune :force}]` | Fetches from :remote (default origin); returns :ok or :up-to-date. |
 | `git-head` | `[repo]` | Returns {:name :branch :hash} for HEAD. |
 | `git-init` | `[path & {:bare :object-format}]` | Creates a repository at path and returns a handle; :object-format "sha256" for a SHA-256 repo. |
@@ -505,7 +505,7 @@ Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integr
 | `git-remotes` | `[repo]` | Returns a vector of {:name :urls} for the configured remotes. |
 | `git-show` | `[repo rev]` | Returns the commit map for rev (hash, "HEAD", branch or tag name). |
 | `git-status` | `[repo]` | Returns {:clean bool :files {path {:staging kw :worktree kw}}} for the worktree. |
-| `git-tag` | `[repo name & {:at :message :tagger {:name :email} :sign}]` | Creates a tag at HEAD (or :at rev); :message makes it annotated, :sign (requires :message) signs it. |
+| `git-tag` | `[repo name & {:at :message :tagger {:name :email}}]` | Creates a tag at HEAD (or :at rev); :message makes it annotated. Under --integrity-keys an annotated tag is SSH-signed with the ssh-agent key listed there. |
 | `git-tag-verified?` | `[repo name allowed-keys]` | (git-tag-verified? repo name allowed-keys) is true when the tag's SSH signature verifies against allowed-keys. |
 | `git-tags` | `[repo]` | Returns a vector of {:name :hash :target :annotated} for all tags. |
 | `git-verified?` | `[repo rev allowed-keys]` | (git-verified? repo rev allowed-keys) is true when the commit's SSH signature verifies against allowed-keys. |

--- a/command/integrity.go
+++ b/command/integrity.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/jig/lisp/lib/core"
+	libgit "github.com/jig/lisp/lib/git"
 	"github.com/jig/lisp/lib/integrity"
 	"github.com/jig/lisp/lib/require"
 )
@@ -42,6 +43,14 @@ func setupIntegrity(a args) error {
 	}
 	require.VerifyModule = integrity.VerifyFile
 	core.VerifySource = integrity.VerifyFile
+
+	// With --integrity-keys, git commits/tags and state-save made during
+	// the run are SSH-signed with the ssh-agent key that is listed in the
+	// keys file. No private key ever enters the process; the resolution
+	// is lazy and fails closed if no listed key is loaded in the agent.
+	if keys != "" {
+		libgit.SetSigningKeys(os.Getenv("SSH_AUTH_SOCK"), keys)
+	}
 
 	// One structured line to stderr for the operator's audit trail. It
 	// attests the pinned ref and the entry script only; each require /

--- a/examples-integrity/04-state/service.lisp
+++ b/examples-integrity/04-state/service.lisp
@@ -3,8 +3,8 @@
 ;; under --integrity, requires it to match its committed version at
 ;; HEAD. The state commits do not invalidate the code ref: every
 ;; restart uses the same --integrity argument.
-;; Pass {:sign {:key (slurp "/path/to/key")}} as state-save's third
-;; argument when the state commit itself should carry an SSH signature.
+;; Run under --integrity-keys and the state commit is SSH-signed
+;; automatically with the ssh-agent key listed there — no key in the code.
 (assert-integrity)
 
 (def db (state-load "db" {:visits 0}))

--- a/examples-integrity/demo.sh
+++ b/examples-integrity/demo.sh
@@ -25,6 +25,10 @@ repo() { # repo <example-dir> → sets up $WORK/<example-dir> as a fresh tagged 
 	cp -r "$HERE/$1/." "$dir/"
 	cd "$dir"
 	git init -q
+	# Hermetic: ignore the runner's global commit.gpgsign / tag.gpgsign so
+	# the plain commit and lightweight tag below never demand a signature.
+	git config commit.gpgsign false
+	git config tag.gpgsign false
 	git add -A
 	git -c user.name=Demo -c user.email=demo@example.com commit -qm "release"
 	git tag v1

--- a/lib/git/README.md
+++ b/lib/git/README.md
@@ -15,28 +15,20 @@ nsgit.Load(env)
 ## Quick example
 
 ```clojure
-(def key (slurp "/home/me/.ssh/id_ed25519"))
 (def pub (slurp "/home/me/.ssh/id_ed25519.pub"))
 
 (git-with-repo [r (git-init "/tmp/demo" {:object-format "sha256"})]
   (spit "/tmp/demo/a.txt" "hello\n")
   (git-add r "a.txt")
-  (git-commit r "first" {:author {:name "Me" :email "me@example.com"}
-                         :sign   {:key key}})
-  (git-verify-commit r "HEAD" pub))
-;; => {:valid true :key-type "ssh-ed25519" :fingerprint "SHA256:…"
-;;     :hash-algorithm "sha512" :signer "me@laptop"}
+  (git-commit r "first" {:author {:name "Me" :email "me@example.com"}})
+  (git-verify-commit r "HEAD" pub))   ;; throws unless the commit was signed
 ```
 
 ## Signed commits and tags
 
-`:sign {:key pem :passphrase p}` takes an OpenSSH private key as a PEM string (read it with `slurp`; `:passphrase` only for encrypted keys). The signature uses the SSH signature format with namespace `git` and SHA-512, exactly what `ssh-keygen -Y sign` and `git commit -S` produce with `gpg.format=ssh`. Generate a key with:
+There is **no per-call signing key**. `git-commit` and annotated `git-tag` are SSH-signed only when a signing policy is installed, which the interpreter does under `lisp --integrity-keys FILE`: it signs with the **ssh-agent** key whose public key is listed in FILE (the same trusted-key list that verifies the code ref). The private key never enters the process — it stays in the agent, unlocked however the agent is (keychain, `ssh-add`, …). No policy → commits and tags are unsigned.
 
-```
-ssh-keygen -t ed25519 -f signing-key
-```
-
-In sha256 repositories the commit signature is stored under the `gpgsig-sha256` header, as git expects; tag signatures are appended to the tag body in both formats.
+The signature uses the SSH signature format with namespace `git` and SHA-512, exactly what `ssh-keygen -Y sign` and `git commit -S` produce with `gpg.format=ssh`. In sha256 repositories the commit signature is stored under the `gpgsig-sha256` header, as git expects; tag signatures are appended to the tag body in both formats. (Go embedders install their own policy with `git.SetSigner`.)
 
 ## Verification — fail closed
 
@@ -68,7 +60,7 @@ SSH host keys are checked against the default `known_hosts` files. Override with
 | `git-close` | `[repo]` | nil |
 | `git-with-repo` | `[[r expr] & body]` | body value; guarantees `git-close` |
 | `git-add` | `[repo path & {:all :glob}]` | nil |
-| `git-commit` | `[repo msg & {:author :committer :sign :all :allow-empty :amend}]` | commit map |
+| `git-commit` | `[repo msg & {:author :committer :all :allow-empty :amend}]` | commit map |
 | `git-log` | `[repo & {:max :from :all :path}]` | vector of commit maps, newest first |
 | `git-show` | `[repo rev]` | commit map |
 | `git-status` | `[repo]` | `{:clean bool :files {path {:staging kw :worktree kw}}}` |
@@ -76,7 +68,7 @@ SSH host keys are checked against the default `known_hosts` files. Override with
 | `git-branch` | `[repo name & {:checkout :at}]` | nil |
 | `git-branches` | `[repo]` | vector of `{:name :hash :head}` |
 | `git-checkout` | `[repo ref & {:create :force}]` | nil |
-| `git-tag` | `[repo name & {:at :message :tagger :sign}]` | `{:name :hash :target :annotated}` |
+| `git-tag` | `[repo name & {:at :message :tagger}]` | `{:name :hash :target :annotated}` |
 | `git-tags` | `[repo]` | vector of tag maps |
 | `git-remote-add` | `[repo name url]` | nil |
 | `git-remotes` | `[repo]` | vector of `{:name :urls}` |

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -97,8 +97,8 @@ func Load(env EnvType) {
 		"Closes a repository handle.")
 	call.Doc(env, "git-add", "[repo path & {:all :glob}]",
 		"Stages path (\".\" for everything); :all true stages all modified/deleted files, :glob true treats path as a glob pattern.")
-	call.Doc(env, "git-commit", "[repo msg & {:author {:name :email} :committer :sign {:key :passphrase} :all :allow-empty :amend}]",
-		"Commits staged changes and returns the commit map; :sign takes an OpenSSH private key (PEM string) and produces an SSH signature.")
+	call.Doc(env, "git-commit", "[repo msg & {:author {:name :email} :committer :all :allow-empty :amend}]",
+		"Commits staged changes and returns the commit map. Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there; otherwise it is unsigned (there is no per-call key option).")
 	call.Doc(env, "git-log", "[repo & {:max :from :all :path}]",
 		"Returns a vector of commit maps from HEAD (or :from rev), newest first.")
 	call.Doc(env, "git-show", "[repo rev]",
@@ -113,8 +113,8 @@ func Load(env EnvType) {
 		"Returns a vector of {:name :hash :head} for local branches.")
 	call.Doc(env, "git-checkout", "[repo ref & {:create :force}]",
 		"Checks out a branch, tag or revision; :create true creates the branch first.")
-	call.Doc(env, "git-tag", "[repo name & {:at :message :tagger {:name :email} :sign}]",
-		"Creates a tag at HEAD (or :at rev); :message makes it annotated, :sign (requires :message) signs it.")
+	call.Doc(env, "git-tag", "[repo name & {:at :message :tagger {:name :email}}]",
+		"Creates a tag at HEAD (or :at rev); :message makes it annotated. Under --integrity-keys an annotated tag is SSH-signed with the ssh-agent key listed there.")
 	call.Doc(env, "git-tags", "[repo]",
 		"Returns a vector of {:name :hash :target :annotated} for all tags.")
 	call.Doc(env, "git-remote-add", "[repo name url]",
@@ -301,10 +301,6 @@ func gitCommit(rv MalType, msg string, params ...MalType) (MalType, error) {
 	if commitOpts.Committer, err = optSignature(o, "committer"); err != nil {
 		return nil, err
 	}
-	signer, err := optSigner(o)
-	if err != nil {
-		return nil, err
-	}
 	wt, err := worktree(r)
 	if err != nil {
 		return nil, err
@@ -313,13 +309,12 @@ func gitCommit(rv MalType, msg string, params ...MalType) (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
-	if signer != nil {
-		// Signing is done after the fact (see resignCommit) so the
-		// signature lands in the header matching the repo's object
-		// format; go-git's own Signer support always writes gpgsig.
-		if hash, err = resignCommit(r, hash, signer); err != nil {
-			return nil, err
-		}
+	// Signing is driven by the installed policy (--integrity-keys, via
+	// the ssh-agent), never a per-call key. It is done after the fact
+	// (see resignCommit) so the signature lands in the header matching
+	// the repo's object format; go-git's own Signer always writes gpgsig.
+	if hash, err = signCommitIfPolicy(r, hash); err != nil {
+		return nil, err
 	}
 	c, err := r.repo.CommitObject(hash)
 	if err != nil {
@@ -587,13 +582,6 @@ func gitTag(rv MalType, name string, params ...MalType) (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
-	signer, err := optSigner(o)
-	if err != nil {
-		return nil, err
-	}
-	if signer != nil && !annotated {
-		return nil, fmt.Errorf("git-tag: :sign requires :message (only annotated tags can be signed)")
-	}
 	var tagOpts *gogit.CreateTagOptions
 	if annotated {
 		tagOpts = &gogit.CreateTagOptions{Message: message, Signer: gogitutil.NoSign{}}
@@ -605,8 +593,10 @@ func gitTag(rv MalType, name string, params ...MalType) (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
-	if signer != nil {
-		if ref, err = resignTag(r, ref, signer); err != nil {
+	// Only annotated tags carry a signature; a lightweight tag is just a
+	// ref and is left unsigned even when a signing policy is active.
+	if annotated {
+		if ref, err = signTagIfPolicy(r, ref); err != nil {
 			return nil, err
 		}
 	}

--- a/lib/git/git_test.go
+++ b/lib/git/git_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/env"
 	"github.com/jig/lisp/lib/core/nscore"
+	libgit "github.com/jig/lisp/lib/git"
 	"github.com/jig/lisp/lib/git/nsgit"
 	"github.com/jig/lisp/types"
 	gossh "golang.org/x/crypto/ssh"
@@ -95,6 +96,19 @@ func testKey(t *testing.T, comment string) (privPEM, authorized string) {
 	return string(pem.EncodeToMemory(block)), line
 }
 
+// signWith installs a signing policy from a PEM private key — the test
+// stand-in for --integrity-keys' ssh-agent signer — and clears it when
+// the (sub)test ends. git-commit and annotated git-tag then sign.
+func signWith(t *testing.T, privPEM string) {
+	t.Helper()
+	signer, err := gossh.ParsePrivateKey([]byte(privPEM))
+	if err != nil {
+		t.Fatal(err)
+	}
+	libgit.SetSigner(func() (gossh.Signer, error) { return signer, nil })
+	t.Cleanup(libgit.ClearSigner)
+}
+
 // objectFormats parametrizes tests over sha1 and sha256 repositories.
 var objectFormats = []string{"sha1", "sha256"}
 
@@ -169,7 +183,8 @@ func TestSignedCommitVerify(t *testing.T) {
 				t.Fatal(err)
 			}
 			eval(t, ns, `(git-add r "a.txt")`)
-			eval(t, ns, fmt.Sprintf(`(def c (git-commit r "signed" {:author %s :sign {:key %q}}))`, author, privPEM))
+			signWith(t, privPEM)
+			eval(t, ns, fmt.Sprintf(`(def c (git-commit r "signed" {:author %s}))`, author))
 			expectTrue(t, ns, `(get c :signed)`)
 			eval(t, ns, fmt.Sprintf(`(def v (git-verify-commit r "HEAD" %q))`, authorized))
 			expectTrue(t, ns, `(get v :valid)`)
@@ -203,7 +218,8 @@ func TestVerifyFailClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 	eval(t, ns, `(git-add r "a.txt")`)
-	eval(t, ns, fmt.Sprintf(`(git-commit r "signed" {:author %s :sign {:key %q}})`, author, privPEM))
+	signWith(t, privPEM)
+	eval(t, ns, fmt.Sprintf(`(git-commit r "signed" {:author %s})`, author))
 
 	// wrong key throws; a multi-line allowed-keys with the right key passes
 	expectThrow(t, ns, fmt.Sprintf(`(git-verify-commit r "HEAD" %q)`, otherAuthorized))
@@ -229,7 +245,8 @@ func TestRejectAllowedSignersFormat(t *testing.T) {
 		t.Fatal(err)
 	}
 	eval(t, ns, `(git-add r "a.txt")`)
-	eval(t, ns, fmt.Sprintf(`(git-commit r "signed" {:author %s :sign {:key %q}})`, author, privPEM))
+	signWith(t, privPEM)
+	eval(t, ns, fmt.Sprintf(`(git-commit r "signed" {:author %s})`, author))
 
 	// authorized_keys format (key-first) verifies.
 	expectTrue(t, ns, fmt.Sprintf(`(get (git-verify-commit r "HEAD" %q) :valid)`, authorized))
@@ -260,19 +277,27 @@ func TestBranchesTagsStatus(t *testing.T) {
 	eval(t, ns, `(git-checkout r "master")`)
 	expectTrue(t, ns, `(= "master" (get (git-head r) :branch))`)
 
-	// tags: lightweight, annotated, signed
+	// tags: lightweight and annotated are unsigned; the signed one is
+	// created while a signing policy is active (as under --integrity-keys).
 	eval(t, ns, `(git-tag r "light")`)
 	eval(t, ns, `(git-tag r "annotated" {:message "v1" :tagger `+author+`})`)
-	eval(t, ns, fmt.Sprintf(`(git-tag r "signed" {:message "v2" :tagger %s :sign {:key %q}})`, author, privPEM))
-	expectTrue(t, ns, `(= 3 (count (git-tags r)))`)
+	signer, err := gossh.ParsePrivateKey([]byte(privPEM))
+	if err != nil {
+		t.Fatal(err)
+	}
+	libgit.SetSigner(func() (gossh.Signer, error) { return signer, nil })
+	eval(t, ns, fmt.Sprintf(`(git-tag r "signed" {:message "v2" :tagger %s})`, author))
+	// A lightweight tag is not signed even while the policy is active.
+	eval(t, ns, `(git-tag r "light2")`)
+	libgit.ClearSigner()
+
+	expectTrue(t, ns, `(= 4 (count (git-tags r)))`)
 	expectTrue(t, ns, fmt.Sprintf(`(get (git-verify-tag r "signed" %q) :valid)`, authorized))
 	expectThrow(t, ns, fmt.Sprintf(`(git-verify-tag r "annotated" %q)`, authorized))
 	expectThrow(t, ns, fmt.Sprintf(`(git-verify-tag r "light" %q)`, authorized))
+	expectThrow(t, ns, fmt.Sprintf(`(git-verify-tag r "light2" %q)`, authorized))
 	expectTrue(t, ns, fmt.Sprintf(`(git-tag-verified? r "signed" %q)`, authorized))
 	expectTrue(t, ns, fmt.Sprintf(`(= false (git-tag-verified? r "light" %q))`, authorized))
-
-	// :sign without :message is rejected
-	expectThrow(t, ns, fmt.Sprintf(`(git-tag r "bad" {:sign {:key %q}})`, privPEM))
 	eval(t, ns, `(git-close r)`)
 }
 
@@ -341,8 +366,9 @@ func TestGitCLIInterop(t *testing.T) {
 				t.Fatal(err)
 			}
 			eval(t, ns, `(git-add r "a.txt")`)
-			eval(t, ns, fmt.Sprintf(`(git-commit r "signed" {:author %s :sign {:key %q}})`, author, privPEM))
-			eval(t, ns, fmt.Sprintf(`(git-tag r "v1" {:message "v1" :tagger %s :sign {:key %q}})`, author, privPEM))
+			signWith(t, privPEM)
+			eval(t, ns, fmt.Sprintf(`(git-commit r "signed" {:author %s})`, author))
+			eval(t, ns, fmt.Sprintf(`(git-tag r "v1" {:message "v1" :tagger %s})`, author))
 			eval(t, ns, `(git-close r)`)
 
 			for _, args := range [][]string{

--- a/lib/git/sign.go
+++ b/lib/git/sign.go
@@ -75,7 +75,7 @@ func resolveAgentSigner(sshAuthSock, allowedKeys string) (gossh.Signer, error) {
 			return s, nil
 		}
 	}
-	conn.Close()
+	_ = conn.Close()
 	return nil, fmt.Errorf("no ssh-agent key is listed in --integrity-keys")
 }
 

--- a/lib/git/sign.go
+++ b/lib/git/sign.go
@@ -4,13 +4,16 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net"
 	"strings"
+	"sync"
 
 	gogit "github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/hiddeco/sshsig"
 	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 
 	. "github.com/jig/lisp/types"
 )
@@ -19,34 +22,121 @@ import (
 // signatures (see gitformat-signature).
 const gitNamespace = "git"
 
-// optSigner builds an SSH signer from the :sign {:key :passphrase} option,
-// or returns nil when signing was not requested.
-func optSigner(o map[string]MalType) (gossh.Signer, error) {
-	m, ok, err := optHashMap(o, "sign")
-	if err != nil || !ok {
-		return nil, err
-	}
-	key, ok, err := optString(m, "key")
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
-		return nil, fmt.Errorf(":sign requires :key with an OpenSSH private key (PEM string)")
-	}
-	passphrase, hasPass, err := optString(m, "passphrase")
-	if err != nil {
-		return nil, err
-	}
-	if hasPass && passphrase != "" {
-		return gossh.ParsePrivateKeyWithPassphrase([]byte(key), []byte(passphrase))
-	}
-	return gossh.ParsePrivateKey([]byte(key))
+// signerResolve returns the SSH signer to sign commits and tags with, or
+// nil when no signing policy is installed. It is the single knob for
+// signing — there is no per-call key option and no private key ever
+// enters the process. The command package installs it (SetSigningKeys)
+// when --integrity-keys is active; tests inject a signer with SetSigner.
+var signerResolve func() (gossh.Signer, error)
+
+// SetSigner installs a signing policy: git-commit, git-tag and
+// state-save sign with the signer it returns. A resolver returning an
+// error fails the commit/tag closed.
+func SetSigner(resolve func() (gossh.Signer, error)) { signerResolve = resolve }
+
+// ClearSigner removes the signing policy (commits and tags are left
+// unsigned). Used by the command package and tests to reset state.
+func ClearSigner() { signerResolve = nil }
+
+// SetSigningKeys installs the ssh-agent signing policy used under
+// --integrity-keys: commits and tags are signed with the agent key (at
+// sshAuthSock) whose public key appears in allowedKeys (authorized_keys
+// / .pub format). Resolution is lazy and cached on first use, so a run
+// that never commits needs no agent; a run that commits under
+// --integrity-keys with no matching agent key fails closed.
+func SetSigningKeys(sshAuthSock, allowedKeys string) {
+	var once sync.Once
+	var s gossh.Signer
+	var e error
+	SetSigner(func() (gossh.Signer, error) {
+		once.Do(func() { s, e = resolveAgentSigner(sshAuthSock, allowedKeys) })
+		return s, e
+	})
 }
 
-// SSHSignerFromOptions parses the same {:sign {:key :passphrase}} options
-// accepted by git-commit and git-tag.
-func SSHSignerFromOptions(options HashMap) (gossh.Signer, error) {
-	return optSigner(options.Val)
+// resolveAgentSigner finds the ssh-agent signer whose public key is
+// listed in allowedKeys. The agent connection is kept open for the
+// process lifetime because the returned signer calls back over it.
+func resolveAgentSigner(sshAuthSock, allowedKeys string) (gossh.Signer, error) {
+	if sshAuthSock == "" {
+		return nil, fmt.Errorf("signing under --integrity-keys needs an ssh-agent, but SSH_AUTH_SOCK is unset")
+	}
+	conn, err := net.Dial("unix", sshAuthSock)
+	if err != nil {
+		return nil, fmt.Errorf("cannot reach ssh-agent at %s: %w", sshAuthSock, err)
+	}
+	signers, err := agent.NewClient(conn).Signers()
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("ssh-agent: %w", err)
+	}
+	for _, s := range signers {
+		if keyListed(s.PublicKey(), allowedKeys) {
+			return s, nil
+		}
+	}
+	conn.Close()
+	return nil, fmt.Errorf("no ssh-agent key is listed in --integrity-keys")
+}
+
+// keyListed reports whether pub appears in allowedKeys (authorized_keys
+// format; blank lines and # comments skipped, options rejected as in
+// matchAllowedKey).
+func keyListed(pub gossh.PublicKey, allowedKeys string) bool {
+	want := pub.Marshal()
+	for line := range strings.SplitSeq(allowedKeys, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		p, _, options, _, err := gossh.ParseAuthorizedKey([]byte(line))
+		if err != nil || len(options) > 0 {
+			continue
+		}
+		if bytes.Equal(p.Marshal(), want) {
+			return true
+		}
+	}
+	return false
+}
+
+// signCommitIfPolicy signs the commit at hash with the installed policy,
+// or returns it unchanged when none is installed.
+func signCommitIfPolicy(r *Repo, hash plumbing.Hash) (plumbing.Hash, error) {
+	if signerResolve == nil {
+		return hash, nil
+	}
+	signer, err := signerResolve()
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+	return resignCommit(r, hash, signer)
+}
+
+// signTagIfPolicy signs annotated tag ref with the installed policy, or
+// returns it unchanged when none is installed.
+func signTagIfPolicy(r *Repo, ref *plumbing.Reference) (*plumbing.Reference, error) {
+	if signerResolve == nil {
+		return ref, nil
+	}
+	signer, err := signerResolve()
+	if err != nil {
+		return nil, err
+	}
+	return resignTag(r, ref, signer)
+}
+
+// SignCommitIfPolicy is signCommitIfPolicy for callers holding a
+// *gogit.Repository (state-save).
+func SignCommitIfPolicy(repo *gogit.Repository, hash plumbing.Hash) (plumbing.Hash, error) {
+	if signerResolve == nil {
+		return hash, nil
+	}
+	r, err := newRepo(repo, "")
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+	return signCommitIfPolicy(r, hash)
 }
 
 // payloadEncoder is the part of commits and tags that reproduces the exact
@@ -113,16 +203,6 @@ func resignCommit(r *Repo, hash plumbing.Hash, signer gossh.Signer) (plumbing.Ha
 	}
 	ref := plumbing.NewHashReference(head.Name(), signedHash)
 	return signedHash, r.repo.Storer.SetReference(ref)
-}
-
-// SignCommitSSH rewrites hash with a Git-compatible SSH signature and moves
-// HEAD to the signed commit, preserving the repository's object format.
-func SignCommitSSH(repo *gogit.Repository, hash plumbing.Hash, signer gossh.Signer) (plumbing.Hash, error) {
-	r, err := newRepo(repo, "")
-	if err != nil {
-		return plumbing.ZeroHash, err
-	}
-	return resignCommit(r, hash, signer)
 }
 
 // resignTag is resignCommit for annotated tags: it re-creates the tag

--- a/lib/git/sign.go
+++ b/lib/git/sign.go
@@ -67,7 +67,7 @@ func resolveAgentSigner(sshAuthSock, allowedKeys string) (gossh.Signer, error) {
 	}
 	signers, err := agent.NewClient(conn).Signers()
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, fmt.Errorf("ssh-agent: %w", err)
 	}
 	for _, s := range signers {

--- a/lib/integrity/README.md
+++ b/lib/integrity/README.md
@@ -18,7 +18,7 @@ mode](#integrity-mode---integrity) (`lisp --integrity <ref>`).
 | `(ed25519-sign private s)` | base64 signature of `s` |
 | `(ed25519-verify public s signature)` | `true` or `false` |
 | `(assert-integrity)` | the verified commit hash; **throws** unless running under `--integrity` |
-| `(state-save name value)` | writes `value` as canonical lisp data to `.state/name.lisp` and commits it; returns the commit hash |
+| `(state-save name value)` | writes `value` as canonical lisp data to `.state/name.lisp` and commits it (SSH-signed with the ssh-agent key under `--integrity-keys`); returns the commit hash |
 | `(state-load name & [default])` | the state read back as pure data (READ, never EVAL); `default` (or throws) when absent |
 
 Ed25519 signing is deterministic: the same key and message always yield

--- a/lib/integrity/integrity.go
+++ b/lib/integrity/integrity.go
@@ -39,7 +39,7 @@ func Load(env EnvType) {
 	call.Call(env, ed25519_sign)
 	call.Call(env, ed25519_verify)
 	call.Call(env, assert_integrity)
-	call.Call(env, state_save, 2, 3)
+	call.Call(env, state_save)
 	call.Call(env, state_load, 1, 2)
 
 	call.Doc(env, "fmt", "[s]",
@@ -54,8 +54,8 @@ func Load(env EnvType) {
 		"Reports whether the base64 signature of string s verifies against the base64 Ed25519 public key.")
 	call.Doc(env, "assert-integrity", "[]",
 		"Throws unless the interpreter runs under --integrity; returns the verified commit hash.")
-	call.Doc(env, "state-save", "[name value & [options]]",
-		"Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. options may contain :sign {:key OPENSSH-PRIVATE-KEY :passphrase STRING}. Under --integrity the commit keeps the verified ref valid.")
+	call.Doc(env, "state-save", "[name value]",
+		"Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there. Under --integrity the commit keeps the verified ref valid.")
 	call.Doc(env, "state-load", "[name & [default]]",
 		"Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under --integrity the file must match its committed version at HEAD.")
 }

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -103,6 +103,19 @@ func setupRepo(t *testing.T, ns types.EnvType, commitOpts string) (dir, hash str
 	return dir, h
 }
 
+// signWith installs a signing policy from a PEM private key (the test
+// stand-in for --integrity-keys' ssh-agent signer) and returns the
+// function that removes it. git-commit, git-tag and state-save then sign.
+func signWith(t *testing.T, privPEM string) func() {
+	t.Helper()
+	signer, err := gossh.ParsePrivateKey([]byte(privPEM))
+	if err != nil {
+		t.Fatal(err)
+	}
+	libgit.SetSigner(func() (gossh.Signer, error) { return signer, nil })
+	return libgit.ClearSigner
+}
+
 // enable calls integrity.Enable and registers cleanup of the global mode.
 func enable(t *testing.T, script, ref, signers string) error {
 	t.Helper()
@@ -206,7 +219,8 @@ func TestEnableSignedCommit(t *testing.T) {
 	ns := newGitEnv(t)
 	privPEM, authorized := testKey(t, "alice")
 	_, otherAuthorized := testKey(t, "mallory")
-	dir, hash := setupRepo(t, ns, fmt.Sprintf(`:sign {:key %q}`, privPEM))
+	t.Cleanup(signWith(t, privPEM))
+	dir, hash := setupRepo(t, ns, "")
 	script := filepath.Join(dir, "script.lisp")
 
 	if err := enable(t, script, hash, authorized); err != nil {
@@ -223,7 +237,9 @@ func TestEnableSignedTag(t *testing.T) {
 	privPEM, authorized := testKey(t, "alice")
 	dir, _ := setupRepo(t, ns, "")
 	script := filepath.Join(dir, "script.lisp")
-	evalLisp(t, ns, fmt.Sprintf(`(git-tag r "v1" {:message "release" :tagger `+author+` :sign {:key %q}})`, privPEM))
+	clear := signWith(t, privPEM)
+	evalLisp(t, ns, `(git-tag r "v1" {:message "release" :tagger `+author+`})`)
+	clear()
 
 	if err := enable(t, script, "v1", authorized); err != nil {
 		t.Fatalf("Enable(signed tag, allowed key): %v", err)
@@ -358,6 +374,7 @@ func TestStateSaveSignedCommit(t *testing.T) {
 			privPEM, authorized := testKey(t, "state-writer")
 			dir := t.TempDir()
 			t.Chdir(dir)
+			t.Cleanup(signWith(t, privPEM))
 			evalLisp(t, ns, fmt.Sprintf(
 				`(def r (git-init %q {:object-format %q}))`,
 				dir,
@@ -366,9 +383,8 @@ func TestStateSaveSignedCommit(t *testing.T) {
 
 			for n := 1; n <= 2; n++ {
 				hash := evalLisp(t, ns, fmt.Sprintf(
-					`(state-save "db" {:n %d} {:sign {:key %q}})`,
+					`(state-save "db" {:n %d})`,
 					n,
-					privPEM,
 				)).(string)
 				repo, err := gogit.PlainOpen(dir)
 				if err != nil {

--- a/lib/integrity/state.go
+++ b/lib/integrity/state.go
@@ -77,26 +77,9 @@ func statePath(fnName, name string) (string, error) {
 	return stateDir + "/" + name + ".lisp", nil
 }
 
-func state_save(name string, value MalType, params ...MalType) (MalType, error) {
+func state_save(name string, value MalType) (MalType, error) {
 	stateMu.Lock()
 	defer stateMu.Unlock()
-
-	options := HashMap{Val: map[string]MalType{}}
-	switch len(params) {
-	case 0:
-	case 1:
-		var ok bool
-		options, ok = params[0].(HashMap)
-		if !ok {
-			return nil, fmt.Errorf("state-save: options must be a map, got %T", params[0])
-		}
-	default:
-		return nil, fmt.Errorf("state-save: expected one options map, got %d arguments", len(params))
-	}
-	signer, err := libgit.SSHSignerFromOptions(options)
-	if err != nil {
-		return nil, fmt.Errorf("state-save: %w", err)
-	}
 
 	rel, err := statePath("state-save", name)
 	if err != nil {
@@ -145,9 +128,7 @@ func state_save(name string, value MalType, params ...MalType) (MalType, error) 
 		// Deterministic serialization means an unchanged value produces
 		// a byte-identical file, so re-saving the same state leaves the
 		// worktree clean. That is a no-op, not an error: the state is
-		// already committed, so return the existing HEAD commit. (A
-		// :sign option is ignored here — there is nothing new to sign;
-		// sign when the value actually changes.)
+		// already committed, so return the existing HEAD commit.
 		if errors.Is(err, gogit.ErrEmptyCommit) {
 			head, herr := repo.Head()
 			if herr != nil {
@@ -157,11 +138,10 @@ func state_save(name string, value MalType, params ...MalType) (MalType, error) 
 		}
 		return nil, fmt.Errorf("state-save: %w", err)
 	}
-	if signer != nil {
-		hash, err = libgit.SignCommitSSH(repo, hash, signer)
-		if err != nil {
-			return nil, fmt.Errorf("state-save: sign commit: %w", err)
-		}
+	// Sign the state commit when --integrity-keys installed a signing
+	// policy (ssh-agent key); a no-op otherwise.
+	if hash, err = libgit.SignCommitIfPolicy(repo, hash); err != nil {
+		return nil, fmt.Errorf("state-save: sign commit: %w", err)
 	}
 	return hash.String(), nil
 }


### PR DESCRIPTION
## Summary

Reverts the per-call `:sign {:key PEM}` option (a private key by value — ugly, and it leaked into `.state/` history) in favour of **agent-based signing tied to the trust anchor**, as discussed:

- `git-commit`, annotated `git-tag` and `state-save` are SSH-signed **iff a signing policy is installed**. The interpreter installs it under **`--integrity-keys`**: it signs with the **ssh-agent** key whose public key is listed in the keys file — the same set that verifies the code ref. No private key ever enters the process; resolution is lazy and **fails closed** if no listed key is loaded in the agent. Without `--integrity-keys`, git functions do not sign.
- `lib/git` gains a `SetSigner`/`ClearSigner`/`SetSigningKeys` hook (same pattern as `require.VerifyModule` / `core.VerifySource`); `command` wires `SetSigningKeys(SSH_AUTH_SOCK, keys)`. Removed `optSigner`, `SSHSignerFromOptions`, `SignCommitSSH` and `state-save`'s options arg.

## Threat-model note

`--integrity-keys` now anchors both "who may release code" (verify the ref) and "who may author state" (sign commits), and requires the running node's agent to hold a listed key. For a single operator that's the same key; for an org with separation of duties they'd differ. State signatures are still **auditable, not yet enforced** at startup (unchanged).

## ⚠️ Capability removed

This removes file/PEM-based signing from `lib/git` entirely. Any embedder that signed with an explicit key (e.g. the memoize work) must now install a signer via `git.SetSigner`.

## Test plan

- `lib/git` + `lib/integrity` signing tests reworked to install a policy via `git.SetSigner` instead of `:sign`; lightweight tags stay unsigned under a policy; ambient `commit.gpgsign` still ignored.
- Full suite green with and without `-tags debugger`; `examples-integrity/demo.sh` made hermetic and passing.
- **Verified end to end against a real ssh-agent (ed25519)**: under `--integrity <hash> --integrity-keys keys`, `state-save` produces a commit signed by the agent key with **no key in the lisp code**; a keys file with no matching agent key fails closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
