### PR TITLE
test: run EVAL timeout tests under testing/synctest

### DIFF
--- a/timeout_test.go
+++ b/timeout_test.go
@@ -4,97 +4,89 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/jig/lisp/lib/concurrent"
 	"github.com/jig/lisp/types"
 )
 
-func TestContextTimeoutFiresOnTime(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
+// These tests exercise context-deadline handling in EVAL. They run inside
+// a synctest bubble: the time package uses a fake clock that only advances
+// when every goroutine is durably blocked, so the deadlines below fire
+// deterministically (no wall-clock jitter) and instantly (no real wait).
 
-	if _, err := REPL(ctx, newEnv(t.Name()), `(sleep 1000)`, types.NewCursorFile(t.Name())); err == nil {
-		t.Fatalf("Must fail")
-	} else {
-		if !strings.Contains(err.Error(), "timeout while evaluating expression") {
-			t.Fatalf("%s != %s", err.Error(), "timeout while evaluating expression")
+func TestContextTimeoutFiresOnTime(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		_, err := REPL(ctx, newEnv(t.Name()), `(sleep 1000)`, types.NewCursorFile(t.Name()))
+		if err == nil || !strings.Contains(err.Error(), "timeout while evaluating expression") {
+			t.Fatalf("want a timeout error, got %v", err)
 		}
-	}
+	})
 }
 
 func TestContextNoTimeout(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
 
-	if _, err := REPL(ctx, newEnv(t.Name()), `(sleep 1)`, types.NewCursorFile(t.Name())); err != nil {
-		t.Fatal(err)
-	}
+		if _, err := REPL(ctx, newEnv(t.Name()), `(sleep 1)`, types.NewCursorFile(t.Name())); err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestFutureContextTimeoutFiresOnTime(t *testing.T) {
-	ctxB := context.Background()
-	env := newEnv(t.Name())
-	concurrent.Load(env)
-	concurrentHeader := concurrent.HeaderConcurrent()
-	if _, err := REPL(ctxB, env, concurrentHeader, types.NewCursorFile(t.Name())); err != nil {
-		t.Fatal(err)
-	}
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-
-	if _, err := REPL(ctx, newEnv(t.Name()), `@(future (sleep 1000))`, types.NewCursorFile(t.Name())); err == nil {
-		t.Fatalf("Must fail")
-	} else {
-		if !strings.Contains(err.Error(), "timeout while dereferencing future") {
-			t.Fatalf("%s != %s", err.Error(), "timeout while dereferencing future")
+		_, err := REPL(ctx, newEnv(t.Name()), `@(future (sleep 1000))`, types.NewCursorFile(t.Name()))
+		if err == nil || !strings.Contains(err.Error(), "timeout while dereferencing future") {
+			t.Fatalf("want a future-deref timeout, got %v", err)
 		}
-	}
+	})
 }
 
 func TestFutureContextNoTimeout(t *testing.T) {
-	ctxB := context.Background()
-	env := newEnv(t.Name())
-	concurrent.Load(env)
-	concurrentHeader := concurrent.HeaderConcurrent()
-	if _, err := REPL(ctxB, env, concurrentHeader, types.NewCursorFile(t.Name())); err != nil {
-		t.Fatal(err)
-	}
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
+		defer cancel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1000*time.Millisecond)
-	defer cancel()
-
-	if _, err := REPL(ctx, newEnv(t.Name()), `@(future (sleep 1))`, types.NewCursorFile(t.Name())); err != nil {
-		t.Fatal(err)
-	}
+		if _, err := REPL(ctx, newEnv(t.Name()), `@(future (sleep 1))`, types.NewCursorFile(t.Name())); err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestTimeoutOnTryCatch(t *testing.T) {
-	ns := newEnv(t.Name())
-	ast, err := READ(`(try (sleep 10000) (catch e (str "ERR: " (error-string e))))`, types.NewCursorFile(t.Name()), ns)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// `try` reserves 20% of the deadline for the catch/finally handlers
-	// (mal.go: 80% goes to the try body). The handler here is a trivial
-	// string concat, but on a loaded CI runner the scheduling jitter
-	// between the try body's timeout firing and the handler running can
-	// exceed a too-small 20% slice — then the top-of-loop ctx check
-	// re-fires the (now expired) deadline outside the try, uncatchably.
-	// A comfortable deadline keeps that 20% (~400ms) far larger than any
-	// realistic jitter, so the timeout is caught deterministically.
-	ctx, cancel := context.WithTimeout(context.Background(), 2000*time.Millisecond)
-	defer cancel()
-	res, err := EVAL(ctx, ast, ns)
-	if err != nil {
-		if err.Error() == "timeout while evaluating expression" {
-			t.Fatalf("timeout not catched: %s", err)
+	synctest.Test(t, func(t *testing.T) {
+		ns := newEnv(t.Name())
+		ast, err := READ(`(try (sleep 10000) (catch e (str "ERR: " (error-string e))))`, types.NewCursorFile(t.Name()), ns)
+		if err != nil {
+			t.Fatal(err)
 		}
-		t.Fatalf("unexpected error caught %s", err)
-	}
-
-	if res.(string) != "ERR: timeout while evaluating expression" {
-		t.Fatalf("unexpected result %s", res)
-	}
+		// `try` gives 80% of the deadline to the body and reserves 20% for
+		// the catch/finally handler (mal.go). Under the real clock a small
+		// 20% slice was flaky: scheduling jitter between the body's timeout
+		// firing and the handler running could exceed it, and the
+		// top-of-loop ctx check then re-fired the expired deadline outside
+		// the try, uncatchably. Under synctest's fake clock there is no
+		// jitter — the catch handler runs at zero fake time — so the
+		// timeout is caught deterministically even with this tight deadline.
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+		res, err := EVAL(ctx, ast, ns)
+		if err != nil {
+			if err.Error() == "timeout while evaluating expression" {
+				t.Fatalf("timeout not caught: %s", err)
+			}
+			t.Fatalf("unexpected error caught: %s", err)
+		}
+		if res.(string) != "ERR: timeout while evaluating expression" {
+			t.Fatalf("unexpected result: %s", res)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Wraps the EVAL context-deadline tests in `synctest.Test` (Go 1.25+): inside the bubble the `time` package uses a fake clock that only advances when every goroutine is durably blocked, so deadlines fire **deterministically** (no wall-clock jitter) and **instantly** (no real wait).

Converted: `TestContextTimeoutFiresOnTime`, `TestContextNoTimeout`, `TestFutureContextTimeoutFiresOnTime`, `TestFutureContextNoTimeout`, `TestTimeoutOnTryCatch`.

The headline win: `TestTimeoutOnTryCatch` goes back to a tight **500ms** deadline — the value that was flaky under the real clock, which an earlier commit had widened to 2s to mask the jitter. Under the fake clock the `catch` handler runs at zero fake time, so the timeout is caught deterministically. Also drops the redundant `concurrent.Load` setup in the future tests (`newEnv` already loads it), which was building an env the test then didn't use.

## Test plan

- All five tests pass **30× under full CPU load** in ~2.3s (vs tens of seconds of real waiting before).
- Full suite green with and without `-tags debugger` (the debugger build activates the EVAL hook path; synctest still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)