### PR TITLE
feat(integrity): optional commit message for state-save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,7 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   trusted key (state authenticity, not just consistency). New builtins:
   `(assert-integrity)` throws unless the run is verified — so
   committed code can demand the flag — and returns the verified commit
-  hash; `(state-save name value)` / `(state-load name & [default])`
+  hash; `(state-save name value & [message])` / `(state-load name & [default])`
   persist program state as canonical lisp data under `.state/`
   (deterministic key order, width-aware wrapping, reader-macro sugar —
   `'x`, `` `x ``, `~x`, `~@x`, `@x`, `^meta form`),

--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -130,7 +130,7 @@ verified. Color also honours `NO_COLOR` / `CLICOLOR_FORCE`.
 | Builtin | Behaviour |
 |---|---|
 | `(assert-integrity)` | Throws unless running under `--integrity`; returns the verified commit hash. Committed code uses it to demand the mode — effective as long as operators know the program is supposed to carry it. |
-| `(state-save name value)` | Writes `value` as canonical lisp data to `.state/name.lisp` and **commits it in the same operation** (message `state: name`); returns the commit hash. Under `--integrity-keys` the commit is SSH-signed with the ssh-agent key listed there (no per-call key). Saving an unchanged value is a no-op returning the current commit. Works with or without the mode; requires a Git repository. |
+| `(state-save name value & [message])` | Writes `value` as canonical lisp data to `.state/name.lisp` and **commits it in the same operation**; returns the commit hash. The commit `message` defaults to `state: name`. Under `--integrity-keys` the commit is SSH-signed with the ssh-agent key listed there (no per-call key). Saving an unchanged value is a no-op returning the current commit. Works with or without the mode; requires a Git repository. |
 | `(state-load name)` / `(state-load name default)` | Reads the state back as pure data (READ, never EVAL — state cannot smuggle code). Returns `default`, or throws without one, when the state does not exist. Under the mode, enforces invariant 6. |
 | `(slurp-source path)` | `slurp` for files about to be evaluated: identical, plus invariant 5 under the mode. `load-file` builds on it. |
 

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -458,7 +458,7 @@ Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integr
 | `fmt` | `[s]` | Formats lisp source s into its canonical form (as lisp --fmt does); errors if s does not parse. |
 | `sha2-256` | `[s]` | SHA2-256 digest of string s, as lowercase hex. |
 | `state-load` | `[name & [default]]` | Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under --integrity the file must match its committed version at HEAD. |
-| `state-save` | `[name value]` | Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there. Under --integrity the commit keeps the verified ref valid. |
+| `state-save` | `[name value & [message]]` | Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. message is the commit message (default "state: name"). Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there. Under --integrity the commit keeps the verified ref valid. |
 
 ### regexp
 

--- a/command/integrity_test.go
+++ b/command/integrity_test.go
@@ -36,10 +36,16 @@ func newIntegrityEnv(t *testing.T) types.EnvType {
 }
 
 // runGit runs a git command in dir and returns its trimmed output,
-// failing the test on error. Shared by the integrity tests.
+// failing the test on error. Shared by the integrity tests. Signing is
+// disabled so the test is hermetic regardless of the runner's global
+// commit.gpgsign / tag.gpgsign config.
 func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-	cmd := exec.Command("git", append([]string{"-c", "user.name=Test", "-c", "user.email=test@example.com"}, args...)...)
+	base := []string{
+		"-c", "user.name=Test", "-c", "user.email=test@example.com",
+		"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false",
+	}
+	cmd := exec.Command("git", append(base, args...)...)
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/lib/integrity/README.md
+++ b/lib/integrity/README.md
@@ -18,7 +18,7 @@ mode](#integrity-mode---integrity) (`lisp --integrity <ref>`).
 | `(ed25519-sign private s)` | base64 signature of `s` |
 | `(ed25519-verify public s signature)` | `true` or `false` |
 | `(assert-integrity)` | the verified commit hash; **throws** unless running under `--integrity` |
-| `(state-save name value)` | writes `value` as canonical lisp data to `.state/name.lisp` and commits it (SSH-signed with the ssh-agent key under `--integrity-keys`); returns the commit hash |
+| `(state-save name value & [message])` | writes `value` as canonical lisp data to `.state/name.lisp` and commits it (message defaults to `state: name`; SSH-signed with the ssh-agent key under `--integrity-keys`); returns the commit hash |
 | `(state-load name & [default])` | the state read back as pure data (READ, never EVAL); `default` (or throws) when absent |
 
 Ed25519 signing is deterministic: the same key and message always yield

--- a/lib/integrity/integrity.go
+++ b/lib/integrity/integrity.go
@@ -39,7 +39,7 @@ func Load(env EnvType) {
 	call.Call(env, ed25519_sign)
 	call.Call(env, ed25519_verify)
 	call.Call(env, assert_integrity)
-	call.Call(env, state_save)
+	call.Call(env, state_save, 2, 3)
 	call.Call(env, state_load, 1, 2)
 
 	call.Doc(env, "fmt", "[s]",
@@ -54,8 +54,8 @@ func Load(env EnvType) {
 		"Reports whether the base64 signature of string s verifies against the base64 Ed25519 public key.")
 	call.Doc(env, "assert-integrity", "[]",
 		"Throws unless the interpreter runs under --integrity; returns the verified commit hash.")
-	call.Doc(env, "state-save", "[name value]",
-		"Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there. Under --integrity the commit keeps the verified ref valid.")
+	call.Doc(env, "state-save", "[name value & [message]]",
+		"Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. message is the commit message (default \"state: name\"). Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there. Under --integrity the commit keeps the verified ref valid.")
 	call.Doc(env, "state-load", "[name & [default]]",
 		"Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under --integrity the file must match its committed version at HEAD.")
 }

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -515,6 +515,45 @@ func TestStateSaveIdempotentUnchanged(t *testing.T) {
 	}
 }
 
+// TestStateSaveMessage covers the optional commit-message argument:
+// default "state: name", a custom message when given, and a type error
+// for a non-string message.
+func TestStateSaveMessage(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, _ := setupRepo(t, ns, "")
+	t.Chdir(dir)
+
+	evalLisp(t, ns, `(state-save "db" {:n 1})`)             // default message
+	evalLisp(t, ns, `(state-save "db" {:n 2} "bump to 2")`) // custom message
+
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Message != "bump to 2" {
+		t.Fatalf("HEAD message = %q, want %q", c.Message, "bump to 2")
+	}
+	parent, err := c.Parent(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parent.Message != "state: db" {
+		t.Fatalf("parent (default) message = %q, want %q", parent.Message, "state: db")
+	}
+
+	if err := evalErr(t, ns, `(state-save "db" {:n 3} 42)`); !strings.Contains(err.Error(), "message must be a string") {
+		t.Fatalf("non-string message = %v, want a type error", err)
+	}
+}
+
 // TestStateChainSignedUnderKeys verifies that under --integrity-keys every
 // state commit above the ref must be SSH-signed by a listed key: a signed
 // chain verifies, an unsigned state commit on top fails closed.

--- a/lib/integrity/state.go
+++ b/lib/integrity/state.go
@@ -77,9 +77,23 @@ func statePath(fnName, name string) (string, error) {
 	return stateDir + "/" + name + ".lisp", nil
 }
 
-func state_save(name string, value MalType) (MalType, error) {
+func state_save(name string, value MalType, params ...MalType) (MalType, error) {
 	stateMu.Lock()
 	defer stateMu.Unlock()
+
+	// Optional commit message; defaults to "state: <name>".
+	message := "state: " + name
+	switch len(params) {
+	case 0:
+	case 1:
+		m, ok := params[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("state-save: message must be a string, got %T", params[0])
+		}
+		message = m
+	default:
+		return nil, fmt.Errorf("state-save: expected at most one message argument, got %d", len(params))
+	}
 
 	rel, err := statePath("state-save", name)
 	if err != nil {
@@ -120,7 +134,7 @@ func state_save(name string, value MalType) (MalType, error) {
 	}); err != nil {
 		return nil, fmt.Errorf("state-save: %w", err)
 	}
-	hash, err := wt.Commit("state: "+name, &gogit.CommitOptions{
+	hash, err := wt.Commit(message, &gogit.CommitOptions{
 		Author: &object.Signature{Name: "state-save", Email: "state-save@lisp", When: time.Now()},
 		Signer: gogitutil.NoSign{},
 	})


### PR DESCRIPTION
## Summary

`state-save` becomes variadic — `(state-save name value & [message])` — mirroring `state-load`. The optional `message` is the git commit message for the state commit; it **defaults to `state: name`**, so existing calls are unchanged (backward-compatible).

```clojure
(state-save "db" value)                 ; commit message "state: db" (as before)
(state-save "db" value "bump counter")  ; commit message "bump counter"
```

Nothing keys on the commit message for correctness (the `.state/`-only descent check is path-based), so a custom message is safe.

Also makes the command integrity tests' `runGit` helper hermetic (disables `commit.gpgsign` / `tag.gpgsign`) so they don't fail on a machine whose global git config enables signing.

## Test plan

- New `TestStateSaveMessage`: default message on a plain save, custom message when given, parent keeps the default, non-string message rejected.
- Doc/arglist updated (`[name value & [message]]`, `call.Call(env, state_save, 2, 3)`); `LANGUAGE.md` regenerated. Full suite green with and without `-tags debugger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)