### PR TITLE
feat(regexp): re-seq, re-replace/-first, re-split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,7 +218,9 @@ Non-breaking, for context (see `git log v0.2.24..` for the full list):
   `re-pattern` compiles a reusable regex; `re-matches?` / `re-find?`
   return booleans (anchored / substring), `re-matches` / `re-find`
   return Clojure-style match data (`nil`, the match string, or a vector
-  of capture groups). `re-replace`/`re-split`/`re-seq` are planned. See
+  of capture groups). `re-seq` returns every match, `re-replace` /
+  `re-replace-first` rewrite matches (with `$1` / `${name}` group
+  references), and `re-split` breaks a string around matches. See
   `lib/regexp/README.md`
 - `system` library grows directory/process primitives: `(chdir path)`
   (changes the process-global working directory — affects the `.state`

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -466,7 +466,7 @@ Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integr
 
 ### regexp
 
-Regular expressions (Go RE2): re-pattern, re-matches / re-find and their ? predicates.
+Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-replace and re-split.
 
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
@@ -475,6 +475,10 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find and their ? predi
 | `re-matches` | `[re-or-pattern s]` | Anchored match of the whole string: nil, the match string when there are no groups, or a vector [whole g1 g2 …] (nil for an unmatched group). |
 | `re-matches?` | `[re-or-pattern s]` | Reports whether the whole string s matches (anchored). Accepts a compiled regex or a raw pattern string. |
 | `re-pattern` | `[pattern]` | Compiles a raw pattern string (Go RE2 syntax; write it as ¬…¬) into a reusable regex value. |
+| `re-replace` | `[re-or-pattern s replacement]` | Replaces every match in s with replacement, where $1 or ${name} expand captured groups (use ${1} to delimit a number, $$ for a literal $). Returns the new string. |
+| `re-replace-first` | `[re-or-pattern s replacement]` | Like re-replace but only replaces the first match; the string is returned unchanged when there is no match. |
+| `re-seq` | `[re-or-pattern s]` | Vector of every successive match in s (left to right, non-overlapping); each element is the match string when there are no groups, or a vector [whole g1 g2 …]. Empty vector when there is no match. |
+| `re-split` | `[re-or-pattern s & limit]` | Splits s around matches of the pattern, returning a vector of the pieces. An optional integer limit caps the number of pieces (the last one keeps the remainder); a negative or absent limit returns them all, including trailing empty strings. |
 
 ### web
 

--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -58,7 +58,7 @@ var sectionBlurb = map[string]struct{ title, desc string }{
 	"sql":                 {"sql", "SQL database access."},
 	"cli":                 {"cli", "Command-line option parsing (clojure/tools.cli style)."},
 	"integrity":           {"integrity", "Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integrity mode)."},
-	"regexp":              {"regexp", "Regular expressions (Go RE2): re-pattern, re-matches / re-find and their ? predicates."},
+	"regexp":              {"regexp", "Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-replace and re-split."},
 }
 
 // entry is one documented symbol.

--- a/lib/regexp/README.md
+++ b/lib/regexp/README.md
@@ -27,14 +27,35 @@ catastrophic backtracking). Most everyday patterns are identical.
 | `(re-find? re-or-pattern s)` | `true`/`false` — matches anywhere (substring) |
 | `(re-matches re-or-pattern s)` | `nil`, the match string, or `[whole g1 g2 …]` (anchored) |
 | `(re-find re-or-pattern s)` | `nil`, the match string, or `[whole g1 g2 …]` (unanchored) |
+| `(re-seq re-or-pattern s)` | vector of every match, each shaped like `re-find`'s result (`[]` if none) |
+| `(re-replace re-or-pattern s replacement)` | `s` with every match replaced |
+| `(re-replace-first re-or-pattern s replacement)` | `s` with only the first match replaced |
+| `(re-split re-or-pattern s & limit)` | vector of the pieces `s` splits into around matches |
 
 Every function accepts **either a compiled regex** (from `re-pattern`)
 **or a raw pattern string** (compiled on use), so `re-pattern` is only
 needed to reuse a pattern.
 
