### PR TITLE
feat(integrity): require state commits to be signed under --integrity-keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,10 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   **ssh-agent** key listed there — no private key ever enters the
   process, and it fails closed if no listed key is loaded in the agent.
   (`git-commit`/`git-tag` therefore no longer take a `:sign {:key …}`
-  option — signing is agent-driven only.) New builtins:
+  option — signing is agent-driven only.) Under `--integrity-keys`,
+  startup also **requires** every state commit between the ref and HEAD
+  to be signed by a listed key, so the whole chain is signed by a
+  trusted key (state authenticity, not just consistency). New builtins:
   `(assert-integrity)` throws unless the run is verified — so
   committed code can demand the flag — and returns the verified commit
   hash; `(state-save name value)` / `(state-load name & [default])`

--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -49,7 +49,10 @@ At startup (`--integrity <ref>`):
    `state-save` creates). Anything else fails.
 3. With `--integrity-keys FILE`: the ref must carry an SSH
    signature by one of the public keys in `FILE` — the tag signature
-   if the ref is an annotated tag, the commit signature otherwise.
+   if the ref is an annotated tag, the commit signature otherwise — and
+   **every state commit** between `C` and `HEAD` (point 2) must
+   likewise be signed by a listed key. The whole chain from ref to
+   `HEAD` is thus signed by a trusted key.
 4. The script must byte-match its blob in `C`'s tree.
 
 At runtime, while the mode is active:
@@ -194,11 +197,6 @@ attacker cannot write to what the interpreter reads:
 
 ## Future revisions (not implemented)
 
-- **Enforced signed state chain** — under `--integrity-keys` state
-  commits are SSH-signed, but integrity startup does not yet *require*
-  every state commit to be signed by a listed key. A future check on
-  load would verify that membership, giving state authenticity rather
-  than auditability alone.
 - **Keys baked into the binary** — accept allowed signers via
   `-ldflags -X` at build time, shrinking the trust anchor to the
   binary alone.

--- a/lib/integrity/mode.go
+++ b/lib/integrity/mode.go
@@ -125,7 +125,7 @@ func Enable(scriptPath, ref, allowedSigners string) error {
 		// HEAD may sit above the ref: state-save commits its writes,
 		// moving HEAD, and the code ref stays valid across restarts as
 		// long as every commit in between touches only .state/.
-		if err := verifyStateOnlyDescent(repo, head.Hash(), commit.Hash); err != nil {
+		if err := verifyStateOnlyDescent(repo, head.Hash(), commit.Hash, allowedSigners); err != nil {
 			return fmt.Errorf("integrity: HEAD is at %s, not at %q (%s): %w", head.Hash(), ref, commit.Hash, err)
 		}
 	}
@@ -177,8 +177,12 @@ func verifyRefSignature(repo *gogit.Repository, ref string, tag *object.Tag, com
 
 // verifyStateOnlyDescent checks that ref is an ancestor of head through
 // a linear chain of commits that touch only .state/ paths — the commits
-// state-save creates. Any other divergence is an error.
-func verifyStateOnlyDescent(repo *gogit.Repository, head, ref plumbing.Hash) error {
+// state-save creates. Any other divergence is an error. When
+// allowedSigners is non-empty (--integrity-keys), each state commit must
+// additionally carry an SSH signature by one of those keys, so the whole
+// chain from ref to HEAD is signed by a trusted key — state authenticity,
+// not just consistency.
+func verifyStateOnlyDescent(repo *gogit.Repository, head, ref plumbing.Hash, allowedSigners string) error {
 	cur, err := repo.CommitObject(head)
 	if err != nil {
 		return err
@@ -186,6 +190,11 @@ func verifyStateOnlyDescent(repo *gogit.Repository, head, ref plumbing.Hash) err
 	for cur.Hash != ref {
 		if cur.NumParents() != 1 {
 			return fmt.Errorf("commit %s is not part of a linear state-only descent from the ref", cur.Hash)
+		}
+		if allowedSigners != "" {
+			if _, err := libgit.VerifyCommitSSH(cur, allowedSigners); err != nil {
+				return fmt.Errorf("state commit %s is not signed by an allowed key: %w", cur.Hash, err)
+			}
 		}
 		parent, err := cur.Parent(0)
 		if err != nil {

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -515,6 +515,34 @@ func TestStateSaveIdempotentUnchanged(t *testing.T) {
 	}
 }
 
+// TestStateChainSignedUnderKeys verifies that under --integrity-keys every
+// state commit above the ref must be SSH-signed by a listed key: a signed
+// chain verifies, an unsigned state commit on top fails closed.
+func TestStateChainSignedUnderKeys(t *testing.T) {
+	ns := newGitEnv(t)
+	privPEM, authorized := testKey(t, "release")
+
+	// Signed release commit + one signed state commit.
+	clear := signWith(t, privPEM)
+	dir, hash := setupRepo(t, ns, "")
+	t.Chdir(dir)
+	evalLisp(t, ns, `(state-save "db" {:n 1})`)
+	clear()
+
+	script := filepath.Join(dir, "script.lisp")
+	if err := enable(t, script, hash, authorized); err != nil {
+		t.Fatalf("Enable(signed state chain): %v", err)
+	}
+	integrity.Disable()
+
+	// An unsigned state commit on top must fail closed under --integrity-keys.
+	evalLisp(t, ns, `(state-save "db" {:n 2})`)
+	if err := enable(t, script, hash, authorized); err == nil ||
+		!strings.Contains(err.Error(), "not signed by an allowed key") {
+		t.Fatalf("Enable(unsigned state commit) = %v, want 'not signed by an allowed key'", err)
+	}
+}
+
 func TestStateUnderIntegrity(t *testing.T) {
 	ns := newGitEnv(t)
 	dir, hash := setupRepo(t, ns, "")


### PR DESCRIPTION
## Summary

Closes the trust loop opened by the agent-signing PR (#122). `--integrity-keys` already required the **ref** to be signed and drives **signing** of state commits, but startup did not verify those state-commit signatures — they were auditable, not enforced.

Now `verifyStateOnlyDescent`, given the keys, requires **every state commit** between the ref and HEAD to carry an SSH signature by a listed key. The whole chain from ref to HEAD is therefore signed by a trusted key — **state authenticity, not just consistency**.

Consequence: a run under `--integrity-keys` over state commits that were created *without* it (unsigned) now fails closed at startup with `state commit <hash> is not signed by an allowed key`.

## Test plan

- New `TestStateChainSignedUnderKeys`: a signed release + signed state commit verifies under `--integrity-keys`; an unsigned state commit on top fails closed.
- Full suite green with and without `-tags debugger`.
- INTEGRITY.md invariant 3 updated; the "enforced signed state chain" future item is now done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
