### PR TITLE
feat(integrity): human-readable colored audit output on a terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,8 +163,10 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   additionally requires REF to be SSH-signed by a key listed in FILE
   (authorized_keys / `.pub` format, as `git-verify-commit` — not git's
   `allowed_signers`; a principal-first line is rejected, keys are
-  matched by key with no expiry); a JSON audit line is logged on
-  successful verification. That same key set also **drives signing**:
+  matched by key with no expiry); the audit outcome is reported on
+  stderr — a colored human-readable block (green ✓ / red ✗, one field
+  per line) on an interactive terminal, a structured JSON line when
+  redirected. That same key set also **drives signing**:
   while `--integrity-keys` is active, every `git-commit`, annotated
   `git-tag` and `state-save` made during the run is SSH-signed with the
   **ssh-agent** key listed there — no private key ever enters the

--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -105,12 +105,25 @@ lisp --integrity v1.4.2 --integrity-keys /etc/lisp/release-keys service.lisp
   listed key is loaded in the agent). Requires
   `--integrity`.
 
-On success one structured JSON line is logged to stderr for the audit
-trail: `{"msg":"integrity: entry script and ref verified","ref":…,"commit":…,"signer":…}`
-(`signer` only when keys were required). It attests the pinned ref and
-the entry script; each cascaded `require` / `load-file` is verified as
-it loads and aborts the run on mismatch, so the line does not mean the
-whole run is already verified.
+The result is reported to stderr for the audit trail. On an
+**interactive terminal** it is a human-readable block — green when
+integrity is satisfied, red when not — with the ref, commit and (when
+keys were required) signer each on their own line:
+
+```
+✓ integrity verified
+    ref     v1.4.2
+    commit  9fceb02da8f3c1…
+    signer  alice
+```
+
+When stderr is **redirected** (a pipe or file — the server/log-ingestion
+case) it is instead one structured JSON line:
+`{"msg":"integrity: entry script and ref verified","ref":…,"commit":…,"signer":…}`.
+Either way it attests the pinned ref and the entry script only; each
+cascaded `require` / `load-file` is verified as it loads and aborts the
+run on mismatch, so a green block does not mean the whole run is already
+verified. Color also honours `NO_COLOR` / `CLICOLOR_FORCE`.
 
 ## Builtins
 

--- a/cmd/lisp/main.go
+++ b/cmd/lisp/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"os"
 
@@ -64,6 +65,11 @@ func main() {
 	}
 
 	if err := command.Execute(os.Args, ns); err != nil {
+		// An integrity failure has already been shown to the user as its
+		// own red block; just exit non-zero without a second "Error:" line.
+		if errors.Is(err, command.ErrIntegrityReported) {
+			os.Exit(1)
+		}
 		log.Fatalf("Error: %v\n", err)
 	}
 }

--- a/command/integrity.go
+++ b/command/integrity.go
@@ -1,15 +1,23 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/jig/lisp/lib/core"
 	libgit "github.com/jig/lisp/lib/git"
 	"github.com/jig/lisp/lib/integrity"
 	"github.com/jig/lisp/lib/require"
+	libterm "github.com/jig/lisp/lib/term"
 )
+
+// ErrIntegrityReported signals that the integrity failure has already
+// been shown to the user (the red block); main exits non-zero without
+// re-printing it.
+var ErrIntegrityReported = errors.New("integrity check failed")
 
 // setupIntegrity validates the --integrity flags and enables integrity
 // mode: the script is verified against the given Git ref before it
@@ -39,7 +47,7 @@ func setupIntegrity(a args) error {
 		keys = string(b)
 	}
 	if err := integrity.Enable(a.Script, a.Integrity, keys); err != nil {
-		return err
+		return reportIntegrity(false, "", "", "", err)
 	}
 	require.VerifyModule = integrity.VerifyFile
 	core.VerifySource = integrity.VerifyFile
@@ -52,14 +60,52 @@ func setupIntegrity(a args) error {
 		libgit.SetSigningKeys(os.Getenv("SSH_AUTH_SOCK"), keys)
 	}
 
