### PR TITLE
refactor: move file I/O from core to system (capability model)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ migration note.
 
 ## Unreleased (since v0.2.24)
 
+### ⚠️ Changed — file I/O moved from `core` to `system`
+
+`slurp`, `spit`, `load-file` and `load-file-once` are no longer part of
+`core`; they moved to the `system` library. This makes `core` a pure
+base with **no ambient filesystem access** — it keeps `eval`,
+`read-program` and `read-string` (evaluate code you already hold as
+data) but can no longer read a file to run it. File access is now an
+explicit capability:
+
+- **`+system`** (`nssystem.Load`) — raw host I/O: `slurp`/`spit`,
+  `load-file`/`load-file-once`, plus `chdir`/`cwd`/`mkdtemp`/`remove-all`
+  and the env-var builtins.
+- **`+require`** — structured module loading; `require` reads modules
+  itself (in Go), so it works without `system`.
+
+**Not user-facing:** the `lisp` binary loads `system` by default, so
+scripts using `slurp`/`spit`/`load-file` are unaffected, as is running a
+script (which the CLI does via `load-file`). **Embedders** who loaded
+only `core`/`nscore` and used those builtins must now also load
+`nssystem.Load` (after core and its input layer — `load-file` builds on
+`slurp-source` from system plus `read-program`/`eval` from core). The
+`core.VerifySource` integrity hook moved to `system.VerifySource`.
+
 ### ⚠️ Changed — one binary, `debugger` build tag (was `lispdebug`)
 
 The two-binary split (`lisp` + `lisp-debug`) is gone. There is one

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -288,18 +288,13 @@ Runtime variables: `*host-language*`
 
 ### core — input/output
 
-Reading and writing files and stdin.
+Reading a line or password from stdin, and process exit.
 
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
 | `exit` | `([] [status])` | Terminates the process with status (an integer, 0 when omitted). Does not return. |
-| `load-file` | `[file-path]` | Reads and evaluates the lisp file at file-path in the current environment; returns the value of its last form. |
-| `load-file-once` | `[file-path]` | Like load-file, but never loads the same path twice. |
 | `read-password` | `[prompt]` | Prints prompt (to stderr) and reads a line with terminal echo disabled; falls back to a plain read when input is not a terminal. Returns nil on end of input. |
 | `readline` | `[prompt]` | Prints prompt and reads a line from input. |
-| `slurp` | `[filename]` | Reads a file and returns its contents as a string. |
-| `slurp-source` | `[filename]` | Reads a source file like slurp and, under --integrity, verifies it against the pinned commit; load-file builds on it. |
-| `spit` | `[filename s & opts]` | Writes string s to a file, creating or truncating it; with :append true, appends instead. |
 
 ### core — runtime variables
 
@@ -372,16 +367,21 @@ Higher-order helpers written in lisp (the prelude): reduce, map, partial, protoc
 
 ### system
 
-Host OS: environment variables, working directory, temp directories, file removal.
+Host OS: environment variables, files (slurp/spit, load-file), working directory, temp directories, file removal.
 
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
 | `chdir` | `[path]` | Changes the process working directory to path. Process-global: affects the working directory of all subsequent operations, including the .state store and git repository detection. |
 | `cwd` | `[]` | Returns the process working directory as an absolute path string. |
 | `getenv` | `[name]` | Value of the environment variable name, or nil. |
+| `load-file` | `[file-path]` | Reads and evaluates the lisp file at file-path in the current environment; returns the value of its last form. |
+| `load-file-once` | `[file-path]` | Like load-file, but never loads the same path twice. |
 | `mkdtemp` | `[& prefix]` | Creates a new uniquely-named temporary directory (optionally name-prefixed) and returns its absolute path. |
 | `remove-all` | `[path]` | Recursively removes path and everything under it; does not error if path is absent. |
 | `setenv` | `[name value]` | Sets the environment variable name to value. |
+| `slurp` | `[filename]` | Reads a file and returns its contents as a string. |
+| `slurp-source` | `[filename]` | Reads a source file like slurp and, under --integrity, verifies it against the pinned commit; load-file builds on it. |
+| `spit` | `[filename s & opts]` | Writes string s to a file, creating or truncating it; with :append true, appends instead. |
 | `unsetenv` | `[name]` | Removes the environment variable name. |
 
 ### lazy

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jig/lisp/env"
 	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/system/nssystem"
 	"github.com/jig/lisp/types"
 )
 
@@ -41,6 +42,9 @@ func newTestEnv(t *testing.T) types.EnvType {
 	}
 	if err := nscore.LoadInput(ns); err != nil {
 		t.Fatalf("nscore.LoadInput: %v", err)
+	}
+	if err := nssystem.Load(ns); err != nil {
+		t.Fatalf("nssystem.Load: %v", err)
 	}
 	return ns
 }

--- a/command/debug_debug_test.go
+++ b/command/debug_debug_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/env"
 	"github.com/jig/lisp/lib/core"
+	"github.com/jig/lisp/lib/system"
 	"github.com/jig/lisp/runtime"
 )
 
