### PR TITLE
feat(system): directory/process primitives (chdir, cwd, mkdtemp, remove-all)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,14 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   return Clojure-style match data (`nil`, the match string, or a vector
   of capture groups). `re-replace`/`re-split`/`re-seq` are planned. See
   `lib/regexp/README.md`
+- `system` library grows directory/process primitives: `(chdir path)`
+  (changes the process-global working directory — affects the `.state`
+  store and git detection), `(cwd)` (the working directory as an
+  absolute path), `(mkdtemp & [prefix])` (a fresh unique temp directory)
+  and `(remove-all path)` (recursive delete, no error if absent). These
+  let in-process tests drive `state-save`/`state-load` against a
+  temporary git repo (via `mkdtemp` + `git-init` + `chdir`) instead of
+  the real one
 - `exit` builtin: `(exit)` / `(exit status)` ends the process with the
   given status (`0` by default), like Clojure's `System/exit`. It stops
   before the interpreter echoes a script's final value, so a program run

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -372,11 +372,15 @@ Higher-order helpers written in lisp (the prelude): reduce, map, partial, protoc
 
 ### system
 
-Access to the host environment (env vars, …).
+Host OS: environment variables, working directory, temp directories, file removal.
 
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
+| `chdir` | `[path]` | Changes the process working directory to path. Process-global: affects the working directory of all subsequent operations, including the .state store and git repository detection. |
+| `cwd` | `[]` | Returns the process working directory as an absolute path string. |
 | `getenv` | `[name]` | Value of the environment variable name, or nil. |
+| `mkdtemp` | `[& prefix]` | Creates a new uniquely-named temporary directory (optionally name-prefixed) and returns its absolute path. |
+| `remove-all` | `[path]` | Recursively removes path and everything under it; does not error if path is absent. |
 | `setenv` | `[name value]` | Sets the environment variable name to value. |
 | `unsetenv` | `[name]` | Removes the environment variable name. |
 

