### PR TITLE
feat(core): time-add, time-before?, time-after?

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -265,6 +265,9 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `take` | `[n coll]` | First n elements of coll. |
 | `take-last` | `[n coll]` | Last n elements of coll. |
 | `throw` | `[value]` | Raises value as an error. |
+| `time-add` | `[ms deltas]` | Shifts epoch milliseconds ms by the deltas hash-map. :years :months :days are calendar-aware (via UTC); :hours :minutes :seconds :milliseconds add a fixed duration. Missing keys are 0, values may be negative; an unknown key or non-integer value errors. |
+| `time-after?` | `[t1 t2]` | Reports whether epoch milliseconds t1 is strictly after t2. |
+| `time-before?` | `[t1 t2]` | Reports whether epoch milliseconds t1 is strictly before t2. |
 | `time-format` | `[ms]` | Formats epoch milliseconds (as of time-ms) as an RFC 3339 UTC timestamp with millisecond precision. |
 | `time-ms` | `[]` | Current time in milliseconds since the epoch. |
 | `time-ns` | `[]` | Current time in nanoseconds since the epoch. |

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -109,6 +109,9 @@ func Load(env EnvType) {
 	call.Call(env, time_ns)
 	call.Call(env, time_format)
 	call.Call(env, time_parse)
+	call.Call(env, time_add)
+	call.CallOverrideFN(env, "time-before?", time_before)
+	call.CallOverrideFN(env, "time-after?", time_after)
 	call.Call(env, uUid)
 	call.Call(env, pr_str)
 	call.Call(env, str)
@@ -771,6 +774,57 @@ func time_parse(s string) (int, error) {
 		return 0, err
 	}
 	return int(t.UnixMilli()), nil
+}
+
+// time_add returns the instant millis (Unix milliseconds, UTC) shifted by
+// the deltas in hm. :years :months :days go through time.AddDate, which is
+// calendar-aware (variable month lengths, leap years) and normalise overflow
+// like time.AddDate (Jan 31 + 1 month → March 2, Feb 29 + 1 year → March 1);
+// :hours :minutes :seconds :milliseconds add a fixed duration. Any key may be omitted (0) or
+// negative (shift backwards); an unknown key, or a value that is not an int,
+// is an error. Times cross the lisp boundary as Unix-millisecond ints,
+// matching core's time-ms/time-format. hm is read, never mutated.
+func time_add(millis int, hm HashMap) (int, error) {
+	var d struct{ years, months, days, hours, minutes, seconds, millis int }
+	fields := map[string]*int{
+		NewKeyword("years"):        &d.years,
+		NewKeyword("months"):       &d.months,
+		NewKeyword("days"):         &d.days,
+		NewKeyword("hours"):        &d.hours,
+		NewKeyword("minutes"):      &d.minutes,
+		NewKeyword("seconds"):      &d.seconds,
+		NewKeyword("milliseconds"): &d.millis,
+	}
+	for key, v := range hm.Val {
+		p, ok := fields[key]
+		if !ok {
+			return 0, fmt.Errorf("time-add: unsupported parameter %q", strings.TrimPrefix(key, "ʞ"))
+		}
+		n, ok := v.(int)
+		if !ok {
+			return 0, fmt.Errorf("time-add: %s must be an integer (was %T)", strings.TrimPrefix(key, "ʞ"), v)
+		}
+		*p = n
+	}
+	t := time.UnixMilli(int64(millis)).UTC().
+		AddDate(d.years, d.months, d.days).
+		Add(time.Duration(d.hours)*time.Hour +
+			time.Duration(d.minutes)*time.Minute +
+			time.Duration(d.seconds)*time.Second +
+			time.Duration(d.millis)*time.Millisecond)
+	return int(t.UnixMilli()), nil
+}
+
+// time_before reports whether t1 is strictly before t2 (both Unix
+// milliseconds). Lisp name: time-before? (predicate convention).
+func time_before(t1, t2 int) (bool, error) {
+	return t1 < t2, nil
+}
+
+// time_after reports whether t1 is strictly after t2 (both Unix
+// milliseconds). Lisp name: time-after? (predicate convention).
+func time_after(t1, t2 int) (bool, error) {
+	return t1 > t2, nil
 }
 
 // Hash Map, Set, Vector functions

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -136,6 +136,9 @@ var coreDocs = []struct{ name, arglist, doc string }{
 	{"time-ns", "[]", "Current time in nanoseconds since the epoch."},
 	{"time-format", "[ms]", "Formats epoch milliseconds (as of time-ms) as an RFC 3339 UTC timestamp with millisecond precision."},
 	{"time-parse", "[string]", "Parses an RFC 3339 timestamp and returns epoch milliseconds (as of time-ms)."},
+	{"time-add", "[ms deltas]", "Shifts epoch milliseconds ms by the deltas hash-map. :years :months :days are calendar-aware (via UTC); :hours :minutes :seconds :milliseconds add a fixed duration. Missing keys are 0, values may be negative; an unknown key or non-integer value errors."},
+	{"time-before?", "[t1 t2]", "Reports whether epoch milliseconds t1 is strictly before t2."},
+	{"time-after?", "[t1 t2]", "Reports whether epoch milliseconds t1 is strictly after t2."},
 	{"version", "[]", "Interpreter build information as a hash-map."},
 
 	// Bytes, base64 & JSON

--- a/lib/core/time_test.go
+++ b/lib/core/time_test.go
@@ -28,3 +28,48 @@ func TestTimeFormatParse(t *testing.T) {
 		}
 	}
 }