-`re-matches`/`re-find` mirror Clojure: `nil` when there is no match, the
-whole match string when the pattern has no capture groups, otherwise a
-vector `[whole g1 g2 …]` — with an unmatched optional group as `nil`.
+`re-matches`/`re-find`/`re-seq` mirror Clojure: `nil` when there is no
+match, the whole match string when the pattern has no capture groups,
+otherwise a vector `[whole g1 g2 …]` — with an unmatched optional group
+as `nil`. `re-seq` collects every non-overlapping match left to right
+into a vector (jig/lisp is eager, so it is a vector, not a lazy seq).
+
+### Replacement strings
+
+In `re-replace` / `re-replace-first` the replacement is a template:
+`$1` (or `${1}`) inserts a captured group, `${name}` a named group, and
+`$$` a literal `$`. Use the braced form `${1}` when a digit is followed
+by more word characters, so `${1}0` is "group 1 then a zero" rather than
+the group named `10`. (Function replacements are not supported.)
+
+### Splitting
+
+`re-split` follows Go's `Split`: trailing empty pieces are **kept**
+(`(re-split ¬,¬ "a,b,,")` → `["a" "b" "" ""]`). An optional integer
+limit caps the number of pieces, the last one holding the remainder;
+a negative or absent limit returns them all.
 
 ## Examples
 
@@ -50,6 +71,16 @@ vector `[whole g1 g2 …]` — with an unmatched optional group as `nil`.
 
 (def word (re-pattern ¬[a-z]+¬))          ; reuse a compiled pattern
 (re-find? word "HELLO world")             ; => true
+
+(re-seq ¬\d+¬ "a1 bb 22 c333")            ; => ["1" "22" "333"]
+(re-seq ¬(\d)(\w)¬ "1a 2b")               ; => [["1a" "1" "a"] ["2b" "2" "b"]]
+
+(re-replace ¬\d+¬ "a1b22c333" "#")        ; => "a#b#c#"
+(re-replace ¬(\d+)-(\d+)¬ "555-1234" "${2}.${1}")  ; => "1234.555"
+(re-replace-first ¬\d+¬ "a1b22" "#")      ; => "a#b22"
+
+(re-split ¬,¬ "a,b,c")                     ; => ["a" "b" "c"]
+(re-split ¬,¬ "a,b,c,d" 2)                 ; => ["a" "b,c,d"]
 ```
 
 ## Loading
@@ -62,8 +93,3 @@ import "github.com/jig/lisp/lib/regexp/nsregexp"
 
 nsregexp.Load(env)
 ```
-
-## Not yet implemented
-
-`re-replace` / `re-replace-first`, `re-split`, and `re-seq` (all
-matches) are planned for a later iteration.

--- a/lib/regexp/regexp.go
+++ b/lib/regexp/regexp.go
@@ -9,7 +9,9 @@
 // accept either a compiled regex or a raw pattern string (compiled on
 // use). Following Clojure, re-matches / re-matches? are anchored (the
 // whole string must match) while re-find / re-find? are unanchored