-	// One structured line to stderr for the operator's audit trail. It
-	// attests the pinned ref and the entry script only; each require /
-	// load-file is verified as it loads and aborts the run on mismatch,
-	// so a green line here does not mean the whole run is pre-verified.
-	logAttrs := []any{"ref", integrity.Ref(), "commit", integrity.CommitHash()}
-	if keys != "" {
-		logAttrs = append(logAttrs, "signer", integrity.Signer())
+	return reportIntegrity(true, integrity.Ref(), integrity.CommitHash(), integrity.Signer(), nil)
+}
+
+// reportIntegrity writes the audit outcome to stderr. On an interactive
+// terminal it prints a human-readable block — green when integrity is
+// satisfied, red when not; when stderr is redirected it emits the
+// machine-readable JSON line instead (JSON is the norm for log
+// ingestion). The block attests the pinned ref and the entry script
+// only: each require/load-file is verified as it loads and aborts the
+// run on mismatch, so a green block does not mean the whole run is
+// pre-verified. Returns nil on success, ErrIntegrityReported on a
+// terminal failure (already shown), or the cause when redirected.
+func reportIntegrity(ok bool, ref, commit, signer string, cause error) error {
+	if !libterm.StderrIsTerminal() {
+		if !ok {
+			return cause // the normal error path reports it
+		}
+		attrs := []any{"ref", ref, "commit", commit}
+		if signer != "" {
+			attrs = append(attrs, "signer", signer)
+		}
+		slog.New(slog.NewJSONHandler(os.Stderr, nil)).Info("integrity: entry script and ref verified", attrs...)
+		return nil
 	}
-	slog.New(slog.NewJSONHandler(os.Stderr, nil)).Info("integrity: entry script and ref verified", logAttrs...)
-	return nil
+
+	fmt.Fprint(os.Stderr, integrityBlock(ok, ref, commit, signer, cause))
+	if ok {
+		return nil
+	}
+	return ErrIntegrityReported
+}
+
+// integrityBlock renders the coloured, one-field-per-line audit block.
+func integrityBlock(ok bool, ref, commit, signer string, cause error) string {
+	field := func(label, value string) string {
+		return fmt.Sprintf("    %-6s  %s\n", label, value)
+	}
+	if !ok {
+		reason := strings.TrimPrefix(cause.Error(), "integrity: ")
+		return libterm.StderrStyle("red", true, "✗ integrity check failed") + "\n" +
+			libterm.StderrStyle("red", false, field("reason", reason))
+	}
+	body := field("ref", ref) + field("commit", commit)
+	if signer != "" {
+		body += field("signer", signer)
+	}
+	return libterm.StderrStyle("green", true, "✓ integrity verified") + "\n" +
+		libterm.StderrStyle("green", false, body)
 }

--- a/command/integrity_test.go
+++ b/command/integrity_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -150,5 +151,35 @@ func TestExecuteIntegrityFlagValidation(t *testing.T) {
 		if err := Execute(cmdline, ns); err == nil {
 			t.Errorf("Execute(%v) did not fail", cmdline)
 		}
+	}
+}
+
+// TestIntegrityBlockFormat pins the human-readable audit block: a green
+// header plus one field per line on success, a red header plus reason on
+// failure. Asserts the text (robust to whether color is on).
+func TestIntegrityBlockFormat(t *testing.T) {
+	ok := integrityBlock(true, "v1.2.3", "abc123def", "alice", nil)
+	for _, want := range []string{"integrity verified", "ref", "v1.2.3", "commit", "abc123def", "signer", "alice"} {
+		if !strings.Contains(ok, want) {
+			t.Errorf("success block missing %q:\n%s", want, ok)
+		}
+	}
+	if n := strings.Count(strings.TrimRight(ok, "\n"), "\n"); n != 3 {
+		t.Errorf("expected header + 3 fields (3 newlines), got %d:\n%s", n, ok)
+	}
+
+	noSigner := integrityBlock(true, "v1", "abc", "", nil)
+	if strings.Contains(noSigner, "signer") {
+		t.Errorf("no signer line expected when signer is empty:\n%s", noSigner)
+	}
+
+	fail := integrityBlock(false, "", "", "", errors.New("integrity: HEAD moved"))
+	for _, want := range []string{"integrity check failed", "reason", "HEAD moved"} {
+		if !strings.Contains(fail, want) {
+			t.Errorf("failure block missing %q:\n%s", want, fail)
+		}
+	}
+	if strings.Contains(fail, "integrity: HEAD moved") {
+		t.Errorf("expected the redundant 'integrity: ' prefix stripped:\n%s", fail)
 	}
 }

--- a/lib/term/export_test.go
+++ b/lib/term/export_test.go
@@ -1,9 +1,13 @@
 package term
 
-import "sync"
+import (
+	"os"
+	"sync"
+)
 
-// ResetColorCache re-evaluates the color decision on next use, so tests
+// ResetColorCache re-evaluates the color decisions on next use, so tests
 // can flip the environment between cases.
 func ResetColorCache() {
-	colorEnabled = sync.OnceValue(colorDecision)
+	colorEnabled = sync.OnceValue(func() bool { return colorDecisionFor(os.Stdout.Fd()) })
+	colorEnabledStderr = sync.OnceValue(func() bool { return colorDecisionFor(os.Stderr.Fd()) })
 }

--- a/lib/term/term.go
+++ b/lib/term/term.go
@@ -47,10 +47,15 @@ func Load(env EnvType) {
 		"The terminal width in columns, or 0 when stdout is not a terminal.")
 }
 