+
+// time-add shifts epoch milliseconds by a hash-map of deltas; :years
+// :months :days are calendar-aware (via UTC), the rest are fixed durations.
+func TestTimeAdd(t *testing.T) {
+	ns := newEnv(t)
+
+	for _, tc := range []struct{ src, want string }{
+		// fixed durations add up
+		{`(time-format (time-add 0 {:hours 1 :minutes 30}))`, `"1970-01-01T01:30:00.000Z"`},
+		{`(time-format (time-add 0 {:milliseconds 123}))`, `"1970-01-01T00:00:00.123Z"`},
+		// calendar arithmetic normalises overflow like Go's AddDate:
+		// 2021 is not a leap year, so Feb 29 + 1 year rolls to March 1,
+		// and Jan 31 + 1 month (no Feb 31) rolls to March 2.
+		{`(time-format (time-add (time-parse "2020-02-29T12:00:00Z") {:years 1}))`, `"2021-03-01T12:00:00.000Z"`},
+		{`(time-format (time-add (time-parse "2020-01-31T00:00:00Z") {:months 1}))`, `"2020-03-02T00:00:00.000Z"`},
+		// negative deltas shift backwards
+		{`(time-format (time-add 0 {:seconds -1}))`, `"1969-12-31T23:59:59.000Z"`},
+		// an empty map is a no-op
+		{`(time-add 12345 {})`, `12345`},
+		// unknown key and non-integer value are catchable errors
+		{`(try (time-add 0 {:fortnights 2}) (catch e :bad))`, `:bad`},
+		{`(try (time-add 0 {:hours "2"}) (catch e :bad))`, `:bad`},
+	} {
+		if got := run(t, ns, tc.src); got != tc.want {
+			t.Errorf("%s: got %s, want %s", tc.src, got, tc.want)
+		}
+	}
+}
+
+func TestTimeBeforeAfter(t *testing.T) {
+	ns := newEnv(t)
+
+	for _, tc := range []struct{ src, want string }{
+		{`(time-before? 1 2)`, `true`},
+		{`(time-before? 2 1)`, `false`},
+		{`(time-before? 5 5)`, `false`},
+		{`(time-after? 2 1)`, `true`},
+		{`(time-after? 1 2)`, `false`},
+		{`(time-after? 5 5)`, `false`},
+	} {
+		if got := run(t, ns, tc.src); got != tc.want {
+			t.Errorf("%s: got %s, want %s", tc.src, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Adds calendar/duration arithmetic and ordering over the epoch-millisecond ints that `time-ms` / `time-format` already use.

## `(time-add ms deltas)`

`deltas` is a hash-map; `:years :months :days` are calendar-aware (via `time.AddDate`, in UTC), `:hours :minutes :seconds :milliseconds` add a fixed duration. Missing keys are `0`, negatives shift backwards. An unknown key or a non-integer value is a catchable error. The map is read, never mutated.

```clojure
(time-format (time-add 0 {:hours 1 :minutes 30}))   ; => "1970-01-01T01:30:00.000Z"
(time-format (time-add (time-parse "2020-01-31T00:00:00Z") {:months 1}))
                                                     ; => "2020-03-02T00:00:00.000Z"
```

Overflow normalises like Go's `AddDate` (Jan 31 + 1 month → March 2, Feb 29 + 1 year → March 1) — documented on the builtin and covered by tests.

## `(time-before? t1 t2)` / `(time-after? t1 t2)`

Strict ordering of two epoch-millisecond ints.

Docs (`docs.go`, regenerated `LANGUAGE.md`) and tests updated; both the untagged and `-tags debugger` suites pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)