-// (match anywhere).
+// (match anywhere). re-seq returns every match, re-replace /
+// re-replace-first rewrite matches (with $1 / ${name} group references),
+// and re-split breaks a string around matches.
 package regexp
 
 import (
@@ -64,6 +66,10 @@ func Load(env EnvType) {
 	call.CallOverrideFN(env, "re-find?", reFindQ)
 	call.CallOverrideFN(env, "re-matches", reMatches)
 	call.CallOverrideFN(env, "re-find", reFind)
+	call.CallOverrideFN(env, "re-seq", reSeq)
+	call.CallOverrideFN(env, "re-replace", reReplace)
+	call.CallOverrideFN(env, "re-replace-first", reReplaceFirst)
+	call.CallOverrideFN(env, "re-split", reSplit, 2, 3)
 
 	call.Doc(env, "re-pattern", "[pattern]",
 		"Compiles a raw pattern string (Go RE2 syntax; write it as ¬…¬) into a reusable regex value.")
@@ -75,6 +81,14 @@ func Load(env EnvType) {
 		"Anchored match of the whole string: nil, the match string when there are no groups, or a vector [whole g1 g2 …] (nil for an unmatched group).")
 	call.Doc(env, "re-find", "[re-or-pattern s]",
 		"First match anywhere in s: nil, the match string when there are no groups, or a vector [whole g1 g2 …] (nil for an unmatched group).")
+	call.Doc(env, "re-seq", "[re-or-pattern s]",
+		"Vector of every successive match in s (left to right, non-overlapping); each element is the match string when there are no groups, or a vector [whole g1 g2 …]. Empty vector when there is no match.")
+	call.Doc(env, "re-replace", "[re-or-pattern s replacement]",
+		"Replaces every match in s with replacement, where $1 or ${name} expand captured groups (use ${1} to delimit a number, $$ for a literal $). Returns the new string.")
+	call.Doc(env, "re-replace-first", "[re-or-pattern s replacement]",
+		"Like re-replace but only replaces the first match; the string is returned unchanged when there is no match.")
+	call.Doc(env, "re-split", "[re-or-pattern s & limit]",
+		"Splits s around matches of the pattern, returning a vector of the pieces. An optional integer limit caps the number of pieces (the last one keeps the remainder); a negative or absent limit returns them all, including trailing empty strings.")
 }
 
 func rePattern(pattern MalType) (MalType, error) {
@@ -136,4 +150,79 @@ func submatch(re *regexp.Regexp, s string) MalType {
 		}
 	}
 	return Vector{Val: out}
+}
+
+// submatchIdx is submatch working from an index slice already produced by
+// FindAllStringSubmatchIndex, so re-seq shares the match-data shape of
+// re-find (whole match string when there are no groups, else a vector).
+func submatchIdx(s string, idx []int) MalType {
+	n := len(idx) / 2
+	if n == 1 {
+		return s[idx[0]:idx[1]]
+	}
+	out := make([]MalType, n)
+	for i := range n {
+		start, end := idx[2*i], idx[2*i+1]
+		if start < 0 {
+			out[i] = nil
+		} else {
+			out[i] = s[start:end]
+		}
+	}
+	return Vector{Val: out}
+}
+
+func reSeq(reOrPattern MalType, s string) (MalType, error) {
+	rx, err := asRegexp("re-seq", reOrPattern)
+	if err != nil {
+		return nil, err
+	}
+	all := rx.re.FindAllStringSubmatchIndex(s, -1)
+	out := make([]MalType, len(all))
+	for i, idx := range all {
+		out[i] = submatchIdx(s, idx)
+	}
+	return Vector{Val: out}, nil
+}
+
+func reReplace(reOrPattern MalType, s, replacement string) (MalType, error) {
+	rx, err := asRegexp("re-replace", reOrPattern)
+	if err != nil {
+		return nil, err
+	}
+	return rx.re.ReplaceAllString(s, replacement), nil
+}
+
+func reReplaceFirst(reOrPattern MalType, s, replacement string) (MalType, error) {
+	rx, err := asRegexp("re-replace-first", reOrPattern)
+	if err != nil {
+		return nil, err
+	}
+	idx := rx.re.FindStringSubmatchIndex(s)
+	if idx == nil {
+		return s, nil
+	}
+	repl := rx.re.ExpandString(nil, replacement, s, idx)
+	return s[:idx[0]] + string(repl) + s[idx[1]:], nil
+}
+
+func reSplit(reOrPattern MalType, s string, limit ...MalType) (MalType, error) {
+	rx, err := asRegexp("re-split", reOrPattern)
+	if err != nil {
+		return nil, err
+	}
+	n := -1
+	if len(limit) == 1 {
+		l, ok := limit[0].(int)
+		if !ok {
+			return nil, fmt.Errorf("re-split: limit must be an integer, got %T", limit[0])
+		}
+		n = l
+	}
+	parts := rx.re.Split(s, n)
+	out := make([]MalType, len(parts))
+	for i, p := range parts {
+		out[i] = p
+	}
+	return Vector{Val: out}, nil
 }

--- a/lib/regexp/regexp_test.go
+++ b/lib/regexp/regexp_test.go
@@ -94,6 +94,75 @@ func TestMatchData(t *testing.T) {
 	}
 }
 