@@ -24,7 +25,7 @@ func TestExecute_DebugFlagInstallsHook(t *testing.T) {
 	if _, err := lisp.REPL(ctx, ns, core.HeaderBasic(), nil); err != nil {
 		t.Fatalf("preamble failed: %v", err)
 	}
-	if _, err := lisp.REPL(ctx, ns, core.HeaderLoadFile(), nil); err != nil {
+	if _, err := lisp.REPL(ctx, ns, system.HeaderLoadFile(), nil); err != nil {
 		t.Fatalf("preamble failed: %v", err)
 	}
 

--- a/command/debug_release_test.go
+++ b/command/debug_release_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/env"
 	"github.com/jig/lisp/lib/core"
+	"github.com/jig/lisp/lib/system"
 )
 
 func TestExecute_DebugFlagRequiresDebugBuild(t *testing.T) {
@@ -20,7 +21,7 @@ func TestExecute_DebugFlagRequiresDebugBuild(t *testing.T) {
 	if _, err := lisp.REPL(ctx, ns, core.HeaderBasic(), nil); err != nil {
 		t.Fatalf("preamble failed: %v", err)
 	}
-	if _, err := lisp.REPL(ctx, ns, core.HeaderLoadFile(), nil); err != nil {
+	if _, err := lisp.REPL(ctx, ns, system.HeaderLoadFile(), nil); err != nil {
 		t.Fatalf("preamble failed: %v", err)
 	}
 

--- a/command/integrity.go
+++ b/command/integrity.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/jig/lisp/lib/core"
 	libgit "github.com/jig/lisp/lib/git"
 	"github.com/jig/lisp/lib/integrity"
 	"github.com/jig/lisp/lib/require"
+	"github.com/jig/lisp/lib/system"
 	libterm "github.com/jig/lisp/lib/term"
 )
 
@@ -50,7 +50,7 @@ func setupIntegrity(a args) error {
 		return reportIntegrity(false, "", "", "", err)
 	}
 	require.VerifyModule = integrity.VerifyFile
-	core.VerifySource = integrity.VerifyFile
+	system.VerifySource = integrity.VerifyFile
 
 	// With --integrity-keys, git commits/tags and state-save made during
 	// the run are SSH-signed with the ssh-agent key that is listed in the

--- a/command/integrity_test.go
+++ b/command/integrity_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 
 	"github.com/jig/lisp/env"
-	"github.com/jig/lisp/lib/core"
 	"github.com/jig/lisp/lib/core/nscore"
 	"github.com/jig/lisp/lib/coreextended/nscoreextended"
 	"github.com/jig/lisp/lib/integrity"
 	"github.com/jig/lisp/lib/integrity/nsintegrity"
 	"github.com/jig/lisp/lib/require"
 	"github.com/jig/lisp/lib/require/nsrequire"
+	"github.com/jig/lisp/lib/system"
+	"github.com/jig/lisp/lib/system/nssystem"
 	"github.com/jig/lisp/types"
 )
 
@@ -25,7 +26,7 @@ func newIntegrityEnv(t *testing.T) types.EnvType {
 	t.Helper()
 	ns := env.NewEnv()
 	for _, load := range []func(types.EnvType) error{
-		nscore.Load, nscore.LoadInput, nscoreextended.Load,
+		nscore.Load, nscore.LoadInput, nssystem.Load, nscoreextended.Load,
 		nsrequire.Load("lisp"), nsintegrity.Load,
 	} {
 		if err := load(ns); err != nil {
@@ -85,7 +86,7 @@ func gitRepoWithScript(t *testing.T) (dir, hash string) {
 	t.Cleanup(func() {
 		integrity.Disable()
 		require.VerifyModule = nil
-		core.VerifySource = nil
+		system.VerifySource = nil
 	})
 	return dir, hash
 }

--- a/command/integrity_toctou_test.go
+++ b/command/integrity_toctou_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jig/lisp/lib/core"
 	"github.com/jig/lisp/lib/integrity"
 	"github.com/jig/lisp/lib/require"
+	"github.com/jig/lisp/lib/system"
 	"github.com/jig/lisp/types"
 )
 
@@ -41,7 +41,7 @@ func TestRunScriptPreambleTOCTOU(t *testing.T) {
 	t.Cleanup(func() {
 		integrity.Disable()
 		require.VerifyModule = nil
-		core.VerifySource = nil
+		system.VerifySource = nil
 	})
 
 	// Enable verifies the committed script; wire the hooks exactly as
@@ -50,7 +50,7 @@ func TestRunScriptPreambleTOCTOU(t *testing.T) {
 		t.Fatalf("Enable: %v", err)
 	}
 	require.VerifyModule = integrity.VerifyFile
-	core.VerifySource = integrity.VerifyFile
+	system.VerifySource = integrity.VerifyFile
 
 	// The attacker swaps the file after verification, before evaluation.
 	if err := os.WriteFile(scriptPath, []byte(payload), 0o644); err != nil {

--- a/command/preamble_test.go
+++ b/command/preamble_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jig/lisp/env"
 	"github.com/jig/lisp/lib/concurrent"
 	"github.com/jig/lisp/lib/core"
+	"github.com/jig/lisp/lib/system"
 	"github.com/jig/lisp/types"
 )
 
@@ -19,11 +20,12 @@ func preambleTestEnv(t *testing.T) types.EnvType {
 	core.Load(ns)
 	core.LoadInput(ns)
 	concurrent.Load(ns)
+	system.Load(ns)
 	ns.Set(types.Symbol{Val: "eval"}, types.Func{Fn: func(ctx context.Context, a []types.MalType) (types.MalType, error) {
 		return lisp.EVAL(ctx, a[0], ns)
 	}})
 	ctx := context.Background()
-	for _, header := range []string{core.HeaderBasic(), core.HeaderLoadFile(), concurrent.HeaderConcurrent()} {
+	for _, header := range []string{core.HeaderBasic(), system.HeaderLoadFile(), concurrent.HeaderConcurrent()} {
 		if _, err := lisp.REPL(ctx, ns, header, types.NewCursorFile("preamble")); err != nil {
 			t.Fatalf("header: %v", err)
 		}

--- a/debugadapter/step_test.go
+++ b/debugadapter/step_test.go
@@ -29,6 +29,7 @@ func fullEnv(t *testing.T) types.EnvType {
 	ns := env.NewEnv()
 	core.Load(ns)
 	core.LoadInput(ns)
+	system.Load(ns) // slurp/slurp-source/spit — load-file (below) builds on them
 	concurrent.Load(ns)
 	ns.Set(types.Symbol{Val: "eval"}, types.Func{Fn: func(ctx context.Context, a []types.MalType) (types.MalType, error) {
 		return lisp.EVAL(ctx, a[0], ns)

--- a/debugadapter/step_test.go
+++ b/debugadapter/step_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jig/lisp/lib/core"
 	"github.com/jig/lisp/lib/coreextended"
 	"github.com/jig/lisp/lib/coreextended/nscoreextended"
+	"github.com/jig/lisp/lib/system"
 	"github.com/jig/lisp/runtime"
 	"github.com/jig/lisp/types"
 )
@@ -37,7 +38,7 @@ func fullEnv(t *testing.T) types.EnvType {
 	if _, err := lisp.REPL(ctx, ns, core.HeaderBasic(), types.NewCursorFile("preamble")); err != nil {
 		t.Fatalf("HeaderBasic: %v", err)
 	}
-	if _, err := lisp.REPL(ctx, ns, core.HeaderLoadFile(), types.NewCursorFile("preamble")); err != nil {
+	if _, err := lisp.REPL(ctx, ns, system.HeaderLoadFile(), types.NewCursorFile("preamble")); err != nil {
 		t.Fatalf("HeaderLoadFile: %v", err)
 	}
 	if _, err := lisp.REPL(ctx, ns, concurrent.HeaderConcurrent(), types.NewCursorFile("preamble")); err != nil {

--- a/deftests_test.go
+++ b/deftests_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jig/lisp/lib/core/nscore"
 	"github.com/jig/lisp/lib/coreextended/nscoreextended"
 	"github.com/jig/lisp/lib/system"
+	"github.com/jig/lisp/lib/system/nssystem"
 	"github.com/jig/lisp/lib/test"
 	"github.com/jig/lisp/lib/test/nstest"
 	"github.com/jig/lisp/types"
@@ -30,6 +31,7 @@ func TestDeftests(t *testing.T) {
 	for _, load := range []func(types.EnvType) error{
 		nscore.Load,
 		nscore.LoadInput,
+		nssystem.Load,
 		nscore.LoadNullArgs,
 		nsconcurrent.Load,
 		nscoreextended.Load,

--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -47,12 +47,12 @@ const (
 // entry here falls back to its raw name and no description.
 var sectionBlurb = map[string]struct{ title, desc string }{
 	"core mal":            {"core", "Arithmetic, collections, predicates, strings, JSON, errors — always loaded."},
-	"core mal with input": {"core — input/output", "Reading and writing files and stdin."},
+	"core mal with input": {"core — input/output", "Reading a line or password from stdin, and process exit."},
 	"command line args":   {"core — runtime variables", "Values the runtime binds for a running script."},
 	"concurrent":          {"concurrent", "Atoms and futures for shared, thread-safe state."},
 	"core mal extended":   {"coreextended", "Higher-order helpers written in lisp (the prelude): reduce, map, partial, protocols…"},
 	"assert":              {"assert", "Minimal test library (run with `lisp --test DIR`)."},
-	"system":              {"system", "Host OS: environment variables, working directory, temp directories, file removal."},
+	"system":              {"system", "Host OS: environment variables, files (slurp/spit, load-file), working directory, temp directories, file removal."},
 	"lazy":                {"lazy", "Lazy sequences."},
 	"require":             {"require", "Module loading by name through a search path."},
 	"sql":                 {"sql", "SQL database access."},

--- a/docmeta/docmeta_test.go
+++ b/docmeta/docmeta_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jig/lisp/lib/concurrent"
 	"github.com/jig/lisp/lib/core"
 	"github.com/jig/lisp/lib/coreextended"
+	"github.com/jig/lisp/lib/system"
 	"github.com/jig/lisp/types"
 )
 
@@ -23,7 +24,7 @@ func fullEnv(t *testing.T) types.EnvType {
 		return lisp.EVAL(ctx, a[0], ns)
 	}})
 	ctx := context.Background()
-	for _, h := range []string{core.HeaderBasic(), core.HeaderLoadFile(), concurrent.HeaderConcurrent(), coreextended.HeaderCoreExtended()} {
+	for _, h := range []string{core.HeaderBasic(), system.HeaderLoadFile(), concurrent.HeaderConcurrent(), coreextended.HeaderCoreExtended()} {
 		if _, err := lisp.REPL(ctx, ns, h, types.NewCursorFile("preamble")); err != nil {
 			t.Fatalf("header: %v", err)
 		}

--- a/docstring_test.go
+++ b/docstring_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jig/lisp/lib/concurrent"
 	"github.com/jig/lisp/lib/core"
 	"github.com/jig/lisp/lib/coreextended"
+	"github.com/jig/lisp/lib/system"
 	"github.com/jig/lisp/types"
 )
 
@@ -24,7 +25,7 @@ func docEnv(t *testing.T) types.EnvType {
 		return lisp.EVAL(ctx, a[0], ns)
 	}})
 	ctx := context.Background()
-	for _, h := range []string{core.HeaderBasic(), core.HeaderLoadFile(), concurrent.HeaderConcurrent(), coreextended.HeaderCoreExtended()} {
+	for _, h := range []string{core.HeaderBasic(), system.HeaderLoadFile(), concurrent.HeaderConcurrent(), coreextended.HeaderCoreExtended()} {
 		if _, err := lisp.REPL(ctx, ns, h, types.NewCursorFile("preamble")); err != nil {
 			t.Fatalf("header: %v", err)
 		}

--- a/err_test.go
+++ b/err_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jig/lisp/env"
 	"github.com/jig/lisp/lib/core"
+	"github.com/jig/lisp/lib/system"
 	"github.com/jig/lisp/types"
 )
 
@@ -333,6 +334,7 @@ func TestLoadFileErrorStackTrace(t *testing.T) {
 	ns := env.NewEnv()
 	core.Load(ns)
 	core.LoadInput(ns) // Needed for slurp function
+	system.Load(ns)    // slurp-source + spit; load-file's deps
 
 	// Manually load eval and load-file since we can't use nscore (import cycle)
 	ns.Set(types.Symbol{Val: "eval"}, types.Func{Fn: func(ctx context.Context, a []types.MalType) (types.MalType, error) {
@@ -344,7 +346,7 @@ func TestLoadFileErrorStackTrace(t *testing.T) {
 		t.Fatalf("Failed to load basic headers: %v", err)
 	}
 
-	_, err = REPL(context.Background(), ns, core.HeaderLoadFile(), types.NewCursorFile(t.Name()))
+	_, err = REPL(context.Background(), ns, system.HeaderLoadFile(), types.NewCursorFile(t.Name()))
 	if err != nil {
 		t.Fatalf("Failed to load load-file: %v", err)
 	}

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path/filepath"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -33,7 +32,6 @@ import (
 	"github.com/jig/lisp/marshaler"
 	"github.com/jig/lisp/printer"
 	"github.com/jig/lisp/reader"
-	lispruntime "github.com/jig/lisp/runtime"
 
 	. "github.com/jig/lisp/types"
 )
@@ -41,11 +39,7 @@ import (
 //go:embed header-basic.lisp
 var headerBasic string
 
-//go:embed header-load-file.lisp
-var headerLoadFile string
-
-func HeaderBasic() string    { return headerBasic }
-func HeaderLoadFile() string { return headerLoadFile }
+func HeaderBasic() string { return headerBasic }
 
 func Load(env EnvType) {
 	call.Call(env, assoc_in)
@@ -298,9 +292,6 @@ func drop_last(n int, arg MalType) (MalType, error) {
 }
 
 func LoadInput(env EnvType) {
-	call.Call(env, slurp)
-	call.Call(env, slurp_source)
-	call.Call(env, spit, 2, 4)
 	call.Call(env, readLine)
 	call.CallOverrideFN(env, "read-password", readPassword)
 	call.Call(env, exit, 0, 1)
@@ -495,89 +486,6 @@ func println(a ...MalType) (MalType, error) {
 func printNoNewline(a ...MalType) (MalType, error) {
 	fmt.Print(printer.Pr_list(a, false, "", "", " "))
 	return nil, nil
-}
-
-// VerifySource is an optional hook that vets a source file before
-// load-file (via slurp-source) evaluates it; a non-nil error aborts the
-// load. The command package installs it when running under --integrity,
-// so code loaded at runtime is verified like the script and its
-// requires. slurp itself is never hooked: it reads data, not code.
-var VerifySource func(absPath string, content []byte) error
-
-// slurp_source is slurp for files that will be evaluated as code:
-// identical, except that under --integrity the content is verified
-// against the pinned commit. load-file builds on it.
-func slurp_source(fileName string) (MalType, error) {
-	v, err := slurp(fileName)
-	if err != nil {
-		return nil, err
-	}
-	if VerifySource != nil {
-		abs, err := filepath.Abs(fileName)
-		if err != nil {
-			return nil, err
-		}
-		if err := VerifySource(abs, []byte(v.(string))); err != nil {
-			return nil, err
-		}
-	}
-	return v, nil
-}
-
-func slurp(fileName string) (MalType, error) {
-	b, e := os.ReadFile(fileName)
-	if e != nil {
-		return nil, e
-	}
-	// Register the module so the debugger can map cursors from files
-	// loaded at runtime back to their on-disk source (load-file injects
-	// a `;; $MODULE <fileName>` prefix naming the module after this same
-	// path); without the mapping, stepping would skip those files as
-	// library code. Dead code in release builds.
-	if lispruntime.Enabled {
-		if abs, err := filepath.Abs(fileName); err == nil {
-			lispruntime.Modules.Register(fileName, abs)
-		}
-	}
-	return string(b), nil
-}
-
-// spit is the write counterpart of slurp, following Clojure's:
-// (spit filename s) creates or truncates the file, and
-// (spit filename s :append true) appends instead.
-func spit(fileName, contents string, opts ...MalType) error {
-	if len(opts)%2 != 0 {
-		return fmt.Errorf("spit: options must be keyword value pairs")
-	}
-	appendMode := false
-	for i := 0; i < len(opts); i += 2 {
-		switch opts[i] {
-		case NewKeyword("append"):
-			b, ok := opts[i+1].(bool)
-			if !ok {
-				return fmt.Errorf("spit: :append expects a boolean (it was %T)", opts[i+1])
-			}
-			appendMode = b
-		default:
-			return fmt.Errorf("spit: unknown option %s", printer.Pr_str(opts[i], true))
-		}
-	}
-	flags := os.O_WRONLY | os.O_CREATE
-	if appendMode {
-		flags |= os.O_APPEND
-	} else {
-		flags |= os.O_TRUNC
-	}
-	f, err := os.OpenFile(fileName, flags, 0o644)
-	if err != nil {
-		return err
-	}
-	_, werr := f.WriteString(contents)
-	cerr := f.Close()
-	if werr != nil {
-		return werr
-	}
-	return cerr
 }
 
 // osExit is the process-exit hook, indirected so tests can observe the

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -27,9 +27,6 @@ func loadInputDocs(env EnvType) {
 }
 
 var inputDocs = []struct{ name, arglist, doc string }{
-	{"slurp", "[filename]", "Reads a file and returns its contents as a string."},
-	{"slurp-source", "[filename]", "Reads a source file like slurp and, under --integrity, verifies it against the pinned commit; load-file builds on it."},
-	{"spit", "[filename s & opts]", "Writes string s to a file, creating or truncating it; with :append true, appends instead."},
 	{"readline", "[prompt]", "Prints prompt and reads a line from input."},
 	{"read-password", "[prompt]", "Prints prompt (to stderr) and reads a line with terminal echo disabled; falls back to a plain read when input is not a terminal. Returns nil on end of input."},
 	{"exit", "([] [status])", "Terminates the process with status (an integer, 0 when omitted). Does not return."},

--- a/lib/core/nscore/nscore.go
+++ b/lib/core/nscore/nscore.go
@@ -2,10 +2,8 @@ package nscore
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"strings"
-	"sync"
 
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/lib/call"
@@ -40,41 +38,17 @@ func Load(env EnvType) error {
 	return nil
 }
 
+// LoadInput registers the stdin builtins and the eval helper. File I/O
+// (slurp/spit) and load-file/load-file-once moved to the system library
+// (nssystem.Load), so core has no ambient filesystem access — reading a
+// file to evaluate it is a system capability, or a require (which reads
+// modules itself).
 func LoadInput(env EnvType) error {
 	core.LoadInput(env)
 	env.Set(Symbol{Val: "eval"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
 		return lisp.EVAL(ctx, a[0], env)
 	}})
 	docEval(env)
-
-	if _, err := lisp.REPL(context.Background(), env, core.HeaderLoadFile(), NewCursorFile(_package_)); err != nil {
-		return err
-	}
-
-	// load-file-once needs mutable state for its seen-set; a Go closure
-	// keeps it available with only core loaded (atoms belong to the
-	// concurrent library).
-	var mu sync.Mutex
-	seen := map[string]bool{}
-	env.Set(Symbol{Val: "load-file-once"}, Func{Fn: func(ctx context.Context, a []MalType) (MalType, error) {
-		if len(a) != 1 {
-			return nil, fmt.Errorf("load-file-once: wrong number of arguments (%d instead of 1)", len(a))
-		}
-		path, ok := a[0].(string)
-		if !ok {
-			return nil, fmt.Errorf("load-file-once: file-path must be a string (was of type %T)", a[0])
-		}
-		mu.Lock()
-		already := seen[path]
-		seen[path] = true
-		mu.Unlock()
-		if already {
-			return nil, nil
-		}
-		return lisp.EVAL(ctx, NewList(nil, Symbol{Val: "load-file"}, path), env)
-	}})
-	call.Doc(env, "load-file-once", "[file-path]", "Like load-file, but never loads the same path twice.")
-
 	return nil
 }
 

--- a/lib/core/spit_test.go
+++ b/lib/core/spit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jig/lisp"
 	"github.com/jig/lisp/env"
 	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/system/nssystem"
 	"github.com/jig/lisp/types"
 )
 
@@ -21,6 +22,9 @@ func newEnv(t *testing.T) types.EnvType {
 	}
 	if err := nscore.LoadInput(ns); err != nil {
 		t.Fatalf("load core input: %v", err)
+	}
+	if err := nssystem.Load(ns); err != nil {
+		t.Fatalf("load system: %v", err)
 	}
 	return ns
 }

--- a/lib/require/require_test.go
+++ b/lib/require/require_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jig/lisp/lib/concurrent"
 	"github.com/jig/lisp/lib/core"
 	"github.com/jig/lisp/lib/coreextended"
+	"github.com/jig/lisp/lib/system"
 	"github.com/jig/lisp/types"
 )
 
@@ -24,6 +25,7 @@ func testEnv(t *testing.T, includeDirs ...string) types.EnvType {
 	core.Load(ns)
 	core.LoadInput(ns)
 	concurrent.Load(ns)
+	system.Load(ns)
 	ns.Set(types.Symbol{Val: "eval"}, types.Func{Fn: func(ctx context.Context, a []types.MalType) (types.MalType, error) {
 		return lisp.EVAL(ctx, a[0], ns)
 	}})
@@ -33,7 +35,7 @@ func testEnv(t *testing.T, includeDirs ...string) types.EnvType {
 		src  string
 	}{
 		{"basic", core.HeaderBasic()},
-		{"load-file", core.HeaderLoadFile()},
+		{"load-file", system.HeaderLoadFile()},
 		{"concurrent", concurrent.HeaderConcurrent()},
 		{"coreextended", coreextended.HeaderCoreExtended()},
 	} {

--- a/lib/system/header-load-file.lisp
+++ b/lib/system/header-load-file.lisp
@@ -5,6 +5,6 @@
     [file-path]
     (eval (read-program (slurp-source file-path) file-path)))
 
-;; load-file-once is registered in Go by nscore.LoadInput: its seen-set
+;; load-file-once is registered in Go by nssystem.Load: its seen-set
 ;; needs mutable state, and atoms live in the concurrent library, which
 ;; is not available at core-load time.

--- a/lib/system/nssystem/nssystem.go
+++ b/lib/system/nssystem/nssystem.go
@@ -1,11 +1,49 @@
 package nssystem
 
 import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/lib/call"
 	"github.com/jig/lisp/lib/system"
 	"github.com/jig/lisp/types"
 )
 
+// Load registers the system builtins (slurp/spit, chdir/cwd/mkdtemp/…),
+// then defines load-file and load-file-once, which read and evaluate a
+// file. load-file uses slurp-source (system) plus read-program and eval
+// (core), so core and its input layer must already be loaded.
 func Load(env types.EnvType) error {
 	system.Load(env)
+
+	if _, err := lisp.REPL(context.Background(), env, system.HeaderLoadFile(), types.NewCursorFile("$nssystem")); err != nil {
+		return err
+	}
+
+	// load-file-once needs mutable state for its seen-set; a Go closure
+	// keeps it available without the concurrent library (atoms).
+	var mu sync.Mutex
+	seen := map[string]bool{}
+	env.Set(types.Symbol{Val: "load-file-once"}, types.Func{Fn: func(ctx context.Context, a []types.MalType) (types.MalType, error) {
+		if len(a) != 1 {
+			return nil, fmt.Errorf("load-file-once: wrong number of arguments (%d instead of 1)", len(a))
+		}
+		path, ok := a[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("load-file-once: file-path must be a string (was of type %T)", a[0])
+		}
+		mu.Lock()
+		already := seen[path]
+		seen[path] = true
+		mu.Unlock()
+		if already {
+			return nil, nil
+		}
+		return lisp.EVAL(ctx, types.NewList(nil, types.Symbol{Val: "load-file"}, path), env)
+	}})
+	call.Doc(env, "load-file-once", "[file-path]", "Like load-file, but never loads the same path twice.")
+
 	return nil
 }

--- a/lib/system/system.go
+++ b/lib/system/system.go
@@ -5,10 +5,20 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/jig/lisp/lib/call"
+	"github.com/jig/lisp/printer"
+	lispruntime "github.com/jig/lisp/runtime"
 	. "github.com/jig/lisp/types"
 )
+
+//go:embed header-load-file.lisp
+var headerLoadFile string
+
+// HeaderLoadFile returns the lisp source defining load-file; nssystem
+// evaluates it after the system builtins (slurp-source) are registered.
+func HeaderLoadFile() string { return headerLoadFile }
 
 func Load(env EnvType) {
 	call.Call(env, getenv)
@@ -18,10 +28,16 @@ func Load(env EnvType) {
 	call.Call(env, cwd)
 	call.Call(env, mkdtemp, 0, 1)
 	call.Call(env, remove_all)
+	call.Call(env, slurp)
+	call.Call(env, slurp_source)
+	call.Call(env, spit, 2, 4)
 
 	call.Doc(env, "getenv", "[name]", "Value of the environment variable name, or nil.")
 	call.Doc(env, "setenv", "[name value]", "Sets the environment variable name to value.")
 	call.Doc(env, "unsetenv", "[name]", "Removes the environment variable name.")
+	call.Doc(env, "slurp", "[filename]", "Reads a file and returns its contents as a string.")
+	call.Doc(env, "slurp-source", "[filename]", "Reads a source file like slurp and, under --integrity, verifies it against the pinned commit; load-file builds on it.")
+	call.Doc(env, "spit", "[filename s & opts]", "Writes string s to a file, creating or truncating it; with :append true, appends instead.")
 	call.Doc(env, "chdir", "[path]",
 		"Changes the process working directory to path. Process-global: affects the working directory of all subsequent operations, including the .state store and git repository detection.")
 	call.Doc(env, "cwd", "[]",
@@ -76,4 +92,87 @@ func mkdtemp(prefix ...MalType) (MalType, error) {
 // remove_all recursively removes path (lisp name: remove-all).
 func remove_all(path string) (MalType, error) {
 	return nil, os.RemoveAll(path)
+}
+
+// VerifySource is an optional hook that vets a source file before
+// load-file (via slurp-source) evaluates it; a non-nil error aborts the
+// load. The command package installs it when running under --integrity,
+// so code loaded at runtime is verified like the script and its
+// requires. slurp itself is never hooked: it reads data, not code.
+var VerifySource func(absPath string, content []byte) error
+
+// slurp_source is slurp for files that will be evaluated as code:
+// identical, except that under --integrity the content is verified
+// against the pinned commit. load-file builds on it.
+func slurp_source(fileName string) (MalType, error) {
+	v, err := slurp(fileName)
+	if err != nil {
+		return nil, err
+	}
+	if VerifySource != nil {
+		abs, err := filepath.Abs(fileName)
+		if err != nil {
+			return nil, err
+		}
+		if err := VerifySource(abs, []byte(v.(string))); err != nil {
+			return nil, err
+		}
+	}
+	return v, nil
+}
+
+func slurp(fileName string) (MalType, error) {
+	b, e := os.ReadFile(fileName)
+	if e != nil {
+		return nil, e
+	}
+	// Register the module so the debugger can map cursors from files
+	// loaded at runtime back to their on-disk source (load-file injects
+	// a `;; $MODULE <fileName>` prefix naming the module after this same
+	// path); without the mapping, stepping would skip those files as
+	// library code. Dead code in release builds.
+	if lispruntime.Enabled {
+		if abs, err := filepath.Abs(fileName); err == nil {
+			lispruntime.Modules.Register(fileName, abs)
+		}
+	}
+	return string(b), nil
+}
+
+// spit is the write counterpart of slurp, following Clojure's:
+// (spit filename s) creates or truncates the file, and
+// (spit filename s :append true) appends instead.
+func spit(fileName, contents string, opts ...MalType) error {
+	if len(opts)%2 != 0 {
+		return fmt.Errorf("spit: options must be keyword value pairs")
+	}
+	appendMode := false
+	for i := 0; i < len(opts); i += 2 {
+		switch opts[i] {
+		case NewKeyword("append"):
+			b, ok := opts[i+1].(bool)
+			if !ok {
+				return fmt.Errorf("spit: :append expects a boolean (it was %T)", opts[i+1])
+			}
+			appendMode = b
+		default:
+			return fmt.Errorf("spit: unknown option %s", printer.Pr_str(opts[i], true))
+		}
+	}
+	flags := os.O_WRONLY | os.O_CREATE
+	if appendMode {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+	}
+	f, err := os.OpenFile(fileName, flags, 0o644)
+	if err != nil {
+		return err
+	}
+	_, werr := f.WriteString(contents)
+	cerr := f.Close()
+	if werr != nil {
+		return werr
+	}
+	return cerr
 }

--- a/macro_test.go
+++ b/macro_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jig/lisp/lib/concurrent"
 	"github.com/jig/lisp/lib/core"
 	"github.com/jig/lisp/lib/coreextended"
+	"github.com/jig/lisp/lib/system"
 	"github.com/jig/lisp/types"
 )
 
@@ -544,7 +545,7 @@ func TestMacro(t *testing.T) {
 	if _, err := REPL(ctx, repl_env, core.HeaderBasic(), types.NewCursorFile(reflect.TypeOf(_here_{}).PkgPath())); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := REPL(ctx, repl_env, core.HeaderLoadFile(), types.NewCursorFile(reflect.TypeOf(_here_{}).PkgPath())); err != nil {
+	if _, err := REPL(ctx, repl_env, system.HeaderLoadFile(), types.NewCursorFile(reflect.TypeOf(_here_{}).PkgPath())); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := REPL(ctx, repl_env, coreextended.HeaderCoreExtended(), types.NewCursorFile(reflect.TypeOf(_here_{}).PkgPath())); err != nil {

--- a/mal_test.go
+++ b/mal_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jig/lisp/lib/concurrent"
 	"github.com/jig/lisp/lib/core"
 	"github.com/jig/lisp/lib/coreextended"
+	"github.com/jig/lisp/lib/system"
 	. "github.com/jig/lisp/types"
 )
 
@@ -33,7 +34,7 @@ func BenchmarkMAL1(b *testing.B) {
 		if _, err := REPL(ctx, repl_env, core.HeaderBasic(), NewCursorFile(b.Name())); err != nil {
 			b.Fatal(err)
 		}
-		if _, err := REPL(ctx, repl_env, core.HeaderLoadFile(), NewCursorFile(b.Name())); err != nil {
+		if _, err := REPL(ctx, repl_env, system.HeaderLoadFile(), NewCursorFile(b.Name())); err != nil {
 			b.Fatal(err)
 		}
 		if _, err := REPL(ctx, repl_env, coreextended.HeaderCoreExtended(), NewCursorFile(b.Name())); err != nil {
@@ -164,7 +165,7 @@ func TestAtomParallel(t *testing.T) {
 	if _, err := REPL(ctx, repl_env, core.HeaderBasic(), NewCursorFile(t.Name())); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := REPL(ctx, repl_env, core.HeaderLoadFile(), NewCursorFile(t.Name())); err != nil {
+	if _, err := REPL(ctx, repl_env, system.HeaderLoadFile(), NewCursorFile(t.Name())); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := REPL(ctx, repl_env, coreextended.HeaderCoreExtended(), NewCursorFile(t.Name())); err != nil {
@@ -213,7 +214,7 @@ func BenchmarkAtomParallel(b *testing.B) {
 	if _, err := REPL(ctx, repl_env, core.HeaderBasic(), NewCursorFile(b.Name())); err != nil {
 		b.Fatal(err)
 	}
-	if _, err := REPL(ctx, repl_env, core.HeaderLoadFile(), NewCursorFile(b.Name())); err != nil {
+	if _, err := REPL(ctx, repl_env, system.HeaderLoadFile(), NewCursorFile(b.Name())); err != nil {
 		b.Fatal(err)
 	}
 	if _, err := REPL(ctx, repl_env, coreextended.HeaderCoreExtended(), NewCursorFile(b.Name())); err != nil {

--- a/runtest_test.go
+++ b/runtest_test.go
@@ -125,7 +125,7 @@ func newEnv(fileName string) types.EnvType {
 	if _, err := REPL(ctx, newenv, core.HeaderBasic(), types.NewCursorFile(fileName)); err != nil {
 		return nil
 	}
-	if _, err := REPL(ctx, newenv, core.HeaderLoadFile(), types.NewCursorFile(fileName)); err != nil {
+	if _, err := REPL(ctx, newenv, system.HeaderLoadFile(), types.NewCursorFile(fileName)); err != nil {
 		return nil
 	}
 	if _, err := REPL(ctx, newenv, coreextended.HeaderCoreExtended(), types.NewCursorFile(fileName)); err != nil {


### PR DESCRIPTION
## Summary

Moves `slurp`, `spit`, `load-file` and `load-file-once` from **`core`** to the **`system`** library, making `core` a pure base with **no ambient filesystem access**. `core` keeps `eval`/`read-program`/`read-string` — it can evaluate code you hold as data — but can no longer read a file to run it. File access becomes an explicit capability:

- **`+system`** (`nssystem.Load`) — raw host I/O: `slurp`/`spit`, `load-file`/`load-file-once`, plus `chdir`/`cwd`/`mkdtemp`/`remove-all` and the env-var builtins.
- **`+require`** — structured module loading; `require` reads modules itself (in Go), so it works **without** `system` or `slurp`.

A coherent three-tier capability model, aligned with the integrity work.

## What moved

- `slurp`/`slurp_source`/`spit` + the `VerifySource` integrity hook: `lib/core` → `lib/system`.
- `load-file` header (`header-load-file.lisp`) + `load-file-once`: `nscore.LoadInput` → `nssystem.Load`.
- `read-program` and `eval` **stay** in core.
- `command`'s `setupIntegrity` now installs `system.VerifySource`.

## Compatibility

- **Not user-facing:** the `lisp` binary loads `system` by default, so scripts using `slurp`/`spit`/`load-file` are unaffected, as is running a script (the CLI does that via `load-file`).
- **Breaking for embedders** who loaded only `core`/`nscore` and used those builtins: they must now also `nssystem.Load` (after core and its input layer — `load-file` builds on `slurp-source` from system plus `read-program`/`eval` from core). Documented as a ⚠️ Changed entry in the CHANGELOG.

## Test plan

- Updated the ~15 test harnesses that build core-only envs and use `slurp`/`load-file` to also load `system`/`nssystem`.
- Full suite green with and without `-tags debugger` (the tag activates `slurp`'s `lispruntime` module-registration path).
- Binary e2e: running a script (`load-file` path) and `spit`+`slurp` round-trip both work. `core.LoadInput` now registers only stdin/exit; a core-only env has no `slurp`/`load-file` (capability model holds by construction).
- `docgen` blurbs + `LANGUAGE.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)