--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -52,7 +52,7 @@ var sectionBlurb = map[string]struct{ title, desc string }{
 	"concurrent":          {"concurrent", "Atoms and futures for shared, thread-safe state."},
 	"core mal extended":   {"coreextended", "Higher-order helpers written in lisp (the prelude): reduce, map, partial, protocols…"},
 	"assert":              {"assert", "Minimal test library (run with `lisp --test DIR`)."},
-	"system":              {"system", "Access to the host environment (env vars, …)."},
+	"system":              {"system", "Host OS: environment variables, working directory, temp directories, file removal."},
 	"lazy":                {"lazy", "Lazy sequences."},
 	"require":             {"require", "Module loading by name through a search path."},
 	"sql":                 {"sql", "SQL database access."},

--- a/lib/system/docs_test.go
+++ b/lib/system/docs_test.go
@@ -13,7 +13,7 @@ import (
 func TestSystemDocs(t *testing.T) {
 	ns := env.NewEnv()
 	Load(ns)
-	for _, name := range []string{"getenv", "setenv", "unsetenv"} {
+	for _, name := range []string{"getenv", "setenv", "unsetenv", "chdir", "cwd", "mkdtemp", "remove-all"} {
 		v, err := ns.Get(types.Symbol{Val: name})
 		if err != nil {
 			t.Errorf("%q not registered", name)

--- a/lib/system/system.go
+++ b/lib/system/system.go
@@ -3,6 +3,7 @@ package system
 import (
 	"context"
 	_ "embed"
+	"fmt"
 	"os"
 
 	"github.com/jig/lisp/lib/call"
@@ -13,10 +14,22 @@ func Load(env EnvType) {
 	call.Call(env, getenv)
 	call.Call(env, setenv)
 	call.Call(env, unsetenv)
+	call.Call(env, chdir)
+	call.Call(env, cwd)
+	call.Call(env, mkdtemp, 0, 1)
+	call.Call(env, remove_all)
 
 	call.Doc(env, "getenv", "[name]", "Value of the environment variable name, or nil.")
 	call.Doc(env, "setenv", "[name value]", "Sets the environment variable name to value.")
 	call.Doc(env, "unsetenv", "[name]", "Removes the environment variable name.")
+	call.Doc(env, "chdir", "[path]",
+		"Changes the process working directory to path. Process-global: affects the working directory of all subsequent operations, including the .state store and git repository detection.")
+	call.Doc(env, "cwd", "[]",
+		"Returns the process working directory as an absolute path string.")
+	call.Doc(env, "mkdtemp", "[& prefix]",
+		"Creates a new uniquely-named temporary directory (optionally name-prefixed) and returns its absolute path.")
+	call.Doc(env, "remove-all", "[path]",
+		"Recursively removes path and everything under it; does not error if path is absent.")
 }
 
 func getenv(ctx context.Context, k string) (MalType, error) {
@@ -32,4 +45,35 @@ func setenv(ctx context.Context, k, v string) error {
 
 func unsetenv(ctx context.Context, k string) error {
 	return os.Unsetenv(k)
+}
+
+// chdir changes the process-global working directory.
+func chdir(path string) (MalType, error) {
+	if err := os.Chdir(path); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// cwd returns the absolute process working directory.
+func cwd() (MalType, error) {
+	return os.Getwd()
+}
+
+// mkdtemp creates a new temporary directory and returns its path.
+func mkdtemp(prefix ...MalType) (MalType, error) {
+	p := ""
+	if len(prefix) == 1 {
+		s, ok := prefix[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("mkdtemp: prefix must be a string, got %T", prefix[0])
+		}
+		p = s
+	}
+	return os.MkdirTemp("", p)
+}
+
+// remove_all recursively removes path (lisp name: remove-all).
+func remove_all(path string) (MalType, error) {
+	return nil, os.RemoveAll(path)
 }

--- a/lib/system/system_test.go
+++ b/lib/system/system_test.go
@@ -1,0 +1,101 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resolve follows symlinks so comparisons hold on macOS, where
+// t.TempDir()/os.MkdirTemp live under /var → /private/var.
+func resolve(t *testing.T, p string) string {
+	t.Helper()
+	r, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func TestChdirCwd(t *testing.T) {
+	dir := t.TempDir() // registers its own cleanup first…
+
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// …so this restore, registered after, runs BEFORE dir is removed —
+	// leaving cwd valid and not polluting other tests in the package.
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	if _, err := chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	got, err := cwd()
+	if err != nil {
+		t.Fatalf("cwd: %v", err)
+	}
+	if resolve(t, got.(string)) != resolve(t, dir) {
+		t.Fatalf("cwd = %q, want %q", got, dir)
+	}
+
+	// chdir to a missing directory errors and leaves cwd unchanged.
+	if _, err := chdir(filepath.Join(dir, "nope")); err == nil {
+		t.Fatal("chdir to a missing directory should error")
+	}
+	if now, _ := os.Getwd(); resolve(t, now) != resolve(t, dir) {
+		t.Fatalf("failed chdir changed cwd to %q", now)
+	}
+}
+
+func TestMkdtemp(t *testing.T) {
+	a, err := mkdtemp()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(a.(string)) })
+	if st, err := os.Stat(a.(string)); err != nil || !st.IsDir() {
+		t.Fatalf("mkdtemp did not create a directory: %v", err)
+	}
+
+	b, err := mkdtemp("jig-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(b.(string)) })
+	if a.(string) == b.(string) {
+		t.Fatal("two mkdtemp calls returned the same path")
+	}
+	if !strings.HasPrefix(filepath.Base(b.(string)), "jig-") {
+		t.Fatalf("prefix not applied: %s", b)
+	}
+
+	if _, err := mkdtemp(42); err == nil {
+		t.Fatal("a non-string prefix should error")
+	}
+}
+
+func TestRemoveAll(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "a", "b")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	target := filepath.Join(dir, "a")
+	if _, err := remove_all(target); err != nil {
+		t.Fatalf("remove-all: %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("remove-all left %s behind", target)
+	}
+
+	// an absent path is not an error
+	if _, err := remove_all(filepath.Join(dir, "missing")); err != nil {
+		t.Fatalf("remove-all on an absent path errored: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds four primitives to the `system` library so lisp code can drive filesystem/process state — the immediate need being an **in-process integration test** that runs the staging→custodian flow against a *temporary* git repo instead of the real one.

| Builtin | Behaviour |
|---|---|
| `(chdir path)` | changes the process-global working directory (`os.Chdir`); `nil` on success |
| `(cwd)` | the working directory as an absolute path string |
| `(mkdtemp & [prefix])` | a fresh, uniquely-named temp directory (`os.MkdirTemp`), returns its path |
| `(remove-all path)` | recursive delete (`os.RemoveAll`); no error if the path is absent |

Placed in `system` (the host-OS library): `chdir`/`cwd` are process-global state like the existing `getenv`/`setenv`, and `mkdtemp`/`remove-all` are OS operations.

Verified end to end: `mkdtemp` + `git-init` + `chdir` + `state-save` (which creates the **first commit** on an unborn branch) + `state-load`, all without `--integrity`, then cleanup with `chdir` back + `remove-all`.

## Notes from the spec review

- The Go func is `remove_all` (snake_case) so the derived lisp name is **`remove-all`** — `removeAll` would have become `removeall` (the name derivation is lowercase + `_`→`-`, no camelCase split).
- The `chdir` Go test **restores cwd** (its cleanup is registered after `t.TempDir()`, so it runs first) to avoid polluting other tests in the package.

## Test plan

- `lib/system/system_test.go`: `chdir`+`cwd` round-trip and failure-leaves-cwd, `mkdtemp` uniqueness/prefix/type-error, `remove-all` recursive + absent-path.
- `docs_test.go` extended to cover the new builtins; `LANGUAGE.md` regenerated. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)