+func TestSeq(t *testing.T) {
+	ns := newEnv(t)
+	cases := []struct {
+		src, want string
+	}{
+		// no groups -> each match is a string
+		{`(re-seq ¬\d+¬ "a1 bb 22 c333")`, `["1" "22" "333"]`},
+		// no match -> empty vector
+		{`(re-seq ¬\d+¬ "abc")`, "[]"},
+		// groups -> each match is [whole g1 g2 …]
+		{`(re-seq ¬(\d)(\w)¬ "1a 2b")`, `[["1a" "1" "a"] ["2b" "2" "b"]]`},
+		// a compiled pattern works too
+		{`(re-seq (re-pattern ¬[a-z]+¬) "ab CD ef")`, `["ab" "ef"]`},
+	}
+	for _, c := range cases {
+		if got := eval(t, ns, c.src); got != c.want {
+			t.Errorf("%s = %s, want %s", c.src, got, c.want)
+		}
+	}
+}
+
+func TestReplace(t *testing.T) {
+	ns := newEnv(t)
+	cases := []struct {
+		src, want string
+	}{
+		// replace all, literal replacement
+		{`(re-replace ¬\d+¬ "a1b22c333" "#")`, `"a#b#c#"`},
+		// group references with ${n}
+		{`(re-replace ¬(\d+)-(\d+)¬ "555-1234 and 9-8" "${2}.${1}")`, `"1234.555 and 8.9"`},
+		// $$ is a literal dollar
+		{`(re-replace ¬\d¬ "a1" "$$")`, `"a$"`},
+		// no match -> unchanged
+		{`(re-replace ¬x¬ "abc" "y")`, `"abc"`},
+		// replace-first only touches the first match
+		{`(re-replace-first ¬\d+¬ "a1b22c333" "#")`, `"a#b22c333"`},
+		{`(re-replace-first ¬(\d+)¬ "v42 v7" "[${1}]")`, `"v[42] v7"`},
+		{`(re-replace-first ¬x¬ "abc" "y")`, `"abc"`},
+	}
+	for _, c := range cases {
+		if got := eval(t, ns, c.src); got != c.want {
+			t.Errorf("%s = %s, want %s", c.src, got, c.want)
+		}
+	}
+}
+
+func TestSplit(t *testing.T) {
+	ns := newEnv(t)
+	cases := []struct {
+		src, want string
+	}{
+		{`(re-split ¬,¬ "a,b,c")`, `["a" "b" "c"]`},
+		{`(re-split ¬\s+¬ "one  two   three")`, `["one" "two" "three"]`},
+		// no match -> the whole string as a single piece
+		{`(re-split ¬,¬ "abc")`, `["abc"]`},
+		// trailing empty pieces are kept (Go semantics)
+		{`(re-split ¬,¬ "a,b,,")`, `["a" "b" "" ""]`},
+		// limit caps the number of pieces; the last keeps the remainder
+		{`(re-split ¬,¬ "a,b,c,d" 2)`, `["a" "b,c,d"]`},
+		// compiled pattern
+		{`(re-split (re-pattern ¬\d¬) "a1b2c")`, `["a" "b" "c"]`},
+	}
+	for _, c := range cases {
+		if got := eval(t, ns, c.src); got != c.want {
+			t.Errorf("%s = %s, want %s", c.src, got, c.want)
+		}
+	}
+}
+
 func TestPatternValue(t *testing.T) {
 	ns := newEnv(t)
 	// re-pattern prints as «regex …» and is idempotent (accepts a regex).
@@ -113,4 +182,6 @@ func TestErrors(t *testing.T) {
 	// wrong argument types
 	evalErr(t, ns, `(re-find? 42 "x")`)
 	evalErr(t, ns, `(re-matches? ¬\d¬ 42)`)
+	// re-split limit must be an integer
+	evalErr(t, ns, `(re-split ¬,¬ "a,b" "2")`)
 }


### PR DESCRIPTION
Closes the regexp library — the three functions left as "planned":

- **`re-seq`** — vector of every non-overlapping match, each shaped like `re-find` (the match string, or `[whole g1 g2 …]` with groups). `[]` when nothing matches.
- **`re-replace` / `re-replace-first`** — rewrite matches with `$1` / `${name}` group references (`$$` for a literal `$`). `re-replace-first` leaves the string unchanged when there is no match. Function replacements are not supported.
- **`re-split`** — split around matches into a vector, with an optional integer limit. Follows Go's `Split`: trailing empty pieces are kept.

All accept a compiled regex or a raw `¬…¬` pattern, like the existing builtins.

Docs (`README.md`, `CHANGELOG.md`, regenerated `LANGUAGE.md`) and tests updated; both the untagged and `-tags debugger` suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)