### PR TITLE
feat(regexp): regular expressions library (Go RE2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,14 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   uncommitted edits, not a security boundary against whoever can
   rewrite the repository or the binary. Full specification in
   `INTEGRITY.md`
+- `regexp` library — regular expressions backed by Go's RE2 engine
+  (linear-time; no backreferences or lookaround). Patterns are written
+  as raw `¬…¬` strings (jig/lisp's equivalent of Clojure's `#"…"`).
+  `re-pattern` compiles a reusable regex; `re-matches?` / `re-find?`
+  return booleans (anchored / substring), `re-matches` / `re-find`
+  return Clojure-style match data (`nil`, the match string, or a vector
+  of capture groups). `re-replace`/`re-split`/`re-seq` are planned. See
+  `lib/regexp/README.md`
 - `exit` builtin: `(exit)` / `(exit status)` ends the process with the
   given status (`0` by default), like Clojure's `System/exit`. It stops
   before the interpreter echoes a script's final value, so a program run

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -460,6 +460,18 @@ Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integr
 | `state-load` | `[name & [default]]` | Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under --integrity the file must match its committed version at HEAD. |
 | `state-save` | `[name value]` | Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there. Under --integrity the commit keeps the verified ref valid. |
 
+### regexp
+
+Regular expressions (Go RE2): re-pattern, re-matches / re-find and their ? predicates.
+
+| Name | Arguments | Description |
+| ---- | --------- | ----------- |
+| `re-find` | `[re-or-pattern s]` | First match anywhere in s: nil, the match string when there are no groups, or a vector [whole g1 g2 …] (nil for an unmatched group). |
+| `re-find?` | `[re-or-pattern s]` | Reports whether the pattern matches anywhere in s (substring). Accepts a compiled regex or a raw pattern string. |
+| `re-matches` | `[re-or-pattern s]` | Anchored match of the whole string: nil, the match string when there are no groups, or a vector [whole g1 g2 …] (nil for an unmatched group). |
+| `re-matches?` | `[re-or-pattern s]` | Reports whether the whole string s matches (anchored). Accepts a compiled regex or a raw pattern string. |
+| `re-pattern` | `[pattern]` | Compiles a raw pattern string (Go RE2 syntax; write it as ¬…¬) into a reusable regex value. |
+
 ### web
 
 | Name | Arguments | Description |

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Changes respect to [kanaka/mal](https://github.com/kanaka/mal):
 - `(context (do ...))` provides a Go context. Context contents depend on Go, and might be passed to specific functions context compatible
 - Unit-testing library (`deftest`, `is`, `are`, `with-out-str`) run with `lisp --test DIR`, which loads every `*_test.lisp` / `*_test.mal` file in `DIR` and runs the registered tests. See "Testing lisp code" below
 - `web` library — a Ring-style HTTP/HTTPS server (`web-serve`, `web-router`, response helpers, middleware) with TLS, mTLS and Keycloak-compatible JWT verification. See [lib/web/README.md](./lib/web/README.md)
+- `regexp` library — regular expressions (Go RE2): `re-pattern`, `re-matches?`/`re-find?` (booleans) and `re-matches`/`re-find` (Clojure-style match data). Patterns are written as raw `¬…¬` strings. See [lib/regexp/README.md](./lib/regexp/README.md)
 - `(read-password prompt)` reads a line from stdin with terminal echo disabled (for secrets); prompt goes to stderr
 - Project compatible with GitHub CodeSpaces. Press `.` on your keyboard and you are ready to deploy a CodeSpace with mal in it
 - `(assert expr & optional-error)` asserts expression is not `nil` nor `false`, otherwise it success returning `nil`

--- a/cmd/lisp/main.go
+++ b/cmd/lisp/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jig/lisp/lib/git/nsgit"
 	"github.com/jig/lisp/lib/integrity/nsintegrity"
 	"github.com/jig/lisp/lib/lazy/nslazy"
+	"github.com/jig/lisp/lib/regexp/nsregexp"
 	"github.com/jig/lisp/lib/require/nsrequire"
 	"github.com/jig/lisp/lib/sql/nssql"
 	"github.com/jig/lisp/lib/system/nssystem"
@@ -48,6 +49,7 @@ func libraries(scriptArgs []string) []library {
 		{"sql", nssql.Load},
 		{"cli", nscli.Load},
 		{"integrity", nsintegrity.Load},
+		{"regexp", nsregexp.Load},
 		{"web", nsweb.Load},
 		{"git", nsgit.Load},
 		{"term", nsterm.Load},

--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -58,6 +58,7 @@ var sectionBlurb = map[string]struct{ title, desc string }{
 	"sql":                 {"sql", "SQL database access."},
 	"cli":                 {"cli", "Command-line option parsing (clojure/tools.cli style)."},
 	"integrity":           {"integrity", "Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integrity mode)."},
+	"regexp":              {"regexp", "Regular expressions (Go RE2): re-pattern, re-matches / re-find and their ? predicates."},
 }
 
 // entry is one documented symbol.

--- a/docgen/libraries.go
+++ b/docgen/libraries.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jig/lisp/lib/git/nsgit"
 	"github.com/jig/lisp/lib/integrity/nsintegrity"
 	"github.com/jig/lisp/lib/lazy/nslazy"
+	"github.com/jig/lisp/lib/regexp/nsregexp"
 	"github.com/jig/lisp/lib/require/nsrequire"
 	"github.com/jig/lisp/lib/sql/nssql"
 	"github.com/jig/lisp/lib/system/nssystem"
@@ -43,6 +44,7 @@ func standardLibraries() []library {
 		{"sql", nssql.Load},
 		{"cli", nscli.Load},
 		{"integrity", nsintegrity.Load},
+		{"regexp", nsregexp.Load},
 		{"web", nsweb.Load},
 		{"git", nsgit.Load},
 		{"term", nsterm.Load},

--- a/lib/regexp/README.md
+++ b/lib/regexp/README.md
@@ -1,0 +1,69 @@
+# regexp
+
+Regular expressions for jig/lisp, backed by Go's [RE2](https://github.com/google/re2/wiki/Syntax)
+engine. Following Clojure: `re-matches` is anchored (the whole string
+must match), `re-find` is unanchored (matches anywhere).
+
+## Writing patterns
+
+Patterns are Go RE2 syntax. Write them as **raw `¬…¬` strings** to avoid
+escaping — this is jig/lisp's equivalent of Clojure's `#"…"` literal:
+
+```clojure
+(re-find? ¬\d+¬ "abc123")     ; => true   — ¬…¬ keeps the backslash
+;; a normal "…" string rejects \d, so "\\d+" would be needed instead
+```
+
+**RE2 is not PCRE**: there are no backreferences (`\1`) and no
+lookahead/lookbehind. In exchange, matching is linear-time (no
+catastrophic backtracking). Most everyday patterns are identical.
+
+## Functions
+
+| Function | Returns |
+|---|---|
+| `(re-pattern pattern)` | a compiled, reusable regex value (prints as `«regex …»`) |
+| `(re-matches? re-or-pattern s)` | `true`/`false` — whole string matches (anchored) |
+| `(re-find? re-or-pattern s)` | `true`/`false` — matches anywhere (substring) |
+| `(re-matches re-or-pattern s)` | `nil`, the match string, or `[whole g1 g2 …]` (anchored) |
+| `(re-find re-or-pattern s)` | `nil`, the match string, or `[whole g1 g2 …]` (unanchored) |
+
+Every function accepts **either a compiled regex** (from `re-pattern`)
+**or a raw pattern string** (compiled on use), so `re-pattern` is only
+needed to reuse a pattern.
+
+`re-matches`/`re-find` mirror Clojure: `nil` when there is no match, the
+whole match string when the pattern has no capture groups, otherwise a
+vector `[whole g1 g2 …]` — with an unmatched optional group as `nil`.
+
+## Examples
+
+```clojure
+(re-matches? ¬\d+¬ "123")                 ; => true
+(re-matches? ¬\d+¬ "12a")                 ; => false  (anchored)
+(re-find?    ¬\d+¬ "abc123")              ; => true   (substring)
+
+(re-find ¬(\d+)-(\d+)¬ "call 555-1234")   ; => ["555-1234" "555" "1234"]
+(get (re-find ¬v(\d+)¬ "v42") 1)          ; => "42"   (a captured group)
+(re-find ¬\d+¬ "abc123def")               ; => "123"  (no groups → the match)
+(re-find ¬xyz¬ "abc")                     ; => nil    (no match)
+
+(def word (re-pattern ¬[a-z]+¬))          ; reuse a compiled pattern
+(re-find? word "HELLO world")             ; => true
+```
+
+## Loading
+
+The `lisp` binary loads the namespace by default. Go embedders load it
+with:
+
+```go
+import "github.com/jig/lisp/lib/regexp/nsregexp"
+
+nsregexp.Load(env)
+```
+
+## Not yet implemented
+
+`re-replace` / `re-replace-first`, `re-split`, and `re-seq` (all
+matches) are planned for a later iteration.

--- a/lib/regexp/nsregexp/nsregexp.go
+++ b/lib/regexp/nsregexp/nsregexp.go
@@ -1,0 +1,12 @@
+// Package nsregexp loads the regexp namespace into a jig/lisp environment.
+package nsregexp
+
+import (
+	"github.com/jig/lisp/lib/regexp"
+	"github.com/jig/lisp/types"
+)
+
+func Load(env types.EnvType) error {
+	regexp.Load(env)
+	return nil
+}

--- a/lib/regexp/regexp.go
+++ b/lib/regexp/regexp.go
@@ -1,0 +1,139 @@
+// Package regexp adds regular expressions to jig/lisp, backed by Go's
+// RE2 engine (linear-time matching; no backreferences or lookaround, so
+// it differs from Java/Clojure's PCRE-style engine). Patterns are best
+// written as raw ¬…¬ strings to avoid escaping — ¬\d+¬ rather than
+// "\\d+" (a normal "…" string rejects \d) — the jig/lisp equivalent of
+// Clojure's #"…" literal.
+//
+// re-pattern compiles a first-class, reusable regex; the other functions
+// accept either a compiled regex or a raw pattern string (compiled on
+// use). Following Clojure, re-matches / re-matches? are anchored (the
+// whole string must match) while re-find / re-find? are unanchored
+// (match anywhere).
+package regexp
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/jig/lisp/lib/call"
+	. "github.com/jig/lisp/types"
+)
+
+// Regexp is a compiled pattern — a first-class lisp value.
+type Regexp struct {
+	src      string
+	re       *regexp.Regexp // as written (unanchored), for find
+	anchored *regexp.Regexp // \A(?:src)\z, for matches
+}
+
+// LispPrint renders the regex as «regex src».
+func (r *Regexp) LispPrint(_ func(MalType, bool) string) string {
+	return "«regex " + r.src + "»"
+}
+
+func compile(fnName, src string) (*Regexp, error) {
+	re, err := regexp.Compile(src)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", fnName, err)
+	}
+	// \A…\z anchor the whole text regardless of any (?m) flag in src, so
+	// re-matches means "the entire string", as in Clojure/Java.
+	anchored, err := regexp.Compile(`\A(?:` + src + `)\z`)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", fnName, err)
+	}
+	return &Regexp{src: src, re: re, anchored: anchored}, nil
+}
+
+// asRegexp accepts a compiled Regexp or a raw pattern string.
+func asRegexp(fnName string, v MalType) (*Regexp, error) {
+	switch t := v.(type) {
+	case *Regexp:
+		return t, nil
+	case string:
+		return compile(fnName, t)
+	default:
+		return nil, fmt.Errorf("%s: expected a regex or a pattern string, got %T", fnName, v)
+	}
+}
+
+func Load(env EnvType) {
+	call.CallOverrideFN(env, "re-pattern", rePattern)
+	call.CallOverrideFN(env, "re-matches?", reMatchesQ)
+	call.CallOverrideFN(env, "re-find?", reFindQ)
+	call.CallOverrideFN(env, "re-matches", reMatches)
+	call.CallOverrideFN(env, "re-find", reFind)
+
+	call.Doc(env, "re-pattern", "[pattern]",
+		"Compiles a raw pattern string (Go RE2 syntax; write it as ¬…¬) into a reusable regex value.")
+	call.Doc(env, "re-matches?", "[re-or-pattern s]",
+		"Reports whether the whole string s matches (anchored). Accepts a compiled regex or a raw pattern string.")
+	call.Doc(env, "re-find?", "[re-or-pattern s]",
+		"Reports whether the pattern matches anywhere in s (substring). Accepts a compiled regex or a raw pattern string.")
+	call.Doc(env, "re-matches", "[re-or-pattern s]",
+		"Anchored match of the whole string: nil, the match string when there are no groups, or a vector [whole g1 g2 …] (nil for an unmatched group).")
+	call.Doc(env, "re-find", "[re-or-pattern s]",
+		"First match anywhere in s: nil, the match string when there are no groups, or a vector [whole g1 g2 …] (nil for an unmatched group).")
+}
+
+func rePattern(pattern MalType) (MalType, error) {
+	return asRegexp("re-pattern", pattern)
+}
+
+func reMatchesQ(reOrPattern MalType, s string) (MalType, error) {
+	rx, err := asRegexp("re-matches?", reOrPattern)
+	if err != nil {
+		return nil, err
+	}
+	return rx.anchored.MatchString(s), nil
+}
+
+func reFindQ(reOrPattern MalType, s string) (MalType, error) {
+	rx, err := asRegexp("re-find?", reOrPattern)
+	if err != nil {
+		return nil, err
+	}
+	return rx.re.MatchString(s), nil
+}
+
+func reMatches(reOrPattern MalType, s string) (MalType, error) {
+	rx, err := asRegexp("re-matches", reOrPattern)
+	if err != nil {
+		return nil, err
+	}
+	return submatch(rx.anchored, s), nil
+}
+
+func reFind(reOrPattern MalType, s string) (MalType, error) {
+	rx, err := asRegexp("re-find", reOrPattern)
+	if err != nil {
+		return nil, err
+	}
+	return submatch(rx.re, s), nil
+}
+
+// submatch mirrors Clojure's re-matches/re-find return: nil when there is
+// no match; the whole match string when the pattern has no capture
+// groups; else a vector [whole g1 g2 …] with an unmatched optional group
+// rendered as nil (Go leaves it "", so index -1 is used to tell apart).
+func submatch(re *regexp.Regexp, s string) MalType {
+	idx := re.FindStringSubmatchIndex(s)
+	if idx == nil {
+		return nil
+	}
+	n := len(idx) / 2
+	if n == 1 {
+		return s[idx[0]:idx[1]]
+	}
+	out := make([]MalType, n)
+	for i := range n {
+		start, end := idx[2*i], idx[2*i+1]
+		if start < 0 {
+			out[i] = nil
+		} else {
+			out[i] = s[start:end]
+		}
+	}
+	return Vector{Val: out}
+}

--- a/lib/regexp/regexp_test.go
+++ b/lib/regexp/regexp_test.go
@@ -1,0 +1,116 @@
+package regexp_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/regexp/nsregexp"
+	"github.com/jig/lisp/types"
+)
+
+func newEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	if err := nscore.Load(ns); err != nil {
+		t.Fatal(err)
+	}
+	if err := nscore.LoadInput(ns); err != nil {
+		t.Fatal(err)
+	}
+	if err := nsregexp.Load(ns); err != nil {
+		t.Fatal(err)
+	}
+	return ns
+}
+
+// eval returns the printed form of src (REPL already prints the result).
+func eval(t *testing.T, ns types.EnvType, src string) string {
+	t.Helper()
+	out, err := lisp.REPL(context.Background(), ns, src, types.NewCursorFile(t.Name()))
+	if err != nil {
+		t.Fatalf("EVAL %s: %v", src, err)
+	}
+	s, _ := out.(string)
+	return s
+}
+
+func evalErr(t *testing.T, ns types.EnvType, src string) {
+	t.Helper()
+	if _, err := lisp.REPL(context.Background(), ns, src, types.NewCursorFile(t.Name())); err == nil {
+		t.Fatalf("%s did not error", src)
+	}
+}
+
+func TestPredicates(t *testing.T) {
+	ns := newEnv(t)
+	cases := []struct {
+		src, want string
+	}{
+		// re-matches? is anchored (whole string)
+		{`(re-matches? ¬\d+¬ "123")`, "true"},
+		{`(re-matches? ¬\d+¬ "12a")`, "false"},
+		{`(re-matches? ¬\d+¬ "a123")`, "false"},
+		// re-find? is unanchored (substring)
+		{`(re-find? ¬\d+¬ "abc123")`, "true"},
+		{`(re-find? ¬\d+¬ "abc")`, "false"},
+		{`(re-find? ¬xyz¬ "abc")`, "false"},
+		// a compiled pattern works the same as a raw string
+		{`(re-find? (re-pattern ¬[a-z]+¬) "HELLO world")`, "true"},
+		{`(re-matches? (re-pattern ¬[a-z]+¬) "HELLO")`, "false"},
+	}
+	for _, c := range cases {
+		if got := eval(t, ns, c.src); got != c.want {
+			t.Errorf("%s = %s, want %s", c.src, got, c.want)
+		}
+	}
+}
+
+func TestMatchData(t *testing.T) {
+	ns := newEnv(t)
+	cases := []struct {
+		src, want string
+	}{
+		// no groups -> the whole match string
+		{`(re-find ¬\d+¬ "abc123def")`, `"123"`},
+		{`(re-matches ¬\d+¬ "123")`, `"123"`},
+		// no match -> nil
+		{`(re-find ¬xyz¬ "abc")`, "nil"},
+		{`(re-matches ¬\d+¬ "12a")`, "nil"},
+		// groups -> [whole g1 g2 …]
+		{`(re-find ¬(\d+)-(\d+)¬ "call 555-1234 now")`, `["555-1234" "555" "1234"]`},
+		{`(re-matches ¬(\d+)-(\d+)¬ "555-1234")`, `["555-1234" "555" "1234"]`},
+		// unmatched optional group -> nil
+		{`(re-find ¬(a)?(b)¬ "b")`, `["b" nil "b"]`},
+		// extracting a captured group
+		{`(get (re-find ¬v(\d+)¬ "v42") 1)`, `"42"`},
+	}
+	for _, c := range cases {
+		if got := eval(t, ns, c.src); got != c.want {
+			t.Errorf("%s = %s, want %s", c.src, got, c.want)
+		}
+	}
+}
+
+func TestPatternValue(t *testing.T) {
+	ns := newEnv(t)
+	// re-pattern prints as «regex …» and is idempotent (accepts a regex).
+	if got := eval(t, ns, `(str (re-pattern ¬[a-z]+¬))`); got != `"«regex [a-z]+»"` {
+		t.Errorf("printed = %s", got)
+	}
+	if got := eval(t, ns, `(re-find? (re-pattern (re-pattern ¬\d¬)) "a1")`); got != "true" {
+		t.Errorf("re-pattern on a regex = %s, want true", got)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	ns := newEnv(t)
+	// invalid pattern
+	evalErr(t, ns, `(re-matches? ¬(unclosed¬ "x")`)
+	evalErr(t, ns, `(re-pattern ¬[¬)`)
+	// wrong argument types
+	evalErr(t, ns, `(re-find? 42 "x")`)
+	evalErr(t, ns, `(re-matches? ¬\d¬ 42)`)
+}


### PR DESCRIPTION
## Summary

Adds regular expressions to jig/lisp — there was none. A `regexp` namespace, loaded by default in the `lisp` binary, with **Clojure-style semantics** on Go's **RE2** engine.

```clojure
(re-matches? ¬\d+¬ "123")                 ; => true   (anchored — whole string)
(re-find?    ¬\d+¬ "abc123")              ; => true   (substring)
(re-find ¬(\d+)-(\d+)¬ "call 555-1234")   ; => ["555-1234" "555" "1234"]
(get (re-find ¬v(\d+)¬ "v42") 1)          ; => "42"
```

- **`re-pattern`** compiles a first-class, reusable regex (prints `«regex …»`). Every function also accepts a **raw pattern string** (compiled on use), so `re-pattern` is optional.
- **`re-matches?` / `re-find?`** → booleans (anchored whole-string / unanchored substring) — the primary need.
- **`re-matches` / `re-find`** → Clojure-style match data: `nil`, the match string when there are no groups, or a vector `[whole g1 g2 …]` (an unmatched optional group is `nil`, faithful to Clojure via `FindStringSubmatchIndex`).

### Design notes

- **RE2, not PCRE**: no backreferences or lookaround; linear-time in exchange. Documented.
- **No `#"…"` reader literal**: jig/lisp's raw `¬…¬` string already avoids escaping (`¬\d+¬`; a normal `"\d+"` is a read error), so it's the natural pattern syntax — no scanner changes.
- `re-matches` anchors with `\A(?:…)\z` so "whole string" holds regardless of a `(?m)` flag.
- `re-replace` / `re-split` / `re-seq` are deferred to a later iteration (agreed scope).

## Test plan

- `lib/regexp/regexp_test.go`: predicates (anchored vs substring, compiled vs raw), match data (no-groups → string, groups → vector, unmatched group → nil, no match → nil), the pattern value (`«regex …»` print, `re-pattern` idempotent), and errors (bad pattern, wrong arg types).
- Registered in `main.go` and `docgen/libraries.go` (sync test passes); `LANGUAGE.md` regenerated. Full suite green with and without `-tags debugger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