-// colorEnabled decides once whether to emit ANSI codes.
-var colorEnabled = sync.OnceValue(colorDecision)
+// colorEnabled decides once whether to emit ANSI codes on stdout;
+// colorEnabledStderr does the same for stderr (where the CLI writes its
+// own audit output).
+var (
+	colorEnabled       = sync.OnceValue(func() bool { return colorDecisionFor(os.Stdout.Fd()) })
+	colorEnabledStderr = sync.OnceValue(func() bool { return colorDecisionFor(os.Stderr.Fd()) })
+)
 
-func colorDecision() bool {
+func colorDecisionFor(fd uintptr) bool {
 	if os.Getenv("CLICOLOR_FORCE") == "1" {
 		return true
 	}
@@ -60,7 +65,35 @@ func colorDecision() bool {
 	if os.Getenv("TERM") == "dumb" {
 		return false
 	}
-	return term.IsTerminal(int(os.Stdout.Fd()))
+	return term.IsTerminal(int(fd))
+}
+
+// StderrStyle wraps s in an SGR sequence for the named color (as
+// term-style's :fg accepts — "green", "red", …), bold when bold is true,
+// honoring NO_COLOR / CLICOLOR_FORCE / TERM=dumb and whether stderr is a
+// terminal. Returns s unchanged when color is disabled or the color name
+// is unknown. It is the Go-facing counterpart of term-style, for the
+// CLI's own colored output on stderr.
+func StderrStyle(color string, bold bool, s string) string {
+	if !colorEnabledStderr() {
+		return s
+	}
+	code, ok := namedColors[color]
+	if !ok {
+		return s
+	}
+	seq := strconv.Itoa(code)
+	if bold {
+		seq = "1;" + seq
+	}
+	return "\x1b[" + seq + "m" + s + "\x1b[0m"
+}
+
+// StderrIsTerminal reports whether stderr is a terminal, so the CLI can
+// print human-readable output there and machine-readable JSON when it is
+// redirected to a file or pipe.
+func StderrIsTerminal() bool {
+	return term.IsTerminal(int(os.Stderr.Fd()))
 }
 
 // namedColors maps color keywords to their base SGR foreground code;

--- a/lib/term/term_test.go
+++ b/lib/term/term_test.go
@@ -115,6 +115,30 @@ func TestStylePlain(t *testing.T) {
 	}
 }
 
+// TestStderrStyle covers the Go-facing helper the CLI uses for its own
+// stderr output.
+func TestStderrStyle(t *testing.T) {
+	t.Setenv("CLICOLOR_FORCE", "1")
+	term.ResetColorCache()
+	if got, want := term.StderrStyle("green", true, "x"), "\x1b[1;32mx\x1b[0m"; got != want {
+		t.Errorf("green bold = %q, want %q", got, want)
+	}
+	if got, want := term.StderrStyle("red", false, "x"), "\x1b[31mx\x1b[0m"; got != want {
+		t.Errorf("red = %q, want %q", got, want)
+	}
+	if got := term.StderrStyle("no-such-color", false, "x"); got != "x" {
+		t.Errorf("unknown color should be plain: %q", got)
+	}
+}
+
+func TestStderrStylePlain(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	term.ResetColorCache()
+	if got := term.StderrStyle("green", true, "x"); got != "x" {
+		t.Errorf("under NO_COLOR should be plain: %q", got)
+	}
+}
+
 func TestWidthNonTTY(t *testing.T) {
 	ns := newEnv(t)
 	v, err := eval(t, ns, `(term-width)`)


### PR DESCRIPTION
## Summary

The integrity audit was a single JSON line to stderr — fine for servers, noisy for interactive use. Now the output adapts to where stderr goes:

- **Interactive terminal** → a human-readable block via the `term` package, one field per line, **green when integrity is satisfied, red when not**:
  ```
  ✓ integrity verified
      ref     v1.4.2
      commit  9fceb02da8f3c1…
      signer  alice
  ```
  ```
  ✗ integrity check failed
      reason  … differs from its committed version at "v1"
  ```
- **Redirected (pipe/file)** → the structured JSON line is kept unchanged, so log ingestion is unaffected. Matches the "JSON for servers, readable for clients" split.

Honors `NO_COLOR` / `CLICOLOR_FORCE`. A terminal failure prints the red block and exits non-zero without the old second `Error:` line.

## Implementation

- `lib/term`: exported `StderrStyle` (Go-facing colorizer — stderr TTY + `NO_COLOR`/`CLICOLOR_FORCE` aware) and `StderrIsTerminal`; `colorDecision` refactored to take an fd (separate stdout/stderr caches).
- `command`: `reportIntegrity`/`integrityBlock`; `ErrIntegrityReported` sentinel so `main` suppresses the duplicate error line.

## Test plan

- `TestStderrStyle` / `TestStderrStylePlain` (term): SGR codes under `CLICOLOR_FORCE`, plain under `NO_COLOR`.
- `TestIntegrityBlockFormat` (command): green success block (header + 3 field lines), no signer line when absent, red failure block with the `integrity: ` prefix stripped.
- Full suite green with and without `-tags debugger`; verified end to end under a pty (colored block) and a pipe (JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
