### PR TITLE
feat(types)!: first-class Keyword type (option B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,82 @@ pre-1.0, so minor tags can carry behaviour changes; the ones that may
 need action when upgrading are called out under **Changed** with a
 migration note.
 
+## 0.4 (unreleased, branch `proto/keyword-type`)
+
+### ⚠️ Changed — keywords are a first-class type
+
+Keywords are now a dedicated Go type, `types.Keyword`, instead of a
+string carrying a `ʞ` (U+029E) prefix. Hash-map keys and set elements
+are `map[types.MalType]…`, restricted to strings and keywords
+(validated at construction). **Lisp code is unaffected** — `:foo`
+reads, prints, compares and hashes exactly as before — but the type
+split fixes real bugs:
+
+- External data can no longer forge keywords: a JSON value `"ʞx"`
+  used to *become* the keyword `:x` (`keyword?` true, `string?`
+  false); it now stays a string. This closed a data-driven type
+  confusion affecting every input path (`json-decode`, `lib/web`,
+  `lib/sql`, files) and `--integrity` runs.
+- `(json-encode {:a 1})` returns `{"a":1}` — the internal prefix no
+  longer leaks (`{"ʞa":1}` before).
+- A literal `ʞ` inside a string survives reading; the reader used the
+  same rune as an unescape sentinel and silently corrupted it to `\`.
+- `(seq :ab)` errors instead of splitting the keyword as a string.
+
+**JSON round-trips are no longer lossless, by design**: keyword keys
+and values serialise as their bare name, and `json-decode` keeps
+producing plain string keys (as in Clojure), so
+`(get (json-decode {} (json-encode {:a 1})) :a)` must become
+`(get … "a")`. The old losslessness existed only because the prefix
+leaked into the wire format.
+
+### Migration (embedders — Go code using jig/lisp)
+
+Scripts and lisp data files need no changes. Go code embedding the
+interpreter recompiles against three deliberate compile-time breaks:
+
+1. **`HashMap.Val` and `Set.Val` are renamed to `Items`**, with key
+   type `map[types.MalType]MalType` / `map[types.MalType]struct{}`.
+   Every literal and access breaks loudly on purpose: with the old
+   field name kept, `hm.Val["ʞa"]` would have compiled against the new
+   key type and silently returned `nil`.
+2. **`"ʞ…"` string literals** used as keys or values must become
+   `types.KW("…")`. Fixing the `Items` errors leads the compiler to
+   each one.
+3. **`types.NewKeyword` returns `types.Keyword`** (kept as a
+   deprecated alias of the new constructor `types.KW`); assignments to
+   `string` variables and comparisons against strings stop compiling.
+
+Unchanged: `List.Val`/`Vector.Val`, `Symbol`, `REPL`/`EVAL`/`READ`,
+`AddPreamble` (placeholder names stay `map[string]MalType`), and all
+of `lnotation` (`L`/`S`/`LS`/`V`/`HM`/`SET`).
+`marshalingexample_test.go` shows a typical embedder marshaler before
+and after.
+
+After the compiler is happy, audit for the changes that *don't* break
+compilation:
+
+- `case string:` branches in type switches that used to receive
+  keywords: keywords no longer match — add `case types.Keyword:`.
+- Custom builtins registered through `lib/call` with `string`
+  parameters that lisp code calls with keywords: they now return a
+  lisp error at call time (`reflect: Call using types.Keyword as type
+  string`) — widen the parameter to `types.Keyword` or
+  `types.MalType`.
+- `key.(string)` assertions with `, ok` over map keys: they now fail
+  (silently, if only `ok` is checked) for keyword keys.
+- `types.Keyword_Q(someGoString)` is now always false; `%T` prints
+  `types.Keyword`.
+- Keyword-keyed JSON round-trips: switch post-decode lookups to
+  string keys (see above).
+
+A quick sweep finds the risky spots:
+
+```sh
+grep -rn 'ʞ' --include='*.go' .
+grep -rn 'case string\|\.(string)\|Keyword_Q' --include='*.go' .
+```
+
 ## Unreleased (since v0.2.24)
 
 ### ⚠️ Changed — file I/O moved from `core` to `system`

--- a/ROADMAP-keywords.md
+++ b/ROADMAP-keywords.md
@@ -258,7 +258,47 @@ Plan:
   - Same breaking window: arbitrary-value sets / arbitrary-key maps (Tier 2)
     if desired — they require exactly this key-type change.
 
-## 7. Conclusion
+## 7. Prototype status (branch `proto/keyword-type`, 2026-07-24)
+
+Option B is implemented end to end: `types.Keyword` (+ `types.KW`
+constructor, `NewKeyword` kept as a deprecated alias returning `Keyword`),
+`HashMap.Val`/`Set.Val` renamed to **`Items`** with `map[MalType]…` keys,
+`ValidKey` construction-time validation (string|Keyword), `KeyLess` total
+order (strings first, then keywords — the grouping the sorted legacy
+encoding produced). Full test suite green (31 packages, both tag sets);
+MAL1 and a map-heavy lisp loop benchmark are within noise of `develop`,
+as predicted in §5.
+
+Findings and decisions made while implementing:
+
+- **JSON round-trip is no longer lossless, by choice.** `json-encode`
+  emits keyword keys/values as bare names and `json-decode` keeps
+  producing plain string keys, so keyword→JSON→decode returns strings
+  (Clojure parity). The old lossless round-trip existed only because the
+  ʞ prefix leaked into the JSON — behaviour the marshaling step test
+  itself marked `TODO`. Tests updated; a `:key-fn`-style keywordizing
+  decode could be added later if wanted.
+- The reader's `ʞ` unescape sentinel was replaced by a single-pass
+  unescaper (the 0.3.x fix folded in): literal `ʞ` in strings survives.
+- Builtin signature changes beyond the plan: `keyword` takes
+  `MalType` (string or keyword), `contains?` takes a `MalType` key,
+  `get` gained per-container key-type errors, web's `web-log` level is
+  `MalType`. `AddPreamble` keeps `map[string]MalType` (placeholder names
+  are not lisp keys).
+- `(seq :ab)` now errors (keywords no longer fall into the string case) —
+  the §1 bug fixed for free.
+- The data printer (state-save canonical format) sorts by *printed* key,
+  so state files keep their exact key order across the migration.
+- gopls field-rename covered 33 files but missed tag-gated files
+  (`debugadapter`, `command/coverage_debug.go`) — remember `-tags` builds
+  when refactoring.
+
+Not done yet (for the real 0.4 PR): CHANGELOG entry and migration guide,
+LANGUAGE.md wording, docgen/docs sweep, deciding whether `lnotation`
+gains keyword-key helpers, Tier-2 arbitrary sets/maps (now a small step:
+relax `ValidKey` and extend `KeyLess`).
+
+## 8. Conclusion
 
 Feasible and desirable: the prefix encoding causes real correctness bugs
 (data-driven type confusion, JSON leakage, reader corruption), not just

--- a/ROADMAP-keywords.md
+++ b/ROADMAP-keywords.md
@@ -293,10 +293,11 @@ Findings and decisions made while implementing:
   (`debugadapter`, `command/coverage_debug.go`) — remember `-tags` builds
   when refactoring.
 
-Not done yet (for the real 0.4 PR): CHANGELOG entry and migration guide,
-LANGUAGE.md wording, docgen/docs sweep, deciding whether `lnotation`
-gains keyword-key helpers, Tier-2 arbitrary sets/maps (now a small step:
-relax `ValidKey` and extend `KeyLess`).
+CHANGELOG now carries the 0.4 section with the embedder migration
+guide. Still pending for the real 0.4 PR: LANGUAGE.md wording,
+docgen/docs sweep, deciding whether `lnotation` gains keyword-key
+helpers, Tier-2 arbitrary sets/maps (now a small step: relax
+`ValidKey` and extend `KeyLess`).
 
 ## 8. Conclusion
 

--- a/command/coverage_debug.go
+++ b/command/coverage_debug.go
@@ -86,7 +86,7 @@ func coverableLines(path string) (map[int]bool, error) {
 			}
 		case types.HashMap:
 			mark(f.Cursor)
-			for _, c := range f.Val {
+			for _, c := range f.Items {
 				walk(c)
 			}
 		case types.Symbol:

--- a/command/preamble.go
+++ b/command/preamble.go
@@ -107,7 +107,11 @@ func runScript(ctx context.Context, env types.EnvType, fileName string, preamble
 		return nil, err
 	}
 
-	ast, err := reader.Read_program(content, types.NewCursorFile(fileName), &types.HashMap{Val: values}, env)
+	items := make(map[types.MalType]types.MalType, len(values))
+	for k, v := range values {
+		items[k] = v
+	}
+	ast, err := reader.Read_program(content, types.NewCursorFile(fileName), &types.HashMap{Items: items}, env)
 	if err != nil {
 		return nil, err
 	}

--- a/debugadapter/server.go
+++ b/debugadapter/server.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -528,19 +527,23 @@ func (s *Server) childrenOf(v types.MalType) []Variable {
 		}
 		return out
 	case types.HashMap:
-		out := make([]Variable, 0, len(v.Val))
-		for k, val := range v.Val {
-			displayKey := k
-			if strings.HasPrefix(k, "ʞ") {
-				displayKey = ":" + strings.TrimPrefix(k, "ʞ")
+		out := make([]Variable, 0, len(v.Items))
+		for k, val := range v.Items {
+			displayKey, _ := k.(string)
+			if kw, ok := k.(types.Keyword); ok {
+				displayKey = ":" + string(kw)
 			}
 			out = append(out, s.formatVariable(displayKey, val))
 		}
 		return out
 	case types.Set:
-		out := make([]Variable, 0, len(v.Val))
-		for k := range v.Val {
-			out = append(out, s.formatVariable(k, k))
+		out := make([]Variable, 0, len(v.Items))
+		for k := range v.Items {
+			name, _ := k.(string)
+			if kw, ok := k.(types.Keyword); ok {
+				name = ":" + string(kw)
+			}
+			out = append(out, s.formatVariable(name, k))
 		}
 		return out
 	}

--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -175,7 +175,7 @@ func malFuncDoc(f types.MalFunc) string {
 	if !ok {
 		return ""
 	}
-	if d, ok := hm.Items[types.NewKeyword("doc")].(string); ok {
+	if d, ok := hm.Items[types.KW("doc")].(string); ok {
 		return d
 	}
 	return ""

--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -175,7 +175,7 @@ func malFuncDoc(f types.MalFunc) string {
 	if !ok {
 		return ""
 	}
-	if d, ok := hm.Val[types.NewKeyword("doc")].(string); ok {
+	if d, ok := hm.Items[types.NewKeyword("doc")].(string); ok {
 		return d
 	}
 	return ""

--- a/example_configfile-in-lisp_test.go
+++ b/example_configfile-in-lisp_test.go
@@ -20,7 +20,7 @@ func Example_configInLisp() {
 		ns,
 	)
 
-	fmt.Println("sessions:", config.(types.HashMap).Val[types.NewKeyword("sessions")])
+	fmt.Println("sessions:", config.(types.HashMap).Items[types.NewKeyword("sessions")])
 
 	// Output:
 	// sessions: 10

--- a/example_configfile-in-lisp_test.go
+++ b/example_configfile-in-lisp_test.go
@@ -20,7 +20,7 @@ func Example_configInLisp() {
 		ns,
 	)
 
-	fmt.Println("sessions:", config.(types.HashMap).Items[types.NewKeyword("sessions")])
+	fmt.Println("sessions:", config.(types.HashMap).Items[types.KW("sessions")])
 
 	// Output:
 	// sessions: 10

--- a/lib/call/call.go
+++ b/lib/call/call.go
@@ -144,15 +144,15 @@ func call(overrideFN *string, namespace types.EnvType, fIn types.MalType, args .
 
 	_, err := namespace.Update(types.Symbol{Val: "_PACKAGES_"}, func(_hm types.MalType) (types.MalType, error) {
 		if _hm == nil {
-			_hm = types.HashMap{Val: make(map[string]types.MalType)}
+			_hm = types.HashMap{Items: make(map[types.MalType]types.MalType)}
 		}
 		hm := _hm.(types.HashMap)
-		set, ok := hm.Val[packageName].(types.Set)
+		set, ok := hm.Items[packageName].(types.Set)
 		if !ok {
-			set = types.Set{Val: make(map[string]struct{})}
+			set = types.Set{Items: make(map[types.MalType]struct{})}
 		}
-		set.Val[functionName] = struct{}{}
-		hm.Val[packageName] = set
+		set.Items[functionName] = struct{}{}
+		hm.Items[packageName] = set
 		return hm, nil
 	})
 	if err != nil {

--- a/lib/call/call_test.go
+++ b/lib/call/call_test.go
@@ -95,7 +95,7 @@ func TestPackageRegister(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	set := hm.(types.HashMap).Val["github.com/jig/lisp/lib/call"].(types.Set).Val
+	set := hm.(types.HashMap).Items["github.com/jig/lisp/lib/call"].(types.Set).Items
 	if len(set) != 4 {
 		t.Fatal("test failed")
 	}
@@ -254,9 +254,9 @@ func count(seq types.MalType) (types.MalType, error) {
 	case types.Vector:
 		return len(seq.Val), nil
 	case types.HashMap:
-		return len(seq.Val), nil
+		return len(seq.Items), nil
 	case types.Set:
-		return len(seq.Val), nil
+		return len(seq.Items), nil
 	case nil:
 		return 0, nil
 	default:
@@ -271,9 +271,9 @@ func empty_Q(seq types.MalType) (types.MalType, error) {
 	case types.Vector:
 		return len(seq.Val) == 0, nil
 	case types.HashMap:
-		return len(seq.Val) == 0, nil
+		return len(seq.Items) == 0, nil
 	case types.Set:
-		return len(seq.Val) == 0, nil
+		return len(seq.Items) == 0, nil
 	case nil:
 		return true, nil
 	default:

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -73,11 +73,14 @@ func Load(env EnvType) {
 	call.Call(env, mAp)
 	call.Call(env, throw)
 	call.CallOverrideFN(env, "symbol", func(a string) (Symbol, error) { return Symbol{Val: a}, nil })
-	call.CallOverrideFN(env, "keyword", func(a string) (string, error) {
-		if Keyword_Q(a) {
+	call.CallOverrideFN(env, "keyword", func(a MalType) (Keyword, error) {
+		switch a := a.(type) {
+		case Keyword:
 			return a, nil
-		} else {
-			return NewKeyword(a), nil
+		case string:
+			return KW(a), nil
+		default:
+			return "", fmt.Errorf("keyword requires a string or a keyword (found %T)", a)
 		}
 	})
 	call.Call(env, sPew)
@@ -336,29 +339,29 @@ func version() (HashMap, error) {
 	if !ok {
 		return HashMap{}, nil
 	}
-	build := map[string]MalType{}
+	build := map[MalType]MalType{}
 	for _, s := range bi.Settings {
 		build[s.Key] = s.Value
 	}
-	deps := map[string]MalType{}
+	deps := map[MalType]MalType{}
 	for _, d := range bi.Deps {
 		if d.Replace == nil {
-			deps[d.Path] = HashMap{Val: map[string]MalType{
-				"ʞversion": d.Version,
-				"ʞsum":     d.Sum,
+			deps[d.Path] = HashMap{Items: map[MalType]MalType{
+				KW("version"): d.Version,
+				KW("sum"):     d.Sum,
 			}}
 		} else {
-			deps[d.Path] = HashMap{Val: map[string]MalType{
-				"ʞversion": d.Version,
-				"ʞsum":     d.Sum,
-				"ʞreplace": d.Replace,
+			deps[d.Path] = HashMap{Items: map[MalType]MalType{
+				KW("version"): d.Version,
+				KW("sum"):     d.Sum,
+				KW("replace"): d.Replace,
 			}}
 		}
 	}
-	return HashMap{Val: map[string]MalType{
-		"ʞgo-version":   bi.GoVersion,
-		"ʞbuild":        HashMap{Val: build},
-		"ʞdependencies": HashMap{Val: deps},
+	return HashMap{Items: map[MalType]MalType{
+		KW("go-version"):   bi.GoVersion,
+		KW("build"):        HashMap{Items: build},
+		KW("dependencies"): HashMap{Items: deps},
 	}}, nil
 }
 
@@ -424,10 +427,9 @@ func istype(arg MalType) (string, error) {
 		return "boolean", nil
 	case Symbol:
 		return "symbol", nil
+	case Keyword:
+		return "keyword", nil
 	case string:
-		if len(arg) != 0 && strings.HasPrefix(arg, "ʞ") {
-			return "keyword", nil
-		}
 		return "string", nil
 	case MalFunc:
 		return "function", nil
@@ -786,23 +788,23 @@ func time_parse(s string) (int, error) {
 // matching core's time-ms/time-format. hm is read, never mutated.
 func time_add(millis int, hm HashMap) (int, error) {
 	var d struct{ years, months, days, hours, minutes, seconds, millis int }
-	fields := map[string]*int{
-		NewKeyword("years"):        &d.years,
-		NewKeyword("months"):       &d.months,
-		NewKeyword("days"):         &d.days,
-		NewKeyword("hours"):        &d.hours,
-		NewKeyword("minutes"):      &d.minutes,
-		NewKeyword("seconds"):      &d.seconds,
-		NewKeyword("milliseconds"): &d.millis,
+	fields := map[MalType]*int{
+		KW("years"):        &d.years,
+		KW("months"):       &d.months,
+		KW("days"):         &d.days,
+		KW("hours"):        &d.hours,
+		KW("minutes"):      &d.minutes,
+		KW("seconds"):      &d.seconds,
+		KW("milliseconds"): &d.millis,
 	}
-	for key, v := range hm.Val {
+	for key, v := range hm.Items {
 		p, ok := fields[key]
 		if !ok {
-			return 0, fmt.Errorf("time-add: unsupported parameter %q", strings.TrimPrefix(key, "ʞ"))
+			return 0, fmt.Errorf("time-add: unsupported parameter %q", key)
 		}
 		n, ok := v.(int)
 		if !ok {
-			return 0, fmt.Errorf("time-add: %s must be an integer (was %T)", strings.TrimPrefix(key, "ʞ"), v)
+			return 0, fmt.Errorf("time-add: %v must be an integer (was %T)", key, v)
 		}
 		*p = n
 	}
@@ -829,17 +831,17 @@ func time_after(t1, t2 int) (bool, error) {
 
 // Hash Map, Set, Vector functions
 func copy_hash_map(hm HashMap) HashMap {
-	new_hm := HashMap{Val: map[string]MalType{}}
-	for k, v := range hm.Val {
-		new_hm.Val[k] = v
+	new_hm := HashMap{Items: map[MalType]MalType{}}
+	for k, v := range hm.Items {
+		new_hm.Items[k] = v
 	}
 	return new_hm
 }
 
 func copy_set(s Set) Set {
-	new_s := Set{Val: map[string]struct{}{}}
-	for k, v := range s.Val {
-		new_s.Val[k] = v
+	new_s := Set{Items: map[MalType]struct{}{}}
+	for k, v := range s.Items {
+		new_s.Items[k] = v
 	}
 	return new_s
 }
@@ -863,10 +865,10 @@ func assoc(a ...MalType) (MalType, error) {
 		new_hm := copy_hash_map(ms)
 		for i := 1; i < len(a); i += 2 {
 			key := a[i]
-			if !Q[string](key) {
-				return nil, errors.New("assoc called with non-string key")
+			if !ValidKey(key) {
+				return nil, errors.New("assoc called with non-string non-keyword key")
 			}
-			new_hm.Val[key.(string)] = a[i+1]
+			new_hm.Items[key] = a[i+1]
 		}
 		return new_hm, nil
 	case Vector:
@@ -889,10 +891,10 @@ func assoc(a ...MalType) (MalType, error) {
 		}
 		new_s := copy_set(ms)
 		for _, value := range a[1:] {
-			if !Q[string](value) {
-				return nil, errors.New("assoc called with non-string key")
+			if !ValidKey(value) {
+				return nil, errors.New("assoc called with non-string non-keyword key")
 			}
-			new_s.Val[value.(string)] = struct{}{}
+			new_s.Items[value] = struct{}{}
 		}
 		return new_s, nil
 	default:
@@ -910,19 +912,19 @@ func dissoc(a ...MalType) (MalType, error) {
 		new_hm := copy_hash_map(ms)
 		for i := 1; i < len(a); i += 1 {
 			key := a[i]
-			if !Q[string](key) {
-				return nil, errors.New("dissoc called with non-string key")
+			if !ValidKey(key) {
+				return nil, errors.New("dissoc called with non-string non-keyword key")
 			}
-			delete(new_hm.Val, key.(string))
+			delete(new_hm.Items, key)
 		}
 		return new_hm, nil
 	case Set:
 		new_s := copy_set(ms)
 		for _, value := range a[1:] {
-			if !Q[string](value) {
-				return nil, errors.New("dissoc called with non-string key")
+			if !ValidKey(value) {
+				return nil, errors.New("dissoc called with non-string non-keyword key")
 			}
-			delete(new_s.Val, value.(string))
+			delete(new_s.Items, value)
 		}
 		return new_s, nil
 	default:
@@ -935,22 +937,36 @@ func get(hm, key MalType) (MalType, error) {
 		return nil, nil
 	}
 	switch key.(type) {
-	case string:
+	case string, Keyword:
 	case int:
 	default:
-		return nil, errors.New("get called with non-string key nor a non-int key")
+		return nil, errors.New("get called with non-string, non-keyword, non-int key")
 	}
 	ms := hm
 	switch ms := ms.(type) {
 	case HashMap:
-		return ms.Val[key.(string)], nil
+		if !ValidKey(key) {
+			return nil, errors.New("get on a hash-map requires a string or keyword key")
+		}
+		return ms.Items[key], nil
 	case Vector:
-		return ms.Val[key.(int)], nil
+		i, ok := key.(int)
+		if !ok {
+			return nil, errors.New("get on a vector requires an int key")
+		}
+		return ms.Val[i], nil
 	case List:
-		return ms.Val[key.(int)], nil
+		i, ok := key.(int)
+		if !ok {
+			return nil, errors.New("get on a list requires an int key")
+		}
+		return ms.Val[i], nil
 	case Set:
-		if _, ok := ms.Val[key.(string)]; ok {
-			return key.(string), nil
+		if !ValidKey(key) {
+			return nil, errors.New("get on a set requires a string or keyword key")
+		}
+		if _, ok := ms.Items[key]; ok {
+			return key, nil
 		}
 		return nil, nil
 	default:
@@ -982,7 +998,7 @@ func _getIn(argMapOrVector MalType, posVector Vector) (MalType, error) {
 		var branch MalType
 		switch argMapOrVector := argMapOrVector.(type) {
 		case HashMap:
-			branch = argMapOrVector.Val[index.(string)]
+			branch = argMapOrVector.Items[index]
 			if branch == nil {
 				branch = HashMap{}
 			}
@@ -1011,7 +1027,7 @@ func update(ctx context.Context, hm, pos, f MalType) (MalType, error) {
 func _update(ctx context.Context, argMapOrVector, index, f MalType) (MalType, error) {
 	switch argMapOrVector := argMapOrVector.(type) {
 	case HashMap:
-		res, err := Apply(ctx, f, []MalType{argMapOrVector.Val[index.(string)]})
+		res, err := Apply(ctx, f, []MalType{argMapOrVector.Items[index]})
 		if err != nil {
 			return nil, err
 		}
@@ -1047,7 +1063,7 @@ func _updateIn(ctx context.Context, seq MalType, posVector Vector, f MalType) (M
 		var branch MalType
 		switch seq := seq.(type) {
 		case HashMap:
-			branch = seq.Val[index.(string)]
+			branch = seq.Items[index]
 			if branch == nil {
 				branch = HashMap{}
 			}
@@ -1089,7 +1105,7 @@ func _assocIn(argMapOrVector MalType, posVector Vector, newValue MalType) (MalTy
 		var branch MalType
 		switch argMapOrVector := argMapOrVector.(type) {
 		case HashMap:
-			branch = argMapOrVector.Val[index.(string)]
+			branch = argMapOrVector.Items[index]
 			if branch == nil {
 				branch = HashMap{}
 			}
@@ -1107,16 +1123,16 @@ func _assocIn(argMapOrVector MalType, posVector Vector, newValue MalType) (MalTy
 	}
 }
 
-func contains_Q(hm MalType, key string) (bool, error) {
+func contains_Q(hm MalType, key MalType) (bool, error) {
 	if Nil_Q(hm) {
 		return false, nil
 	}
 	switch hm := hm.(type) {
 	case HashMap:
-		_, ok := hm.Val[key]
+		_, ok := hm.Items[key]
 		return ok, nil
 	case Set:
-		_, ok := hm.Val[key]
+		_, ok := hm.Items[key]
 		return ok, nil
 	default:
 		return false, errors.New("get called on non-hash map and a non-set")
@@ -1127,7 +1143,7 @@ func keys(hm MalType) (List, error) {
 	switch hm := hm.(type) {
 	case HashMap:
 		slc := []MalType{}
-		for k := range hm.Val {
+		for k := range hm.Items {
 			slc = append(slc, k)
 		}
 		return List{Val: slc}, nil
@@ -1141,7 +1157,7 @@ func vals(hm MalType) (List, error) {
 		return List{}, errors.New("vals called on non-hash map")
 	}
 	slc := []MalType{}
-	for _, v := range hm.(HashMap).Val {
+	for _, v := range hm.(HashMap).Items {
 		slc = append(slc, v)
 	}
 	return List{Val: slc}, nil
@@ -1242,9 +1258,9 @@ func empty_Q(seq MalType) (bool, error) {
 	case Vector:
 		return len(seq.Val) == 0, nil
 	case HashMap:
-		return len(seq.Val) == 0, nil
+		return len(seq.Items) == 0, nil
 	case Set:
-		return len(seq.Val) == 0, nil
+		return len(seq.Items) == 0, nil
 	case nil:
 		return true, nil
 	default:
@@ -1259,9 +1275,9 @@ func count(seq MalType) (int, error) {
 	case Vector:
 		return len(seq.Val), nil
 	case HashMap:
-		return len(seq.Val), nil
+		return len(seq.Items), nil
 	case Set:
-		return len(seq.Val), nil
+		return len(seq.Items), nil
 	case nil:
 		return 0, nil
 	default:
@@ -1336,19 +1352,19 @@ func conj(a ...MalType) (MalType, error) {
 		}
 		for i := 1; i < len(a); i += 2 {
 			key := a[i]
-			if !Q[string](key) {
-				return nil, errors.New("conj called with non-string key")
+			if !ValidKey(key) {
+				return nil, errors.New("conj called with non-string non-keyword key")
 			}
-			new_hm.Val[key.(string)] = a[i+1]
+			new_hm.Items[key] = a[i+1]
 		}
 		return new_hm, nil
 	case Set:
 		new_s := copy_set(seq)
 		for _, key := range a[1:] {
-			if !Q[string](key) {
-				return nil, errors.New("conj called with non-string key")
+			if !ValidKey(key) {
+				return nil, errors.New("conj called with non-string non-keyword key")
 			}
-			new_s.Val[key.(string)] = struct{}{}
+			new_s.Items[key] = struct{}{}
 		}
 		return new_s, nil
 	default:
@@ -1374,8 +1390,8 @@ func isMapEntry(v MalType) bool {
 // in place. Keys must be strings or keywords, as elsewhere for maps.
 func conjMapEntry(hm HashMap, entry MalType) error {
 	if e, ok := entry.(HashMap); ok {
-		for k, v := range e.Val {
-			hm.Val[k] = v
+		for k, v := range e.Items {
+			hm.Items[k] = v
 		}
 		return nil
 	}
@@ -1384,10 +1400,10 @@ func conjMapEntry(hm HashMap, entry MalType) error {
 		return errors.New("conj: map entry must be a [key value] pair or a map")
 	}
 	key := slc[0]
-	if !Q[string](key) {
-		return errors.New("conj called with non-string key")
+	if !ValidKey(key) {
+		return errors.New("conj called with non-string non-keyword key")
 	}
-	hm.Val[key.(string)] = slc[1]
+	hm.Items[key] = slc[1]
 	return nil
 }
 
@@ -1404,13 +1420,13 @@ func seq(seq MalType) (MalType, error) {
 		}
 		return List{Val: arg.Val}, nil
 	case HashMap:
-		if len(arg.Val) == 0 {
+		if len(arg.Items) == 0 {
 			return nil, nil
 		}
 		slc, _ := GetSlice(arg)
 		return List{Val: slc}, nil
 	case Set:
-		if len(arg.Val) == 0 {
+		if len(arg.Items) == 0 {
 			return nil, nil
 		}
 		slc, _ := GetSlice(arg)
@@ -1438,9 +1454,9 @@ func with_meta(obj, meta MalType) (MalType, error) {
 	case Vector:
 		return Vector{Val: tobj.Val, Meta: meta}, nil
 	case HashMap:
-		return HashMap{Val: tobj.Val, Meta: meta}, nil
+		return HashMap{Items: tobj.Items, Meta: meta}, nil
 	case Set:
-		return Set{Val: tobj.Val, Meta: meta}, nil
+		return Set{Items: tobj.Items, Meta: meta}, nil
 	case Func:
 		return Func{Fn: tobj.Fn, Meta: meta, Doc: tobj.Doc, Arglist: tobj.Arglist, Cursor: tobj.Cursor}, nil
 	case MalFunc:
@@ -1484,7 +1500,7 @@ func docString(v MalType) (MalType, error) {
 		}
 	case MalFunc:
 		if hm, ok := f.Meta.(HashMap); ok {
-			if d, ok := hm.Val["ʞdoc"]; ok {
+			if d, ok := hm.Items[KW("doc")]; ok {
 				return d, nil
 			}
 		}
@@ -1539,17 +1555,20 @@ func split(str, sep string) (Vector, error) {
 }
 
 func rename_keys(data, alternative HashMap) (HashMap, error) {
-	output := map[string]MalType{}
-	for k, v := range data.Val {
-		newKey, ok := alternative.Val[k]
+	output := map[MalType]MalType{}
+	for k, v := range data.Items {
+		newKey, ok := alternative.Items[k]
 		if ok {
-			output[newKey.(string)] = v
+			if !ValidKey(newKey) {
+				return HashMap{}, errors.New("rename-keys: new key must be a string or keyword")
+			}
+			output[newKey] = v
 		} else {
 			output[k] = v
 		}
 	}
 	return HashMap{
-		Val:    output,
+		Items:  output,
 		Meta:   data.Meta,
 		Cursor: data.Cursor,
 	}, nil
@@ -1616,17 +1635,17 @@ func mErge(_hm0, _hm1 MalType) (MalType, error) {
 			return nil, errors.New("expected hash map")
 		}
 	}
-	if hm0.Val == nil && hm1.Val == nil {
+	if hm0.Items == nil && hm1.Items == nil {
 		return nil, nil
 	}
 	merged := HashMap{
-		Val: make(map[string]MalType),
+		Items: make(map[MalType]MalType),
 	}
-	for k, v := range hm0.Val {
-		merged.Val[k] = v
+	for k, v := range hm0.Items {
+		merged.Items[k] = v
 	}
-	for k, v := range hm1.Val {
-		merged.Val[k] = v
+	for k, v := range hm1.Items {
+		merged.Items[k] = v
 	}
 	return merged, nil
 }
@@ -1706,17 +1725,17 @@ func JSON_Decode(obj, bytesIn MalType) (MalType, error) {
 
 func map2hashmap(m map[string]interface{}) HashMap {
 	hm := HashMap{
-		Val:  map[string]MalType{},
-		Meta: nil,
+		Items: map[MalType]MalType{},
+		Meta:  nil,
 	}
 	for k, v := range m {
 		switch v := v.(type) {
 		case map[string]interface{}:
-			hm.Val[k] = map2hashmap(v)
+			hm.Items[k] = map2hashmap(v)
 		case []interface{}:
-			hm.Val[k] = array2vector(v)
+			hm.Items[k] = array2vector(v)
 		default:
-			hm.Val[k] = v
+			hm.Items[k] = v
 		}
 	}
 	return hm

--- a/lib/core/version_test.go
+++ b/lib/core/version_test.go
@@ -5,6 +5,8 @@ import (
 	"runtime/debug"
 	"strings"
 	"testing"
+
+	. "github.com/jig/lisp/types"
 )
 
 // TestModuleVersion checks that a module's version is found whether it is
@@ -49,9 +51,9 @@ func TestVersionBuiltin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("version(): %v", err)
 	}
-	for _, k := range []string{"ʞgo-version", "ʞbuild", "ʞdependencies"} {
-		if _, ok := v.Val[k]; !ok {
-			t.Errorf("version() is missing key %q", k)
+	for _, k := range []Keyword{KW("go-version"), KW("build"), KW("dependencies")} {
+		if _, ok := v.Items[k]; !ok {
+			t.Errorf("version() is missing key :%s", k)
 		}
 	}
 }

--- a/lib/coreextended/coreextended.go
+++ b/lib/coreextended/coreextended.go
@@ -43,10 +43,9 @@ func formatArg(v MalType) any {
 		// float32 is the reader's float type; float64 arrives from Go libs
 		return t
 	case string:
-		if Keyword_Q(t) {
-			return lispArg{t}
-		}
 		return t
+	case Keyword:
+		return lispArg{t}
 	default:
 		if _, ok := t.(fmt.Formatter); ok {
 			return t

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -400,14 +400,14 @@ func gitStatus(rv MalType) (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
-	files := HashMap{Val: map[string]MalType{}}
+	files := HashMap{Items: map[MalType]MalType{}}
 	for path, fs := range status {
-		files.Val[path] = HashMap{Val: map[string]MalType{
+		files.Items[path] = HashMap{Items: map[MalType]MalType{
 			NewKeyword("staging"):  statusKeyword(fs.Staging),
 			NewKeyword("worktree"): statusKeyword(fs.Worktree),
 		}}
 	}
-	return HashMap{Val: map[string]MalType{
+	return HashMap{Items: map[MalType]MalType{
 		NewKeyword("clean"): status.IsClean(),
 		NewKeyword("files"): files,
 	}}, nil
@@ -422,7 +422,7 @@ func gitHead(rv MalType) (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
-	return HashMap{Val: map[string]MalType{
+	return HashMap{Items: map[MalType]MalType{
 		NewKeyword("name"):   head.Name().String(),
 		NewKeyword("branch"): head.Name().Short(),
 		NewKeyword("hash"):   head.Hash().String(),
@@ -481,7 +481,7 @@ func gitBranches(rv MalType) (MalType, error) {
 	defer iter.Close()
 	out := []MalType{}
 	err = iter.ForEach(func(ref *plumbing.Reference) error {
-		out = append(out, HashMap{Val: map[string]MalType{
+		out = append(out, HashMap{Items: map[MalType]MalType{
 			NewKeyword("name"): ref.Name().Short(),
 			NewKeyword("hash"): ref.Hash().String(),
 			NewKeyword("head"): head != nil && ref.Name() == head.Name(),
@@ -551,7 +551,7 @@ func gitRemotes(rv MalType) (MalType, error) {
 		for _, u := range remote.Config().URLs {
 			urls = append(urls, u)
 		}
-		out = append(out, HashMap{Val: map[string]MalType{
+		out = append(out, HashMap{Items: map[MalType]MalType{
 			NewKeyword("name"): remote.Config().Name,
 			NewKeyword("urls"): Vector{Val: urls},
 		}})
@@ -600,7 +600,7 @@ func gitTag(rv MalType, name string, params ...MalType) (MalType, error) {
 			return nil, err
 		}
 	}
-	return HashMap{Val: map[string]MalType{
+	return HashMap{Items: map[MalType]MalType{
 		NewKeyword("name"):      name,
 		NewKeyword("hash"):      ref.Hash().String(),
 		NewKeyword("target"):    hash.String(),
@@ -626,7 +626,7 @@ func gitTags(rv MalType) (MalType, error) {
 			target = tag.Target
 			annotated = true
 		}
-		out = append(out, HashMap{Val: map[string]MalType{
+		out = append(out, HashMap{Items: map[MalType]MalType{
 			NewKeyword("name"):      ref.Name().Short(),
 			NewKeyword("hash"):      ref.Hash().String(),
 			NewKeyword("target"):    target.String(),
@@ -660,7 +660,7 @@ func commitMap(c *object.Commit) MalType {
 	for _, p := range c.ParentHashes {
 		parents = append(parents, p.String())
 	}
-	return HashMap{Val: map[string]MalType{
+	return HashMap{Items: map[MalType]MalType{
 		NewKeyword("hash"):      c.Hash.String(),
 		NewKeyword("message"):   c.Message,
 		NewKeyword("author"):    signatureMap(c.Author),
@@ -671,7 +671,7 @@ func commitMap(c *object.Commit) MalType {
 }
 
 func signatureMap(s object.Signature) MalType {
-	return HashMap{Val: map[string]MalType{
+	return HashMap{Items: map[MalType]MalType{
 		NewKeyword("name"):  s.Name,
 		NewKeyword("email"): s.Email,
 		NewKeyword("when"):  s.When.Format(time.RFC3339),
@@ -702,7 +702,7 @@ func statusKeyword(code gogit.StatusCode) MalType {
 }
 
 // trailingOpts extracts the optional trailing options hashmap.
-func trailingOpts(params []MalType) (map[string]MalType, error) {
+func trailingOpts(params []MalType) (map[MalType]MalType, error) {
 	switch len(params) {
 	case 0:
 		return nil, nil
@@ -711,7 +711,7 @@ func trailingOpts(params []MalType) (map[string]MalType, error) {
 		if !ok {
 			return nil, fmt.Errorf("options must be a map, got %T", params[0])
 		}
-		return hm.Val, nil
+		return hm.Items, nil
 	default:
 		return nil, fmt.Errorf("expected a single options map, got %d arguments", len(params))
 	}
@@ -719,7 +719,7 @@ func trailingOpts(params []MalType) (map[string]MalType, error) {
 
 // optGet finds an option, accepting a keyword key (:name, the idiomatic
 // form) or a plain string key ("name").
-func optGet(o map[string]MalType, name string) (MalType, bool) {
+func optGet(o map[MalType]MalType, name string) (MalType, bool) {
 	if v, ok := o[NewKeyword(name)]; ok {
 		return v, true
 	}
@@ -727,7 +727,7 @@ func optGet(o map[string]MalType, name string) (MalType, bool) {
 	return v, ok
 }
 
-func optString(o map[string]MalType, name string) (string, bool, error) {
+func optString(o map[MalType]MalType, name string) (string, bool, error) {
 	v, ok := optGet(o, name)
 	if !ok || v == nil {
 		return "", false, nil
@@ -739,7 +739,7 @@ func optString(o map[string]MalType, name string) (string, bool, error) {
 	return s, true, nil
 }
 
-func optBool(o map[string]MalType, name string) bool {
+func optBool(o map[MalType]MalType, name string) bool {
 	v, ok := optGet(o, name)
 	if !ok {
 		return false
@@ -748,7 +748,7 @@ func optBool(o map[string]MalType, name string) bool {
 	return ok && b
 }
 
-func optInt(o map[string]MalType, name string, def int) (int, error) {
+func optInt(o map[MalType]MalType, name string, def int) (int, error) {
 	v, ok := optGet(o, name)
 	if !ok || v == nil {
 		return def, nil
@@ -760,7 +760,7 @@ func optInt(o map[string]MalType, name string, def int) (int, error) {
 	return n, nil
 }
 
-func optHashMap(o map[string]MalType, name string) (map[string]MalType, bool, error) {
+func optHashMap(o map[MalType]MalType, name string) (map[MalType]MalType, bool, error) {
 	v, ok := optGet(o, name)
 	if !ok || v == nil {
 		return nil, false, nil
@@ -769,11 +769,11 @@ func optHashMap(o map[string]MalType, name string) (map[string]MalType, bool, er
 	if !ok {
 		return nil, false, fmt.Errorf(":%s must be a map, got %T", name, v)
 	}
-	return hm.Val, true, nil
+	return hm.Items, true, nil
 }
 
 // optSignature builds an author/committer signature from {:name :email}.
-func optSignature(o map[string]MalType, name string) (*object.Signature, error) {
+func optSignature(o map[MalType]MalType, name string) (*object.Signature, error) {
 	m, ok, err := optHashMap(o, name)
 	if err != nil || !ok {
 		return nil, err

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -403,13 +403,13 @@ func gitStatus(rv MalType) (MalType, error) {
 	files := HashMap{Items: map[MalType]MalType{}}
 	for path, fs := range status {
 		files.Items[path] = HashMap{Items: map[MalType]MalType{
-			NewKeyword("staging"):  statusKeyword(fs.Staging),
-			NewKeyword("worktree"): statusKeyword(fs.Worktree),
+			KW("staging"):  statusKeyword(fs.Staging),
+			KW("worktree"): statusKeyword(fs.Worktree),
 		}}
 	}
 	return HashMap{Items: map[MalType]MalType{
-		NewKeyword("clean"): status.IsClean(),
-		NewKeyword("files"): files,
+		KW("clean"): status.IsClean(),
+		KW("files"): files,
 	}}, nil
 }
 
@@ -423,9 +423,9 @@ func gitHead(rv MalType) (MalType, error) {
 		return nil, err
 	}
 	return HashMap{Items: map[MalType]MalType{
-		NewKeyword("name"):   head.Name().String(),
-		NewKeyword("branch"): head.Name().Short(),
-		NewKeyword("hash"):   head.Hash().String(),
+		KW("name"):   head.Name().String(),
+		KW("branch"): head.Name().Short(),
+		KW("hash"):   head.Hash().String(),
 	}}, nil
 }
 
@@ -482,9 +482,9 @@ func gitBranches(rv MalType) (MalType, error) {
 	out := []MalType{}
 	err = iter.ForEach(func(ref *plumbing.Reference) error {
 		out = append(out, HashMap{Items: map[MalType]MalType{
-			NewKeyword("name"): ref.Name().Short(),
-			NewKeyword("hash"): ref.Hash().String(),
-			NewKeyword("head"): head != nil && ref.Name() == head.Name(),
+			KW("name"): ref.Name().Short(),
+			KW("hash"): ref.Hash().String(),
+			KW("head"): head != nil && ref.Name() == head.Name(),
 		}})
 		return nil
 	})
@@ -552,8 +552,8 @@ func gitRemotes(rv MalType) (MalType, error) {
 			urls = append(urls, u)
 		}
 		out = append(out, HashMap{Items: map[MalType]MalType{
-			NewKeyword("name"): remote.Config().Name,
-			NewKeyword("urls"): Vector{Val: urls},
+			KW("name"): remote.Config().Name,
+			KW("urls"): Vector{Val: urls},
 		}})
 	}
 	return Vector{Val: out}, nil
@@ -601,10 +601,10 @@ func gitTag(rv MalType, name string, params ...MalType) (MalType, error) {
 		}
 	}
 	return HashMap{Items: map[MalType]MalType{
-		NewKeyword("name"):      name,
-		NewKeyword("hash"):      ref.Hash().String(),
-		NewKeyword("target"):    hash.String(),
-		NewKeyword("annotated"): annotated,
+		KW("name"):      name,
+		KW("hash"):      ref.Hash().String(),
+		KW("target"):    hash.String(),
+		KW("annotated"): annotated,
 	}}, nil
 }
 
@@ -627,10 +627,10 @@ func gitTags(rv MalType) (MalType, error) {
 			annotated = true
 		}
 		out = append(out, HashMap{Items: map[MalType]MalType{
-			NewKeyword("name"):      ref.Name().Short(),
-			NewKeyword("hash"):      ref.Hash().String(),
-			NewKeyword("target"):    target.String(),
-			NewKeyword("annotated"): annotated,
+			KW("name"):      ref.Name().Short(),
+			KW("hash"):      ref.Hash().String(),
+			KW("target"):    target.String(),
+			KW("annotated"): annotated,
 		}})
 		return nil
 	})
@@ -661,43 +661,43 @@ func commitMap(c *object.Commit) MalType {
 		parents = append(parents, p.String())
 	}
 	return HashMap{Items: map[MalType]MalType{
-		NewKeyword("hash"):      c.Hash.String(),
-		NewKeyword("message"):   c.Message,
-		NewKeyword("author"):    signatureMap(c.Author),
-		NewKeyword("committer"): signatureMap(c.Committer),
-		NewKeyword("parents"):   Vector{Val: parents},
-		NewKeyword("signed"):    c.Signature != "" || c.SignatureSHA256 != "",
+		KW("hash"):      c.Hash.String(),
+		KW("message"):   c.Message,
+		KW("author"):    signatureMap(c.Author),
+		KW("committer"): signatureMap(c.Committer),
+		KW("parents"):   Vector{Val: parents},
+		KW("signed"):    c.Signature != "" || c.SignatureSHA256 != "",
 	}}
 }
 
 func signatureMap(s object.Signature) MalType {
 	return HashMap{Items: map[MalType]MalType{
-		NewKeyword("name"):  s.Name,
-		NewKeyword("email"): s.Email,
-		NewKeyword("when"):  s.When.Format(time.RFC3339),
+		KW("name"):  s.Name,
+		KW("email"): s.Email,
+		KW("when"):  s.When.Format(time.RFC3339),
 	}}
 }
 
 func statusKeyword(code gogit.StatusCode) MalType {
 	switch code {
 	case gogit.Unmodified:
-		return NewKeyword("unmodified")
+		return KW("unmodified")
 	case gogit.Untracked:
-		return NewKeyword("untracked")
+		return KW("untracked")
 	case gogit.Modified:
-		return NewKeyword("modified")
+		return KW("modified")
 	case gogit.Added:
-		return NewKeyword("added")
+		return KW("added")
 	case gogit.Deleted:
-		return NewKeyword("deleted")
+		return KW("deleted")
 	case gogit.Renamed:
-		return NewKeyword("renamed")
+		return KW("renamed")
 	case gogit.Copied:
-		return NewKeyword("copied")
+		return KW("copied")
 	case gogit.UpdatedButUnmerged:
-		return NewKeyword("unmerged")
+		return KW("unmerged")
 	default:
-		return NewKeyword("unknown")
+		return KW("unknown")
 	}
 }
 
@@ -720,7 +720,7 @@ func trailingOpts(params []MalType) (map[MalType]MalType, error) {
 // optGet finds an option, accepting a keyword key (:name, the idiomatic
 // form) or a plain string key ("name").
 func optGet(o map[MalType]MalType, name string) (MalType, bool) {
-	if v, ok := o[NewKeyword(name)]; ok {
+	if v, ok := o[KW(name)]; ok {
 		return v, true
 	}
 	v, ok := o[name]

--- a/lib/git/remote.go
+++ b/lib/git/remote.go
@@ -25,7 +25,7 @@ import (
 // for SSH URLs go-git itself falls back to agent auth with the URL's
 // user. When no host-key option is given go-git uses the default
 // known_hosts files — the secure default.
-func clientOpts(o map[string]MalType) ([]client.Option, error) {
+func clientOpts(o map[MalType]MalType) ([]client.Option, error) {
 	v, ok := optGet(o, "auth")
 	if !ok || v == nil {
 		return nil, nil
@@ -41,7 +41,7 @@ func clientOpts(o map[string]MalType) ([]client.Option, error) {
 	if !ok {
 		return nil, fmt.Errorf(":auth must be :ssh-agent or a map, got %T", v)
 	}
-	auth := hm.Val
+	auth := hm.Items
 	if optBool(auth, "ssh-agent") {
 		user, _, err := optString(auth, "user")
 		if err != nil {
@@ -110,7 +110,7 @@ func clientOpts(o map[string]MalType) ([]client.Option, error) {
 }
 
 // refSpecs converts a :refspecs vector of strings.
-func refSpecs(o map[string]MalType, name string) ([]gitcfg.RefSpec, error) {
+func refSpecs(o map[MalType]MalType, name string) ([]gitcfg.RefSpec, error) {
 	v, ok := optGet(o, name)
 	if !ok || v == nil {
 		return nil, nil

--- a/lib/git/remote.go
+++ b/lib/git/remote.go
@@ -30,7 +30,7 @@ func clientOpts(o map[MalType]MalType) ([]client.Option, error) {
 	if !ok || v == nil {
 		return nil, nil
 	}
-	if v == NewKeyword("ssh-agent") {
+	if v == KW("ssh-agent") {
 		auth, err := transportssh.NewSSHAgentAuth(transportssh.DefaultUsername)
 		if err != nil {
 			return nil, err
@@ -137,10 +137,10 @@ func refSpecs(o map[MalType]MalType, name string) ([]gitcfg.RefSpec, error) {
 // upToDate maps go-git's already-up-to-date sentinel to a normal value.
 func upToDate(err error) (MalType, error) {
 	if err == nil {
-		return NewKeyword("ok"), nil
+		return KW("ok"), nil
 	}
 	if errors.Is(err, gogit.NoErrAlreadyUpToDate) {
-		return NewKeyword("up-to-date"), nil
+		return KW("up-to-date"), nil
 	}
 	return nil, err
 }

--- a/lib/git/sign.go
+++ b/lib/git/sign.go
@@ -314,7 +314,7 @@ func signerOf(v MalType) string {
 	if !ok {
 		return ""
 	}
-	s, _ := m.Items[NewKeyword("signer")].(string)
+	s, _ := m.Items[KW("signer")].(string)
 	return s
 }
 
@@ -339,11 +339,11 @@ func verifySignature(obj payloadEncoder, armored, allowedKeys string) (MalType, 
 		return nil, err
 	}
 	return HashMap{Items: map[MalType]MalType{
-		NewKeyword("valid"):          true,
-		NewKeyword("key-type"):       pub.Type(),
-		NewKeyword("fingerprint"):    gossh.FingerprintSHA256(pub),
-		NewKeyword("hash-algorithm"): string(sig.HashAlgorithm),
-		NewKeyword("signer"):         comment,
+		KW("valid"):          true,
+		KW("key-type"):       pub.Type(),
+		KW("fingerprint"):    gossh.FingerprintSHA256(pub),
+		KW("hash-algorithm"): string(sig.HashAlgorithm),
+		KW("signer"):         comment,
 	}}, nil
 }
 

--- a/lib/git/sign.go
+++ b/lib/git/sign.go
@@ -314,7 +314,7 @@ func signerOf(v MalType) string {
 	if !ok {
 		return ""
 	}
-	s, _ := m.Val[NewKeyword("signer")].(string)
+	s, _ := m.Items[NewKeyword("signer")].(string)
 	return s
 }
 
@@ -338,7 +338,7 @@ func verifySignature(obj payloadEncoder, armored, allowedKeys string) (MalType, 
 	if err := sshsig.Verify(rd, sig, pub, sig.HashAlgorithm, gitNamespace); err != nil {
 		return nil, err
 	}
-	return HashMap{Val: map[string]MalType{
+	return HashMap{Items: map[MalType]MalType{
 		NewKeyword("valid"):          true,
 		NewKeyword("key-type"):       pub.Type(),
 		NewKeyword("fingerprint"):    gossh.FingerprintSHA256(pub),

--- a/lib/git/sign_internal_test.go
+++ b/lib/git/sign_internal_test.go
@@ -95,7 +95,7 @@ func TestClientOpts(t *testing.T) {
 		for i := 0; i < len(kv); i += 2 {
 			auth.Items[kv[i]] = kv[i+1]
 		}
-		return map[MalType]MalType{NewKeyword("auth"): auth}
+		return map[MalType]MalType{KW("auth"): auth}
 	}
 
 	// absent :auth → no options
@@ -104,10 +104,10 @@ func TestClientOpts(t *testing.T) {
 	}
 	// bad shapes error
 	for name, o := range map[string]map[MalType]MalType{
-		"non-map":    {NewKeyword("auth"): 42},
+		"non-map":    {KW("auth"): 42},
 		"empty map":  opt(),
-		"bad ssh":    opt(NewKeyword("ssh-key"), "not a pem"),
-		"typed keys": opt(NewKeyword("username"), 7),
+		"bad ssh":    opt(KW("ssh-key"), "not a pem"),
+		"typed keys": opt(KW("username"), 7),
 	} {
 		if _, err := clientOpts(o); err == nil {
 			t.Errorf("%s: expected an error", name)
@@ -115,9 +115,9 @@ func TestClientOpts(t *testing.T) {
 	}
 	// valid shapes yield exactly one client option
 	for name, o := range map[string]map[MalType]MalType{
-		"basic":  opt(NewKeyword("username"), "u", NewKeyword("password"), "p"),
-		"token":  opt(NewKeyword("token"), "t"),
-		"bearer": opt(NewKeyword("bearer"), "t"),
+		"basic":  opt(KW("username"), "u", KW("password"), "p"),
+		"token":  opt(KW("token"), "t"),
+		"bearer": opt(KW("bearer"), "t"),
 	} {
 		opts, err := clientOpts(o)
 		if err != nil || len(opts) != 1 {

--- a/lib/git/sign_internal_test.go
+++ b/lib/git/sign_internal_test.go
@@ -90,20 +90,20 @@ func TestTamperedPayload(t *testing.T) {
 }
 
 func TestClientOpts(t *testing.T) {
-	opt := func(kv ...MalType) map[string]MalType {
-		auth := HashMap{Val: map[string]MalType{}}
+	opt := func(kv ...MalType) map[MalType]MalType {
+		auth := HashMap{Items: map[MalType]MalType{}}
 		for i := 0; i < len(kv); i += 2 {
-			auth.Val[kv[i].(string)] = kv[i+1]
+			auth.Items[kv[i]] = kv[i+1]
 		}
-		return map[string]MalType{NewKeyword("auth"): auth}
+		return map[MalType]MalType{NewKeyword("auth"): auth}
 	}
 
 	// absent :auth → no options
-	if opts, err := clientOpts(map[string]MalType{}); err != nil || opts != nil {
+	if opts, err := clientOpts(map[MalType]MalType{}); err != nil || opts != nil {
 		t.Fatalf("no auth: got %v, %v", opts, err)
 	}
 	// bad shapes error
-	for name, o := range map[string]map[string]MalType{
+	for name, o := range map[string]map[MalType]MalType{
 		"non-map":    {NewKeyword("auth"): 42},
 		"empty map":  opt(),
 		"bad ssh":    opt(NewKeyword("ssh-key"), "not a pem"),
@@ -114,7 +114,7 @@ func TestClientOpts(t *testing.T) {
 		}
 	}
 	// valid shapes yield exactly one client option
-	for name, o := range map[string]map[string]MalType{
+	for name, o := range map[string]map[MalType]MalType{
 		"basic":  opt(NewKeyword("username"), "u", NewKeyword("password"), "p"),
 		"token":  opt(NewKeyword("token"), "t"),
 		"bearer": opt(NewKeyword("bearer"), "t"),

--- a/lib/integrity/integrity.go
+++ b/lib/integrity/integrity.go
@@ -86,8 +86,8 @@ func ed25519_generate() (MalType, error) {
 		return nil, err
 	}
 	return HashMap{Items: map[MalType]MalType{
-		NewKeyword("public"):  base64.StdEncoding.EncodeToString(pub),
-		NewKeyword("private"): base64.StdEncoding.EncodeToString(priv),
+		KW("public"):  base64.StdEncoding.EncodeToString(pub),
+		KW("private"): base64.StdEncoding.EncodeToString(priv),
 	}}, nil
 }
 

--- a/lib/integrity/integrity.go
+++ b/lib/integrity/integrity.go
@@ -85,7 +85,7 @@ func ed25519_generate() (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
-	return HashMap{Val: map[string]MalType{
+	return HashMap{Items: map[MalType]MalType{
 		NewKeyword("public"):  base64.StdEncoding.EncodeToString(pub),
 		NewKeyword("private"): base64.StdEncoding.EncodeToString(priv),
 	}}, nil

--- a/lib/require/require.go
+++ b/lib/require/require.go
@@ -237,19 +237,18 @@ func (l *moduleLoader) evalModule(ctx context.Context, absPath string) (types.En
 }
 
 // parseRequireOptions handles the optional `:as "alias"` and
-// `:refer ["name" …]` argument pairs. Keywords arrive from the reader
-// as strings with the "ʞ" prefix.
+// `:refer ["name" …]` argument pairs.
 func parseRequireOptions(module string, opts []types.MalType) (prefix string, refers []string, referAll bool, err error) {
 	prefix = module
 	for i := 0; i < len(opts); i += 2 {
-		key, ok := opts[i].(string)
-		if !ok || !strings.HasPrefix(key, "ʞ") {
+		key, ok := opts[i].(types.Keyword)
+		if !ok {
 			return "", nil, false, fmt.Errorf("require: expected :as or :refer, got %v", opts[i])
 		}
 		if i+1 >= len(opts) {
-			return "", nil, false, fmt.Errorf("require: %s requires a value", ":"+strings.TrimPrefix(key, "ʞ"))
+			return "", nil, false, fmt.Errorf("require: :%s requires a value", key)
 		}
-		switch strings.TrimPrefix(key, "ʞ") {
+		switch key {
 		case "as":
 			alias, ok := opts[i+1].(string)
 			if !ok || alias == "" {
@@ -258,7 +257,7 @@ func parseRequireOptions(module string, opts []types.MalType) (prefix string, re
 			prefix = alias
 		case "refer":
 			// :refer :all imports every definition of the module unqualified.
-			if kw, ok := opts[i+1].(string); ok && kw == types.NewKeyword("all") {
+			if kw, ok := opts[i+1].(types.Keyword); ok && kw == types.KW("all") {
 				referAll = true
 				continue
 			}
@@ -274,7 +273,7 @@ func parseRequireOptions(module string, opts []types.MalType) (prefix string, re
 				refers = append(refers, name)
 			}
 		default:
-			return "", nil, false, fmt.Errorf("require: unknown option :%s", strings.TrimPrefix(key, "ʞ"))
+			return "", nil, false, fmt.Errorf("require: unknown option :%s", key)
 		}
 	}
 	return prefix, refers, referAll, nil

--- a/lib/sql/sql.go
+++ b/lib/sql/sql.go
@@ -130,17 +130,17 @@ func sqlExec(ctx context.Context, target MalType, query string, params ...MalTyp
 	if err != nil {
 		return nil, err
 	}
-	out := HashMap{Val: map[string]MalType{}}
+	out := HashMap{Items: map[MalType]MalType{}}
 	if ra, err := res.RowsAffected(); err == nil {
-		out.Val[NewKeyword("rows-affected")] = int(ra)
+		out.Items[NewKeyword("rows-affected")] = int(ra)
 	} else {
-		out.Val[NewKeyword("rows-affected")] = nil
+		out.Items[NewKeyword("rows-affected")] = nil
 	}
 	if li, err := res.LastInsertId(); err == nil {
-		out.Val[NewKeyword("last-insert-id")] = int(li)
+		out.Items[NewKeyword("last-insert-id")] = int(li)
 	} else {
 		// Not all drivers (e.g. PostgreSQL) support LastInsertId; use RETURNING.
-		out.Val[NewKeyword("last-insert-id")] = nil
+		out.Items[NewKeyword("last-insert-id")] = nil
 	}
 	return out, nil
 }
@@ -218,9 +218,9 @@ func rowsToVector(rows *stdsql.Rows) (MalType, error) {
 		if err := rows.Scan(ptrs...); err != nil {
 			return nil, err
 		}
-		row := HashMap{Val: make(map[string]MalType, len(cols))}
+		row := HashMap{Items: make(map[MalType]MalType, len(cols))}
 		for i, col := range cols {
-			row.Val[NewKeyword(col)] = fromDriver(cells[i])
+			row.Items[NewKeyword(col)] = fromDriver(cells[i])
 		}
 		out = append(out, row)
 	}
@@ -263,10 +263,9 @@ func toDriver(v MalType) any {
 	switch t := v.(type) {
 	case nil:
 		return nil
+	case Keyword:
+		return string(t)
 	case string:
-		if Keyword_Q(t) {
-			return t[len("ʞ"):]
-		}
 		return t
 	default:
 		return t // int, float64, bool, []byte pass through
@@ -275,7 +274,7 @@ func toDriver(v MalType) any {
 
 // lookup finds a named parameter, accepting either a keyword key (:name,
 // the idiomatic form) or a plain string key ("name").
-func lookup(args map[string]MalType, name string) (MalType, bool) {
+func lookup(args map[MalType]MalType, name string) (MalType, bool) {
 	if v, ok := args[NewKeyword(name)]; ok {
 		return v, true
 	}
@@ -284,7 +283,7 @@ func lookup(args map[string]MalType, name string) (MalType, bool) {
 }
 
 // namedArgs extracts the optional trailing parameter map.
-func namedArgs(params []MalType) (map[string]MalType, error) {
+func namedArgs(params []MalType) (map[MalType]MalType, error) {
 	switch len(params) {
 	case 0:
 		return nil, nil
@@ -293,7 +292,7 @@ func namedArgs(params []MalType) (map[string]MalType, error) {
 		if !ok {
 			return nil, fmt.Errorf("SQL parameters must be a map, got %T", params[0])
 		}
-		return hm.Val, nil
+		return hm.Items, nil
 	default:
 		return nil, fmt.Errorf("expected a single parameter map, got %d arguments", len(params))
 	}

--- a/lib/sql/sql.go
+++ b/lib/sql/sql.go
@@ -132,15 +132,15 @@ func sqlExec(ctx context.Context, target MalType, query string, params ...MalTyp
 	}
 	out := HashMap{Items: map[MalType]MalType{}}
 	if ra, err := res.RowsAffected(); err == nil {
-		out.Items[NewKeyword("rows-affected")] = int(ra)
+		out.Items[KW("rows-affected")] = int(ra)
 	} else {
-		out.Items[NewKeyword("rows-affected")] = nil
+		out.Items[KW("rows-affected")] = nil
 	}
 	if li, err := res.LastInsertId(); err == nil {
-		out.Items[NewKeyword("last-insert-id")] = int(li)
+		out.Items[KW("last-insert-id")] = int(li)
 	} else {
 		// Not all drivers (e.g. PostgreSQL) support LastInsertId; use RETURNING.
-		out.Items[NewKeyword("last-insert-id")] = nil
+		out.Items[KW("last-insert-id")] = nil
 	}
 	return out, nil
 }
@@ -220,7 +220,7 @@ func rowsToVector(rows *stdsql.Rows) (MalType, error) {
 		}
 		row := HashMap{Items: make(map[MalType]MalType, len(cols))}
 		for i, col := range cols {
-			row.Items[NewKeyword(col)] = fromDriver(cells[i])
+			row.Items[KW(col)] = fromDriver(cells[i])
 		}
 		out = append(out, row)
 	}
@@ -275,7 +275,7 @@ func toDriver(v MalType) any {
 // lookup finds a named parameter, accepting either a keyword key (:name,
 // the idiomatic form) or a plain string key ("name").
 func lookup(args map[MalType]MalType, name string) (MalType, bool) {
-	if v, ok := args[NewKeyword(name)]; ok {
+	if v, ok := args[KW(name)]; ok {
 		return v, true
 	}
 	v, ok := args[name]

--- a/lib/sql/sql_test.go
+++ b/lib/sql/sql_test.go
@@ -13,12 +13,12 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-func kw(name string) string { return types.NewKeyword(name) }
+func kw(name string) types.Keyword { return types.KW(name) }
 
 func paramMap(kv map[string]types.MalType) []types.MalType {
-	hm := types.HashMap{Val: map[string]types.MalType{}}
+	hm := types.HashMap{Items: map[types.MalType]types.MalType{}}
 	for k, v := range kv {
-		hm.Val[kw(k)] = v
+		hm.Items[kw(k)] = v
 	}
 	return []types.MalType{hm}
 }
@@ -120,7 +120,7 @@ func TestEndToEnd(t *testing.T) {
 	if !ok {
 		t.Fatalf("sql-exec returned %T, want HashMap", ins)
 	}
-	if ra := hm.Val[kw("rows-affected")]; ra != 1 {
+	if ra := hm.Items[kw("rows-affected")]; ra != 1 {
 		t.Errorf("rows-affected = %v, want 1", ra)
 	}
 
@@ -136,13 +136,13 @@ func TestEndToEnd(t *testing.T) {
 		t.Fatalf("got %d rows, want 2", len(vec.Val))
 	}
 	first := vec.Val[0].(types.HashMap)
-	if first.Val[kw("id")] != 1 || first.Val[kw("name")] != "ada" {
-		t.Errorf("row 0 = %v, want {:id 1 :name ada}", first.Val)
+	if first.Items[kw("id")] != 1 || first.Items[kw("name")] != "ada" {
+		t.Errorf("row 0 = %v, want {:id 1 :name ada}", first.Items)
 	}
 
 	// query-one with a named param
 	one := eval(t, ns, `(sql-query-one db "SELECT name FROM acct WHERE id = :id" {:id 2})`)
-	if got := one.(types.HashMap).Val[kw("name")]; got != "bob" {
+	if got := one.(types.HashMap).Items[kw("name")]; got != "bob" {
 		t.Errorf("query-one name = %v, want bob", got)
 	}
 

--- a/lib/system/system.go
+++ b/lib/system/system.go
@@ -149,7 +149,7 @@ func spit(fileName, contents string, opts ...MalType) error {
 	appendMode := false
 	for i := 0; i < len(opts); i += 2 {
 		switch opts[i] {
-		case NewKeyword("append"):
+		case KW("append"):
 			b, ok := opts[i+1].(bool)
 			if !ok {
 				return fmt.Errorf("spit: :append expects a boolean (it was %T)", opts[i+1])

--- a/lib/term/term.go
+++ b/lib/term/term.go
@@ -119,18 +119,17 @@ var attrs = []struct {
 // as SGR codes; base is 38 for foreground, 48 for background.
 func colorCodes(v MalType, base int) ([]string, error) {
 	switch t := v.(type) {
-	case string:
-		if Keyword_Q(t) {
-			name := t[len("ʞ"):]
-			code, ok := namedColors[name]
-			if !ok {
-				return nil, fmt.Errorf("unknown color :%s", name)
-			}
-			if base == 48 {
-				code += 10
-			}
-			return []string{strconv.Itoa(code)}, nil
+	case Keyword:
+		name := string(t)
+		code, ok := namedColors[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown color :%s", name)
 		}
+		if base == 48 {
+			code += 10
+		}
+		return []string{strconv.Itoa(code)}, nil
+	case string:
 		if len(t) == 7 && t[0] == '#' {
 			r, errR := strconv.ParseUint(t[1:3], 16, 8)
 			g, errG := strconv.ParseUint(t[3:5], 16, 8)
@@ -156,7 +155,7 @@ func termStyle(s string, opts MalType) (MalType, error) {
 	if !ok {
 		return nil, fmt.Errorf("term-style: options must be a map, got %T", opts)
 	}
-	codes, err := sgrCodes(hm.Val)
+	codes, err := sgrCodes(hm.Items)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +167,7 @@ func termStyle(s string, opts MalType) (MalType, error) {
 
 // sgrCodes translates the options map into an SGR code sequence. Unknown
 // options error, so typos do not silently produce unstyled output.
-func sgrCodes(opts map[string]MalType) ([]string, error) {
+func sgrCodes(opts map[MalType]MalType) ([]string, error) {
 	known := map[string]bool{"fg": true, "bg": true}
 	var codes []string
 	for _, a := range attrs {
@@ -198,9 +197,9 @@ func sgrCodes(opts map[string]MalType) ([]string, error) {
 		codes = append(codes, c...)
 	}
 	for k := range opts {
-		name := k
-		if Keyword_Q(k) {
-			name = k[len("ʞ"):]
+		name, _ := k.(string)
+		if kw, ok := k.(Keyword); ok {
+			name = string(kw)
 		}
 		if !known[name] {
 			return nil, fmt.Errorf("term-style: unknown option :%s", name)

--- a/lib/term/term.go
+++ b/lib/term/term.go
@@ -172,7 +172,7 @@ func sgrCodes(opts map[MalType]MalType) ([]string, error) {
 	var codes []string
 	for _, a := range attrs {
 		known[a.name] = true
-		if v, ok := opts[NewKeyword(a.name)]; ok {
+		if v, ok := opts[KW(a.name)]; ok {
 			b, isBool := v.(bool)
 			if !isBool {
 				return nil, fmt.Errorf(":%s must be a boolean, got %T", a.name, v)
@@ -182,14 +182,14 @@ func sgrCodes(opts map[MalType]MalType) ([]string, error) {
 			}
 		}
 	}
-	if v, ok := opts[NewKeyword("fg")]; ok && v != nil {
+	if v, ok := opts[KW("fg")]; ok && v != nil {
 		c, err := colorCodes(v, 38)
 		if err != nil {
 			return nil, err
 		}
 		codes = append(codes, c...)
 	}
-	if v, ok := opts[NewKeyword("bg")]; ok && v != nil {
+	if v, ok := opts[KW("bg")]; ok && v != nil {
 		c, err := colorCodes(v, 48)
 		if err != nil {
 			return nil, err

--- a/lib/test/test.go
+++ b/lib/test/test.go
@@ -166,28 +166,28 @@ func testsAsData(tests []*Test) MalType {
 		checks := make([]MalType, 0, len(t.Checks))
 		for _, c := range t.Checks {
 			m := map[MalType]MalType{
-				NewKeyword("form"): c.Form,
-				NewKeyword("ok"):   c.OK,
+				KW("form"): c.Form,
+				KW("ok"):   c.OK,
 			}
 			if c.Err != "" {
-				m[NewKeyword("error")] = c.Err
+				m[KW("error")] = c.Err
 			}
 			if !c.OK && c.Expected != "" {
-				m[NewKeyword("expected")] = c.Expected
-				m[NewKeyword("actual")] = c.Actual
+				m[KW("expected")] = c.Expected
+				m[KW("actual")] = c.Actual
 			}
 			if c.Message != "" {
-				m[NewKeyword("message")] = c.Message
+				m[KW("message")] = c.Message
 			}
 			checks = append(checks, HashMap{Items: m})
 		}
 		m := map[MalType]MalType{
-			NewKeyword("name"):   t.Name,
-			NewKeyword("ok"):     t.OK(),
-			NewKeyword("checks"): Vector{Val: checks},
+			KW("name"):   t.Name,
+			KW("ok"):     t.OK(),
+			KW("checks"): Vector{Val: checks},
 		}
 		if t.Err != "" {
-			m[NewKeyword("error")] = t.Err
+			m[KW("error")] = t.Err
 		}
 		out = append(out, HashMap{Items: m})
 	}

--- a/lib/test/test.go
+++ b/lib/test/test.go
@@ -165,7 +165,7 @@ func testsAsData(tests []*Test) MalType {
 	for _, t := range tests {
 		checks := make([]MalType, 0, len(t.Checks))
 		for _, c := range t.Checks {
-			m := map[string]MalType{
+			m := map[MalType]MalType{
 				NewKeyword("form"): c.Form,
 				NewKeyword("ok"):   c.OK,
 			}
@@ -179,9 +179,9 @@ func testsAsData(tests []*Test) MalType {
 			if c.Message != "" {
 				m[NewKeyword("message")] = c.Message
 			}
-			checks = append(checks, HashMap{Val: m})
+			checks = append(checks, HashMap{Items: m})
 		}
-		m := map[string]MalType{
+		m := map[MalType]MalType{
 			NewKeyword("name"):   t.Name,
 			NewKeyword("ok"):     t.OK(),
 			NewKeyword("checks"): Vector{Val: checks},
@@ -189,7 +189,7 @@ func testsAsData(tests []*Test) MalType {
 		if t.Err != "" {
 			m[NewKeyword("error")] = t.Err
 		}
-		out = append(out, HashMap{Val: m})
+		out = append(out, HashMap{Items: m})
 	}
 	return Vector{Val: out}
 }
@@ -408,7 +408,7 @@ func ExpandAre(argv MalType, expr MalType, rows MalType) (MalType, error) {
 	}
 	forms := []MalType{Symbol{Val: "do"}}
 	for i := 0; i < len(vals); i += len(syms) {
-		subst := map[string]MalType{}
+		subst := map[MalType]MalType{}
 		for j, name := range syms {
 			subst[name] = vals[i+j]
 		}
@@ -418,7 +418,7 @@ func ExpandAre(argv MalType, expr MalType, rows MalType) (MalType, error) {
 }
 
 // substitute returns expr with every symbol found in subst replaced.
-func substitute(expr MalType, subst map[string]MalType) MalType {
+func substitute(expr MalType, subst map[MalType]MalType) MalType {
 	switch e := expr.(type) {
 	case Symbol:
 		if v, ok := subst[e.Val]; ok {
@@ -438,11 +438,11 @@ func substitute(expr MalType, subst map[string]MalType) MalType {
 		}
 		return Vector{Val: out, Cursor: e.Cursor}
 	case HashMap:
-		out := make(map[string]MalType, len(e.Val))
-		for k, v := range e.Val {
+		out := make(map[MalType]MalType, len(e.Items))
+		for k, v := range e.Items {
 			out[k] = substitute(v, subst)
 		}
-		return HashMap{Val: out, Cursor: e.Cursor}
+		return HashMap{Items: out, Cursor: e.Cursor}
 	default:
 		return expr
 	}

--- a/lib/web/jwt_test.go
+++ b/lib/web/jwt_test.go
@@ -48,7 +48,7 @@ func TestVerifyJWT(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config := HashMap{Val: map[string]MalType{
+	config := HashMap{Items: map[MalType]MalType{
 		NewKeyword("jwks-uri"): srv.URL,
 		NewKeyword("issuer"):   issuer,
 		NewKeyword("audience"): audience,
@@ -62,24 +62,24 @@ func TestVerifyJWT(t *testing.T) {
 	if !ok {
 		t.Fatalf("claims not a hash-map: %T", claims)
 	}
-	if got := hm.Val[NewKeyword("sub")]; got != "user-123" {
+	if got := hm.Items[NewKeyword("sub")]; got != "user-123" {
 		t.Fatalf(":sub = %v", got)
 	}
-	if got := hm.Val[NewKeyword("preferred_username")]; got != "alice" {
+	if got := hm.Items[NewKeyword("preferred_username")]; got != "alice" {
 		t.Fatalf(":preferred_username = %v", got)
 	}
 	// nested claims convert too
-	ra, ok := hm.Val[NewKeyword("realm_access")].(HashMap)
+	ra, ok := hm.Items[NewKeyword("realm_access")].(HashMap)
 	if !ok {
 		t.Fatalf("realm_access not a hash-map")
 	}
-	roles, ok := ra.Val[NewKeyword("roles")].(Vector)
+	roles, ok := ra.Items[NewKeyword("roles")].(Vector)
 	if !ok || len(roles.Val) != 2 || roles.Val[0] != "admin" {
-		t.Fatalf("roles = %v", ra.Val[NewKeyword("roles")])
+		t.Fatalf("roles = %v", ra.Items[NewKeyword("roles")])
 	}
 
 	// a wrong audience is rejected
-	badCfg := HashMap{Val: map[string]MalType{
+	badCfg := HashMap{Items: map[MalType]MalType{
 		NewKeyword("jwks-uri"): srv.URL,
 		NewKeyword("audience"): "someone-else",
 	}}

--- a/lib/web/jwt_test.go
+++ b/lib/web/jwt_test.go
@@ -49,9 +49,9 @@ func TestVerifyJWT(t *testing.T) {
 	}
 
 	config := HashMap{Items: map[MalType]MalType{
-		NewKeyword("jwks-uri"): srv.URL,
-		NewKeyword("issuer"):   issuer,
-		NewKeyword("audience"): audience,
+		KW("jwks-uri"): srv.URL,
+		KW("issuer"):   issuer,
+		KW("audience"): audience,
 	}}
 
 	claims, err := web.VerifyJWT(signed, config)
@@ -62,26 +62,26 @@ func TestVerifyJWT(t *testing.T) {
 	if !ok {
 		t.Fatalf("claims not a hash-map: %T", claims)
 	}
-	if got := hm.Items[NewKeyword("sub")]; got != "user-123" {
+	if got := hm.Items[KW("sub")]; got != "user-123" {
 		t.Fatalf(":sub = %v", got)
 	}
-	if got := hm.Items[NewKeyword("preferred_username")]; got != "alice" {
+	if got := hm.Items[KW("preferred_username")]; got != "alice" {
 		t.Fatalf(":preferred_username = %v", got)
 	}
 	// nested claims convert too
-	ra, ok := hm.Items[NewKeyword("realm_access")].(HashMap)
+	ra, ok := hm.Items[KW("realm_access")].(HashMap)
 	if !ok {
 		t.Fatalf("realm_access not a hash-map")
 	}
-	roles, ok := ra.Items[NewKeyword("roles")].(Vector)
+	roles, ok := ra.Items[KW("roles")].(Vector)
 	if !ok || len(roles.Val) != 2 || roles.Val[0] != "admin" {
-		t.Fatalf("roles = %v", ra.Items[NewKeyword("roles")])
+		t.Fatalf("roles = %v", ra.Items[KW("roles")])
 	}
 
 	// a wrong audience is rejected
 	badCfg := HashMap{Items: map[MalType]MalType{
-		NewKeyword("jwks-uri"): srv.URL,
-		NewKeyword("audience"): "someone-else",
+		KW("jwks-uri"): srv.URL,
+		KW("audience"): "someone-else",
 	}}
 	if _, err := web.VerifyJWT(signed, badCfg); err == nil {
 		t.Fatal("expected audience mismatch to fail")

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -138,8 +138,7 @@ func jsonToMal(v any) MalType {
 // malToJSON converts Lisp data to a Go value ready for json.Marshal,
 // producing clean JSON for HTTP clients: keyword map keys and keyword
 // values lose their sigil (:id → "id", :active → "active"), since JSON
-// has no keyword type. This is what a REST client expects, unlike the
-// core json-encode which preserves keywords for lossless round-tripping.
+// has no keyword type — the same convention core's json-encode follows.
 func malToJSON(v MalType) any {
 	switch v := v.(type) {
 	case Keyword:
@@ -208,13 +207,13 @@ func requestMap(r *http.Request) (HashMap, error) {
 	}
 
 	m := map[MalType]MalType{
-		kw("method"):      NewKeyword(strings.ToLower(r.Method)),
+		kw("method"):      KW(strings.ToLower(r.Method)),
 		kw("uri"):         r.URL.Path,
 		kw("query"):       HashMap{Items: query},
 		kw("headers"):     HashMap{Items: headers},
 		kw("body"):        string(body),
 		kw("remote-addr"): r.RemoteAddr,
-		kw("scheme"):      NewKeyword(scheme),
+		kw("scheme"):      KW(scheme),
 		kw("protocol"):    r.Proto,
 		kw("path-params"): HashMap{Items: map[MalType]MalType{}},
 	}

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -45,7 +45,20 @@ func HeaderWeb() string { return headerWeb }
 
 // --- value helpers -------------------------------------------------------
 
-func kw(s string) string { return NewKeyword(s) }
+func kw(s string) Keyword { return KW(s) }
+
+// kwName returns a keyword's name (:get → "get"), a string verbatim,
+// and anything else rendered via toStr.
+func kwName(v MalType) string {
+	switch v := v.(type) {
+	case Keyword:
+		return string(v)
+	case string:
+		return v
+	default:
+		return toStr(v)
+	}
+}
 
 // hget reads a keyword-keyed value from a hash-map.
 func hget(m MalType, key string) (MalType, bool) {
@@ -53,7 +66,7 @@ func hget(m MalType, key string) (MalType, bool) {
 	if !ok {
 		return nil, false
 	}
-	v, ok := hm.Val[kw(key)]
+	v, ok := hm.Items[kw(key)]
 	return v, ok
 }
 
@@ -89,8 +102,8 @@ func toStr(v MalType) string {
 
 // headerName turns a hash-map key (a plain string or a keyword) into an
 // HTTP header name.
-func headerName(k string) string {
-	return http.CanonicalHeaderKey(strings.TrimPrefix(k, "ʞ"))
+func headerName(k MalType) string {
+	return http.CanonicalHeaderKey(kwName(k))
 }
 
 // --- JSON <-> Lisp (for JWT claims) --------------------------------------
@@ -101,11 +114,11 @@ func headerName(k string) string {
 func jsonToMal(v any) MalType {
 	switch v := v.(type) {
 	case map[string]any:
-		out := make(map[string]MalType, len(v))
+		out := make(map[MalType]MalType, len(v))
 		for k, val := range v {
 			out[kw(k)] = jsonToMal(val)
 		}
-		return HashMap{Val: out}
+		return HashMap{Items: out}
 	case []any:
 		out := make([]MalType, len(v))
 		for i, e := range v {
@@ -129,12 +142,14 @@ func jsonToMal(v any) MalType {
 // core json-encode which preserves keywords for lossless round-tripping.
 func malToJSON(v MalType) any {
 	switch v := v.(type) {
+	case Keyword:
+		return string(v)
 	case string:
-		return strings.TrimPrefix(v, "ʞ")
+		return v
 	case HashMap:
-		m := make(map[string]any, len(v.Val))
-		for k, val := range v.Val {
-			m[strings.TrimPrefix(k, "ʞ")] = malToJSON(val)
+		m := make(map[string]any, len(v.Items))
+		for k, val := range v.Items {
+			m[kwName(k)] = malToJSON(val)
 		}
 		return m
 	case List:
@@ -174,13 +189,13 @@ func requestMap(r *http.Request) (HashMap, error) {
 		return HashMap{}, err
 	}
 
-	headers := make(map[string]MalType, len(r.Header))
+	headers := make(map[MalType]MalType, len(r.Header))
 	for name, vals := range r.Header {
 		if len(vals) > 0 {
 			headers[strings.ToLower(name)] = vals[0]
 		}
 	}
-	query := make(map[string]MalType)
+	query := make(map[MalType]MalType)
 	for name, vals := range r.URL.Query() {
 		if len(vals) > 0 {
 			query[name] = vals[0]
@@ -192,16 +207,16 @@ func requestMap(r *http.Request) (HashMap, error) {
 		scheme = "https"
 	}
 
-	m := map[string]MalType{
+	m := map[MalType]MalType{
 		kw("method"):      NewKeyword(strings.ToLower(r.Method)),
 		kw("uri"):         r.URL.Path,
-		kw("query"):       HashMap{Val: query},
-		kw("headers"):     HashMap{Val: headers},
+		kw("query"):       HashMap{Items: query},
+		kw("headers"):     HashMap{Items: headers},
 		kw("body"):        string(body),
 		kw("remote-addr"): r.RemoteAddr,
 		kw("scheme"):      NewKeyword(scheme),
 		kw("protocol"):    r.Proto,
-		kw("path-params"): HashMap{Val: map[string]MalType{}},
+		kw("path-params"): HashMap{Items: map[MalType]MalType{}},
 	}
 
 	// mTLS: when the transport verified a client certificate, expose its
@@ -212,7 +227,7 @@ func requestMap(r *http.Request) (HashMap, error) {
 		for i, s := range leaf.DNSNames {
 			sans[i] = s
 		}
-		m[kw("mtls")] = HashMap{Val: map[string]MalType{
+		m[kw("mtls")] = HashMap{Items: map[MalType]MalType{
 			kw("subject-cn"): leaf.Subject.CommonName,
 			kw("subject"):    leaf.Subject.String(),
 			kw("issuer-cn"):  leaf.Issuer.CommonName,
@@ -221,7 +236,7 @@ func requestMap(r *http.Request) (HashMap, error) {
 			kw("verified"):   true,
 		}}
 	}
-	return HashMap{Val: m}, nil
+	return HashMap{Items: m}, nil
 }
 
 // writeResponse writes a Ring response hash-map to the ResponseWriter.
@@ -238,7 +253,7 @@ func writeResponse(w http.ResponseWriter, resp MalType) {
 	}
 	if h, ok := hget(hm, "headers"); ok {
 		if hh, ok := h.(HashMap); ok {
-			for k, v := range hh.Val {
+			for k, v := range hh.Items {
 				w.Header().Set(headerName(k), toStr(v))
 			}
 		}
@@ -293,7 +308,7 @@ func tlsConfig(config MalType) (*tls.Config, error) {
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert // default when a CA is given
 	}
 	if v, ok := hget(tlsMap, "client-auth"); ok {
-		name := strings.TrimPrefix(toStr(v), "ʞ")
+		name := kwName(v)
 		at, ok := clientAuthTypes[name]
 		if !ok {
 			return nil, fmt.Errorf("web-serve: unknown :client-auth %q", name)
@@ -402,9 +417,9 @@ func compileRoutes(routes MalType) ([]route, error) {
 		if !ok {
 			return nil, errors.New("web-router: route methods must be a hash-map")
 		}
-		methods := make(map[string]MalType, len(mm.Val))
-		for k, v := range mm.Val {
-			methods[strings.ToLower(strings.TrimPrefix(k, "ʞ"))] = v
+		methods := make(map[string]MalType, len(mm.Items))
+		for k, v := range mm.Items {
+			methods[strings.ToLower(kwName(k))] = v
 		}
 		out = append(out, route{segments: splitPath(path), methods: methods})
 	}
@@ -421,11 +436,11 @@ func splitPath(p string) []string {
 
 // matchRoute matches a request path against a compiled route, returning
 // the captured path params on success.
-func matchRoute(r route, path []string) (map[string]MalType, bool) {
+func matchRoute(r route, path []string) (map[MalType]MalType, bool) {
 	if len(r.segments) != len(path) {
 		return nil, false
 	}
-	params := map[string]MalType{}
+	params := map[MalType]MalType{}
 	for i, seg := range r.segments {
 		if strings.HasPrefix(seg, ":") {
 			params[kw(seg[1:])] = path[i]
@@ -440,9 +455,9 @@ func matchRoute(r route, path []string) (map[string]MalType, bool) {
 
 // notFound and methodNotAllowed are the router's built-in fallbacks.
 func statusResponse(status int, msg string) HashMap {
-	return HashMap{Val: map[string]MalType{
+	return HashMap{Items: map[MalType]MalType{
 		kw("status"):  status,
-		kw("headers"): HashMap{Val: map[string]MalType{"content-type": "text/plain; charset=utf-8"}},
+		kw("headers"): HashMap{Items: map[MalType]MalType{"content-type": "text/plain; charset=utf-8"}},
 		kw("body"):    msg,
 	}}
 }
@@ -460,7 +475,7 @@ func webRouter(routes MalType) (MalType, error) {
 		}
 		req := args[0]
 		path := splitPath(hgetStr(req, "uri", "/"))
-		method := strings.TrimPrefix(toStr(mustGet(req, "method")), "ʞ")
+		method := kwName(mustGet(req, "method"))
 		pathMatched := false
 		for _, rt := range compiled {
 			params, ok := matchRoute(rt, path)
@@ -474,10 +489,10 @@ func webRouter(routes MalType) (MalType, error) {
 			}
 			// assoc :path-params into the request and dispatch.
 			reqHM := req.(HashMap)
-			merged := make(map[string]MalType, len(reqHM.Val)+1)
-			maps.Copy(merged, reqHM.Val)
-			merged[kw("path-params")] = HashMap{Val: params}
-			return Apply(ctx, handler, []MalType{HashMap{Val: merged}})
+			merged := make(map[MalType]MalType, len(reqHM.Items)+1)
+			maps.Copy(merged, reqHM.Items)
+			merged[kw("path-params")] = HashMap{Items: params}
+			return Apply(ctx, handler, []MalType{HashMap{Items: merged}})
 		}
 		if pathMatched {
 			return statusResponse(http.StatusMethodNotAllowed, "405 method not allowed"), nil
@@ -575,10 +590,9 @@ var webLogger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 // sigil, strings/numbers pass through, everything else is printed.
 func logValue(v MalType) any {
 	switch v := v.(type) {
+	case Keyword:
+		return string(v)
 	case string:
-		if strings.HasPrefix(v, "ʞ") {
-			return strings.TrimPrefix(v, "ʞ")
-		}
 		return v
 	case int, float32, float64, bool, nil:
 		return v
@@ -589,16 +603,16 @@ func logValue(v MalType) any {
 
 // webLog logs msg at level with alternating key/value attributes:
 // (web-log :info "message" "key" value …).
-func webLog(level, msg string, kv ...MalType) (MalType, error) {
+func webLog(level MalType, msg string, kv ...MalType) (MalType, error) {
 	attrs := make([]any, 0, len(kv))
 	for i, v := range kv {
 		if i%2 == 0 {
-			attrs = append(attrs, strings.TrimPrefix(toStr(v), "ʞ"))
+			attrs = append(attrs, kwName(v))
 		} else {
 			attrs = append(attrs, logValue(v))
 		}
 	}
-	switch strings.TrimPrefix(level, "ʞ") {
+	switch kwName(level) {
 	case "debug":
 		webLogger.Debug(msg, attrs...)
 	case "warn":

--- a/lisperror/lisperror.go
+++ b/lisperror/lisperror.go
@@ -160,8 +160,8 @@ func (e LispError) AddStackFrame(pos *Position, functionName string) LispError {
 
 func (e LispError) MarshalHashMap() (MalType, error) {
 	hm := HashMap{
-		Val: map[string]MalType{
-			"ʞtype": fmt.Sprintf("%T", e),
+		Items: map[MalType]MalType{
+			KW("type"): fmt.Sprintf("%T", e),
 		},
 	}
 
@@ -171,13 +171,13 @@ func (e LispError) MarshalHashMap() (MalType, error) {
 		if err != nil {
 			return nil, err
 		}
-		hm.Val["ʞerr"] = pHm
+		hm.Items[KW("err")] = pHm
 	default:
-		hm.Val["ʞerr"] = printer.Pr_str(ee, true)
+		hm.Items[KW("err")] = printer.Pr_str(ee, true)
 	}
 
 	if e.cursor != nil {
-		hm.Val["ʞpos"] = e.cursor.String()
+		hm.Items[KW("pos")] = e.cursor.String()
 	}
 
 	return hm, nil

--- a/lisperror/lisperror_test.go
+++ b/lisperror/lisperror_test.go
@@ -33,7 +33,7 @@ func TestErrorFormat(t *testing.T) {
 // TestErrorNonErrorPayload covers the branch that renders a thrown
 // non-error value (e.g. (throw {:a 1})) with the Lisp printer.
 func TestErrorNonErrorPayload(t *testing.T) {
-	e := lisperror.NewLispError(types.HashMap{Val: map[string]types.MalType{"ʞa": 1}}, nil)
+	e := lisperror.NewLispError(types.HashMap{Items: map[types.MalType]types.MalType{types.KW("a"): 1}}, nil)
 	if got := e.Error(); got != "{:a 1}" {
 		t.Fatalf("payload Error = %q, want %q", got, "{:a 1}")
 	}
@@ -83,11 +83,11 @@ func TestMarshalHashMap(t *testing.T) {
 	if !ok {
 		t.Fatalf("MarshalHashMap returned %T, want HashMap", m)
 	}
-	if !strings.Contains(hm.Val["ʞerr"].(string), "boom") {
-		t.Fatalf("ʞerr = %v, want it to contain boom", hm.Val["ʞerr"])
+	if !strings.Contains(hm.Items[types.KW("err")].(string), "boom") {
+		t.Fatalf(":err = %v, want it to contain boom", hm.Items[types.KW("err")])
 	}
-	if _, ok := hm.Val["ʞpos"]; !ok {
-		t.Fatal("ʞpos missing for an error with a cursor")
+	if _, ok := hm.Items[types.KW("pos")]; !ok {
+		t.Fatal(":pos missing for an error with a cursor")
 	}
 }
 

--- a/lnotation/lnotation.go
+++ b/lnotation/lnotation.go
@@ -37,7 +37,7 @@ func V[T any](args []T) Vector {
 
 // M converts Go map to lisp HashMap
 func HM(arg map[string]interface{}) HashMap {
-	result := map[string]MalType{}
+	result := map[MalType]MalType{}
 	for k, v := range arg {
 		switch v := v.(type) {
 		case map[string]interface{}:
@@ -46,13 +46,13 @@ func HM(arg map[string]interface{}) HashMap {
 			result[k] = v
 		}
 	}
-	return HashMap{Val: result}
+	return HashMap{Items: result}
 }
 
 func SET(args []string) Set {
-	result := map[string]struct{}{}
+	result := map[MalType]struct{}{}
 	for _, k := range args {
 		result[k] = struct{}{}
 	}
-	return Set{Val: result}
+	return Set{Items: result}
 }

--- a/lsp/analyse.go
+++ b/lsp/analyse.go
@@ -76,7 +76,7 @@ type analysis struct {
 // run time (--preamble flags or Go embedding), so the editor treats
 // them as nil rather than flagging every placeholder-bearing file as
 // a parse error.
-var emptyPlaceholders = &types.HashMap{Val: map[string]types.MalType{}}
+var emptyPlaceholders = &types.HashMap{Items: map[types.MalType]types.MalType{}}
 
 // preambleLineRE matches one in-file placeholder default line.
 var preambleLineRE = regexp.MustCompile(`^;; (\$[-\w\d]+)\s+(.+)$`)
@@ -144,7 +144,7 @@ func (a *analysis) scan(form types.MalType) {
 				a.scan(c)
 			}
 		case types.HashMap:
-			for _, v := range n.Val {
+			for _, v := range n.Items {
 				a.scan(v)
 			}
 		}
@@ -223,16 +223,16 @@ func (a *analysis) scan(form types.MalType) {
 				ref := requireRef{module: mod, headPos: head.Cursor}
 				opts := tail(list.Val, 2)
 				for i := 0; i+1 < len(opts); i += 2 {
-					key, ok := opts[i].(string)
+					key, ok := opts[i].(types.Keyword)
 					if !ok {
 						continue
 					}
 					switch key {
-					case "ʞas": // keyword :as
+					case "as":
 						if alias, ok := opts[i+1].(string); ok {
 							ref.alias = alias
 						}
-					case "ʞrefer": // keyword :refer
+					case "refer":
 						switch v := opts[i+1].(type) {
 						case types.Vector:
 							for _, e := range v.Val {
@@ -240,9 +240,9 @@ func (a *analysis) scan(form types.MalType) {
 									ref.refers = append(ref.refers, name)
 								}
 							}
-						case string:
+						case types.Keyword:
 							// :refer :all imports every definition unqualified
-							if v == types.NewKeyword("all") {
+							if v == "all" {
 								ref.referAll = true
 							}
 						}
@@ -493,7 +493,7 @@ func (b *semBuilder) walk(form types.MalType) {
 			b.walk(c)
 		}
 	case types.HashMap:
-		for _, v := range n.Val {
+		for _, v := range n.Items {
 			b.walk(v)
 		}
 	case types.List:

--- a/lsp/format.go
+++ b/lsp/format.go
@@ -217,7 +217,7 @@ func formatDiagnostics(anal *analysis, content string) []Diagnostic {
 				walk(c)
 			}
 		case types.HashMap:
-			for _, v := range n.Val {
+			for _, v := range n.Items {
 				walk(v)
 			}
 		case types.List:

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -412,7 +412,7 @@ func envArglistDoc(v types.MalType) (arglist, doc string) {
 		return t.Arglist, t.Doc
 	case types.MalFunc:
 		if hm, ok := t.Meta.(types.HashMap); ok {
-			if s, ok := hm.Val["ʞdoc"].(string); ok {
+			if s, ok := hm.Items[types.KW("doc")].(string); ok {
 				doc = s
 			}
 		}

--- a/mal.go
+++ b/mal.go
@@ -127,7 +127,7 @@ func READ(sourceCode string, cursor *Position, ns EnvType) (MalType, error) {
 // READWithPreamble is used to read code (actually decode) on transmission. Use [AddPreamble]
 // when calling from Go code.
 func READWithPreamble(str string, cursor *Position, ns EnvType) (MalType, error) {
-	placeholderMap := &HashMap{Val: map[string]MalType{}}
+	placeholderMap := &HashMap{Items: map[MalType]MalType{}}
 	i := 0
 	for ; ; i++ {
 		var line string
@@ -152,7 +152,7 @@ func READWithPreamble(str string, cursor *Position, ns EnvType) (MalType, error)
 			Col: 1,
 		}, nil, ns)
 		placeholderKey := lineItems[0][1][3:]
-		placeholderMap.Val[placeholderKey] = item
+		placeholderMap.Items[placeholderKey] = item
 	}
 }
 
@@ -312,8 +312,8 @@ func fillExpansionCursors(ast MalType, fallback *Position) MalType {
 		if n.Cursor != nil {
 			return n
 		}
-		for k, v := range n.Val {
-			n.Val[k] = fillExpansionCursors(v, fallback)
+		for k, v := range n.Items {
+			n.Items[k] = fillExpansionCursors(v, fallback)
 		}
 		n.Cursor = fallback.Copy()
 		return n
@@ -366,14 +366,14 @@ func eval_ast(ctx context.Context, ast MalType, env EnvType) (MalType, error) {
 		return Vector{Val: lst, Cursor: origVec.Cursor}, nil
 	} else if Q[HashMap](ast) {
 		m := ast.(HashMap)
-		new_hm := HashMap{Val: map[string]MalType{}, Cursor: m.Cursor}
-		for k, v := range m.Val {
+		new_hm := HashMap{Items: map[MalType]MalType{}, Cursor: m.Cursor}
+		for k, v := range m.Items {
 			kv, e2 := evalInternal(ctx, v, env)
 			if e2 != nil {
 				// Preserve error and add context about which key failed
 				return nil, e2
 			}
-			new_hm.Val[k] = kv
+			new_hm.Items[k] = kv
 		}
 		return new_hm, nil
 	} else {

--- a/marshalingexample_test.go
+++ b/marshalingexample_test.go
@@ -22,9 +22,9 @@ type LispMarshalExample struct {
 
 func (lec LispMarshalExample) MarshalHashMap() (types.MalType, error) {
 	return types.HashMap{
-		Val: map[string]types.MalType{
-			"ʞa": lec.Val.A,
-			"ʞb": lec.Val.B,
+		Items: map[types.MalType]types.MalType{
+			types.KW("a"): lec.Val.A,
+			types.KW("b"): lec.Val.B,
 		},
 	}, nil
 }
@@ -40,8 +40,8 @@ func new_marshalexample() (types.MalType, error) {
 func (lec LispMarshalExampleFactory) FromHashMap(_hm types.MalType) (types.MalType, error) {
 	hm := _hm.(types.HashMap)
 	ex := MarshalExample{
-		A: hm.Val["ʞa"].(int),
-		B: hm.Val["ʞb"].(string),
+		A: hm.Items[types.KW("a")].(int),
+		B: hm.Items[types.KW("b")].(string),
 	}
 	return LispMarshalExample{ex}, nil
 }

--- a/placeholder_test.go
+++ b/placeholder_test.go
@@ -36,7 +36,7 @@ func TestPlaceholders(t *testing.T) {
 		str,
 		nil,
 		&HashMap{
-			Val: map[string]MalType{
+			Items: map[MalType]MalType{
 				"$0":      "hello",
 				"$1":      "{\"key\": \"value\"}",
 				"$NUMBER": 44,
@@ -150,10 +150,10 @@ func TestREADWithPreamble(t *testing.T) {
 		if !ok {
 			t.Fatal("no {\"key\": \"value\"}")
 		}
-		if len(h.Val) != 1 {
+		if len(h.Items) != 1 {
 			t.Fatal("pum")
 		}
-		if h.Val["key"].(string) != "value" {
+		if h.Items["key"].(string) != "value" {
 			t.Fatal("pum2")
 		}
 
@@ -642,10 +642,10 @@ func TestHashMapMarshalers(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if goStruct.(HashMap).Val["ʞa"] != 1984 {
+		if goStruct.(HashMap).Items[KW("a")] != 1984 {
 			t.Fatal("no 1984")
 		}
-		if goStruct.(HashMap).Val["ʞb"] != "I am B" {
+		if goStruct.(HashMap).Items[KW("b")] != "I am B" {
 			t.Fatal("no B")
 		}
 	}

--- a/printer/data.go
+++ b/printer/data.go
@@ -229,8 +229,8 @@ type mapEntry struct {
 }
 
 func (p dataPrinter) sortedMapEntries(value types.HashMap) []mapEntry {
-	entries := make([]mapEntry, 0, len(value.Val))
-	for key, item := range value.Val {
+	entries := make([]mapEntry, 0, len(value.Items))
+	for key, item := range value.Items {
 		entries = append(entries, mapEntry{keyFlat: p.flat(key), value: item})
 	}
 	sort.Slice(entries, func(i, j int) bool {
@@ -240,8 +240,8 @@ func (p dataPrinter) sortedMapEntries(value types.HashMap) []mapEntry {
 }
 
 func (p dataPrinter) sortedSetEntries(value types.Set) []string {
-	entries := make([]string, 0, len(value.Val))
-	for entry := range value.Val {
+	entries := make([]string, 0, len(value.Items))
+	for entry := range value.Items {
 		entries = append(entries, p.flat(entry))
 	}
 	sort.Strings(entries)
@@ -266,9 +266,9 @@ func isEmptyCollection(value types.MalType) bool {
 	case types.Vector:
 		return len(value.Val) == 0
 	case types.HashMap:
-		return len(value.Val) == 0
+		return len(value.Items) == 0
 	case types.Set:
-		return len(value.Val) == 0
+		return len(value.Items) == 0
 	default:
 		return false
 	}

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -56,15 +56,15 @@ func Pr_str(obj types.MalType, print_readably bool) string {
 	case types.HashMap:
 		return hashMapToString(tobj, print_readably)
 	case types.Set:
-		str_list := make([]string, 0, len(tobj.Val))
-		for k := range tobj.Val {
+		str_list := make([]string, 0, len(tobj.Items))
+		for k := range tobj.Items {
 			str_list = append(str_list, Pr_str(k, print_readably))
 		}
 		return "#{" + strings.Join(str_list, " ") + "}"
+	case types.Keyword:
+		return ":" + string(tobj)
 	case string:
-		if strings.HasPrefix(tobj, "\u029e") {
-			return ":" + tobj[2:]
-		} else if print_readably {
+		if print_readably {
 			if strings.HasPrefix(tobj, `{"`) && strings.HasSuffix(tobj, `}`) {
 				return `¬` + strings.Replace(tobj, `¬`, `¬¬`, -1) + `¬`
 			} else {
@@ -135,8 +135,8 @@ func bigIntToHex(i *big.Int) string {
 }
 
 func hashMapToString(tobj types.HashMap, print_readably bool) string {
-	str_list := make([]string, 0, len(tobj.Val)*2)
-	for k, v := range tobj.Val {
+	str_list := make([]string, 0, len(tobj.Items)*2)
+	for k, v := range tobj.Items {
 		str_list = append(str_list, Pr_str(k, print_readably))
 		str_list = append(str_list, Pr_str(v, print_readably))
 	}

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -25,13 +25,13 @@ func TestPrStr(t *testing.T) {
 		{"nil", nil, "nil"},
 		{"int", 42, "42"},
 		{"symbol", types.Symbol{Val: "foo"}, "foo"},
-		{"keyword", "ʞfoo", ":foo"},
+		{"keyword", types.KW("foo"), ":foo"},
 		{"list", types.List{Val: []types.MalType{1, 2, 3}}, "(1 2 3)"},
 		{"vector", types.Vector{Val: []types.MalType{1, 2, 3}}, "[1 2 3]"},
 		{"empty-list", types.List{}, "()"},
 		{"nested", types.List{Val: []types.MalType{types.Vector{Val: []types.MalType{1}}, 2}}, "([1] 2)"},
-		{"hashmap-1", types.HashMap{Val: map[string]types.MalType{"ʞa": 1}}, "{:a 1}"},
-		{"set-1", types.Set{Val: map[string]struct{}{"ʞa": {}}}, "#{:a}"},
+		{"hashmap-1", types.HashMap{Items: map[types.MalType]types.MalType{types.KW("a"): 1}}, "{:a 1}"},
+		{"set-1", types.Set{Items: map[types.MalType]struct{}{types.KW("a"): {}}}, "#{:a}"},
 		{"go-error", errors.New("boom"), `«go-error "boom"»`},
 		{"malfunc", types.MalFunc{
 			Params: types.Vector{Val: []types.MalType{types.Symbol{Val: "x"}}},
@@ -165,7 +165,7 @@ func TestPrList(t *testing.T) {
 // TestPrStrHashMapMulti keeps the multi-entry case non-flaky: map order
 // is unspecified, so assert structure, not exact order.
 func TestPrStrHashMapMulti(t *testing.T) {
-	got := printer.Pr_str(types.HashMap{Val: map[string]types.MalType{"ʞa": 1, "ʞb": 2}}, true)
+	got := printer.Pr_str(types.HashMap{Items: map[types.MalType]types.MalType{types.KW("a"): 1, types.KW("b"): 2}}, true)
 	if !strings.HasPrefix(got, "{") || !strings.HasSuffix(got, "}") {
 		t.Fatalf("not brace-wrapped: %q", got)
 	}
@@ -177,14 +177,14 @@ func TestPrStrHashMapMulti(t *testing.T) {
 }
 
 func TestPrDataDeterministicMixedCollections(t *testing.T) {
-	value := types.HashMap{Val: map[string]types.MalType{
-		"ʞz": types.HashMap{Val: map[string]types.MalType{"ʞb": 2, "ʞa": 1}},
+	value := types.HashMap{Items: map[types.MalType]types.MalType{
+		types.KW("z"): types.HashMap{Items: map[types.MalType]types.MalType{types.KW("b"): 2, types.KW("a"): 1}},
 		"a": types.List{Val: []types.MalType{
 			types.Symbol{Val: "quote"},
 			types.Vector{Val: []types.MalType{3, 2, 1}},
 		}},
-		"ʞa": types.Set{Val: map[string]struct{}{"beta": {}, "ʞalpha": {}, "alpha": {}}},
-		"z":  nil,
+		types.KW("a"): types.Set{Items: map[types.MalType]struct{}{"beta": {}, types.KW("alpha"): {}, "alpha": {}}},
+		"z":           nil,
 	}}
 	want := `{"a" '[3 2 1] "z" nil :a #{"alpha" "beta" :alpha} :z {:a 1 :b 2}}`
 
@@ -197,18 +197,18 @@ func TestPrDataDeterministicMixedCollections(t *testing.T) {
 
 func TestPrDataNestedWidthAwareLayout(t *testing.T) {
 	value := types.Vector{Val: []types.MalType{
-		types.HashMap{Val: map[string]types.MalType{
-			"ʞvalues": types.Vector{Val: []types.MalType{1, 2, 3, 4}},
-			"ʞname":   "alpha",
+		types.HashMap{Items: map[types.MalType]types.MalType{
+			types.KW("values"): types.Vector{Val: []types.MalType{1, 2, 3, 4}},
+			types.KW("name"):   "alpha",
 		}},
-		types.HashMap{Val: map[string]types.MalType{
+		types.HashMap{Items: map[types.MalType]types.MalType{
 			// A quote long enough to wrap: reader-macro sugar (') is
 			// printed, and the wrapped form aligns under it.
-			"ʞquoted": types.List{Val: []types.MalType{
+			types.KW("quoted"): types.List{Val: []types.MalType{
 				types.Symbol{Val: "quote"},
 				types.Vector{Val: []types.MalType{100, 200, 300, 400}},
 			}},
-			"ʞname": "beta",
+			types.KW("name"): "beta",
 		}},
 	}}
 	want := `[{:name "alpha"

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -131,14 +131,7 @@ func read_atom(rdr *tokenReader) (MalType, error) {
 		}
 		return int(i), nil
 	case scanner.String:
-		str := (*token)[1 : len(*token)-1]
-		return strings.Replace(
-			strings.Replace(
-				strings.Replace(
-					strings.Replace(str, `\\`, "\u029e", -1),
-					`\"`, `"`, -1),
-				`\n`, "\n", -1),
-			"\u029e", "\\", -1), nil
+		return unescapeString((*token)[1 : len(*token)-1]), nil
 	case scanner.RawString:
 		if *token == "¬" {
 			return nil, lisperror.NewLispError(errors.New("expected '¬', got EOF"), tokenStruct.GetPosition())
@@ -169,6 +162,35 @@ func read_atom(rdr *tokenReader) (MalType, error) {
 			Cursor: tokenStruct.GetPosition(),
 		}, nil
 	}
+}
+
+// unescapeString resolves \\, \" and \n escapes in a single pass. (The
+// historical implementation round-tripped through a sentinel rune,
+// which corrupted strings legitimately containing that rune.)
+func unescapeString(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case '\\':
+				b.WriteByte('\\')
+				i++
+				continue
+			case '"':
+				b.WriteByte('"')
+				i++
+				continue
+			case 'n':
+				b.WriteByte('\n')
+				i++
+				continue
+			}
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
 }
 
 func read_list(rdr *tokenReader, start string, end string, placeholderValues *HashMap, ns EnvType) (MalType, error) {
@@ -268,7 +290,7 @@ func read_placeholder(rdr *tokenReader, placeholderValues *HashMap, ns EnvType) 
 	if placeholderValues == nil {
 		return nil, lisperror.NewLispError(fmt.Errorf("placeholder %s used but no placeholder values provided", tokenStruct.Value), tokenStruct.GetPosition())
 	}
-	return placeholderValues.Val[tokenStruct.Value], nil
+	return placeholderValues.Items[tokenStruct.Value], nil
 }
 
 func read_form(rdr *tokenReader, placeholderValues *HashMap, ns EnvType) (MalType, error) {

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -139,7 +139,7 @@ func read_atom(rdr *tokenReader) (MalType, error) {
 		str := (*token)[2 : len(*token)-2]
 		return strings.Replace(str, `¬¬`, `¬`, -1), nil
 	case scanner.Keyword:
-		return NewKeyword((*token)[1:len(*token)]), nil
+		return KW((*token)[1:len(*token)]), nil
 	case scanner.Float:
 		f, err := strconv.ParseFloat(*token, 32)
 		if err != nil {

--- a/tests/stepD_casterror.mal
+++ b/tests/stepD_casterror.mal
@@ -7,7 +7,7 @@
 ;=>nil
 
 (+ 1 :hello)
-;/^.*not a number \(was of type string\)"
+;/^.*not a number \(was of type types.Keyword\)"
 ;=>nil
 
 (+ 1 "hello")

--- a/tests/stepI_marshaling copy.mal
+++ b/tests/stepI_marshaling copy.mal
@@ -2,42 +2,42 @@
 ;=>"{}"
 
 (json-encode {:a 1})
-;=>¬{"ʞa":1}¬
+;=>¬{"a":1}¬
 
-(get (json-decode {} (json-encode {:a 1 :b 2})) :a)
+
+;; JSON has no keyword type: keyword keys serialise as their bare name
+;; and come back from json-decode as plain strings (as in Clojure).
+(get (json-decode {} (json-encode {:a 1 :b 2})) "a")
 ;=>1
-(get (json-decode {} (json-encode {:a 1 :b 2})) :b)
+(get (json-decode {} (json-encode {:a 1 :b 2})) "b")
 ;=>2
 
-(get (json-decode {} (json-encode {:a 1 :b {}})) :b)
+(get (json-decode {} (json-encode {:a 1 :b {}})) "b")
 ;=>{}
 
-(get-in (json-decode {} (json-encode {:a 1 :b {:c 3}})) [:b :c])
+(get-in (json-decode {} (json-encode {:a 1 :b {:c 3}})) ["b" "c"])
 ;=>3
 
 (json-encode #{})
 ;=>"[]"
 
-;; TODO(jig): conversion of keywords to JSON
 (json-encode #{:a})
-;=>"[\"ʞa\"]"
+;=>"[\"a\"]"
 
-(get (json-decode #{} (json-encode #{:a :b})) :a)
-;=>:a
+(get (json-decode #{} (json-encode #{:a :b})) "a")
+;=>"a"
 
-(contains? (json-decode #{} (json-encode #{:a :b})) :a)
+(contains? (json-decode #{} (json-encode #{:a :b})) "a")
 ;=>true
 
 (json-encode [])
 ;=>"[]"
 
-;; TODO(jig): conversion of keywords to JSON
 (json-encode [:a])
-;=>"[\"ʞa\"]"
+;=>"[\"a\"]"
 
-;; TODO(jig): conversion of keywords to JSON
 (json-encode [:a :b])
-;=>"[\"ʞa\",\"ʞb\"]"
+;=>"[\"a\",\"b\"]"
 
 (json-encode 1984)
 ;=>"1984"

--- a/types/types.go
+++ b/types/types.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 	"reflect"
 	"sort"
-	"strings"
 )
 
 type Token struct {
@@ -64,17 +63,67 @@ type Symbol struct {
 	Cursor *Position
 }
 
-// Keywords
-func NewKeyword(s string) string {
-	return "\u029e" + s
+// Keyword is a lisp keyword (:foo). It is a distinct Go type, so a
+// keyword can never be confused with a string carrying the same
+// characters \u2014 unlike the historical representation (a string with a
+// "\u029e" prefix), where any external string starting with that rune
+// became a keyword.
+type Keyword string
+
+func (k Keyword) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(k))
+}
+
+// KW builds the keyword :s from its name (without the colon).
+func KW(s string) Keyword {
+	return Keyword(s)
+}
+
+// NewKeyword builds the keyword :s from its name (without the colon).
+//
+// Deprecated: use KW. NewKeyword returned the prefixed-string
+// representation before 0.4 and is kept so embedder code keeps
+// compiling; it now returns a Keyword.
+func NewKeyword(s string) Keyword {
+	return Keyword(s)
 }
 
 func Keyword_Q(obj MalType) bool {
-	return Q[string](obj) && strings.HasPrefix(obj.(string), "\u029e")
+	return Q[Keyword](obj)
 }
 
 func String_Q(obj MalType) bool {
-	return Q[string](obj) && !strings.HasPrefix(obj.(string), "\u029e")
+	return Q[string](obj)
+}
+
+// ValidKey reports whether obj can be a hash-map key or a set element:
+// a string or a keyword. Restricting keys keeps every map operation
+// panic-free (both types are comparable) and gives them a total order
+// (KeyLess) for deterministic sequencing and printing.
+func ValidKey(obj MalType) bool {
+	switch obj.(type) {
+	case string, Keyword:
+		return true
+	}
+	return false
+}
+
+// KeyLess is the total order over valid hash-map keys and set elements:
+// strings first, then keywords, each lexicographically. (Strings-first
+// matches the order the sorted legacy encoding produced, keywords
+// carrying a prefix above ASCII.)
+func KeyLess(a, b MalType) bool {
+	as, aIsStr := a.(string)
+	bs, bIsStr := b.(string)
+	if aIsStr != bIsStr {
+		return aIsStr
+	}
+	if aIsStr {
+		return as < bs
+	}
+	ak, _ := a.(Keyword)
+	bk, _ := b.(Keyword)
+	return ak < bk
 }
 
 type ExternalCall func(context.Context, []MalType) (MalType, error)
@@ -168,28 +217,20 @@ func GetSlice(seq MalType) ([]MalType, error) {
 		// them disagree and a first/rest traversal (reduce, filter) drops
 		// or repeats entries. Clojure gets the same coherence from its
 		// maps' stable iteration order.
-		keys := make([]string, 0, len(seq.Val))
-		for k := range seq.Val {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
+		keys := sortedKeys(seq.Items)
 		entries := make([]MalType, 0, len(keys))
 		for _, k := range keys {
-			entries = append(entries, Vector{Val: []MalType{k, seq.Val[k]}})
+			entries = append(entries, Vector{Val: []MalType{k, seq.Items[k]}})
 		}
 		return entries, nil
 	case Set:
 		// A set seqs as its elements, as stored, in sorted order — see
 		// the hash-map case for why the order must be deterministic.
-		keys := make([]string, 0, len(seq.Val))
-		for k := range seq.Val {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		elems := make([]MalType, 0, len(keys))
-		for _, k := range keys {
+		elems := make([]MalType, 0, len(seq.Items))
+		for k := range seq.Items {
 			elems = append(elems, k)
 		}
+		sort.Slice(elems, func(i, j int) bool { return KeyLess(elems[i], elems[j]) })
 		return elems, nil
 	default:
 		return nil, errors.New("GetSlice called on non-sequence")
@@ -198,9 +239,22 @@ func GetSlice(seq MalType) ([]MalType, error) {
 
 // Hash Maps
 type HashMap struct {
-	Val    map[string]MalType
+	// Items maps keys to values. Keys are restricted to string and
+	// Keyword (see ValidKey); every constructor validates, so map
+	// operations never hit a non-comparable key.
+	Items  map[MalType]MalType
 	Meta   MalType
 	Cursor *Position
+}
+
+// sortedKeys returns m's keys in KeyLess order.
+func sortedKeys[V any](m map[MalType]V) []MalType {
+	keys := make([]MalType, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return KeyLess(keys[i], keys[j]) })
+	return keys
 }
 
 func NewHashMap(cursor *Position, seq MalType) (MalType, error) {
@@ -211,20 +265,21 @@ func NewHashMap(cursor *Position, seq MalType) (MalType, error) {
 	if len(lst)%2 == 1 {
 		return nil, errors.New("odd number of arguments to NewHashMap")
 	}
-	m := map[string]MalType{}
+	m := map[MalType]MalType{}
 	for i := 0; i < len(lst); i += 2 {
-		str, ok := lst[i].(string)
-		if !ok {
-			return nil, fmt.Errorf("expected hash-map key string (found %T)", lst[i])
+		if !ValidKey(lst[i]) {
+			return nil, fmt.Errorf("expected hash-map key string or keyword (found %T)", lst[i])
 		}
-		m[str] = lst[i+1]
+		m[lst[i]] = lst[i+1]
 	}
-	return HashMap{Val: m, Cursor: cursor}, nil
+	return HashMap{Items: m, Cursor: cursor}, nil
 }
 
 // Sets
 type Set struct {
-	Val    map[string]struct{}
+	// Items holds the elements, restricted to string and Keyword as
+	// hash-map keys are (see ValidKey).
+	Items  map[MalType]struct{}
 	Meta   MalType
 	Cursor *Position
 }
@@ -239,15 +294,14 @@ func NewSet(seq MalType) (Set, error) {
 		return Set{}, e
 	}
 
-	m := map[string]struct{}{}
+	m := map[MalType]struct{}{}
 	for _, item := range lst {
-		sItem, ok := item.(string)
-		if !ok {
+		if !ValidKey(item) {
 			return Set{}, errors.New("set items must be strings or keywords")
 		}
-		m[sItem] = struct{}{}
+		m[item] = struct{}{}
 	}
-	return Set{Val: m}, nil
+	return Set{Items: m}, nil
 }
 
 // Dereferable type
@@ -302,8 +356,8 @@ func Equal_Q(a, b MalType) bool {
 		}
 		return true
 	case HashMap:
-		am := a.(HashMap).Val
-		bm := b.(HashMap).Val
+		am := a.(HashMap).Items
+		bm := b.(HashMap).Items
 		if len(am) != len(bm) {
 			return false
 		}
@@ -314,8 +368,8 @@ func Equal_Q(a, b MalType) bool {
 		}
 		return true
 	case Set:
-		am := a.(Set).Val
-		bm := b.(Set).Val
+		am := a.(Set).Items
+		bm := b.(Set).Items
 		if len(am) != len(bm) {
 			return false
 		}
@@ -338,8 +392,23 @@ func Equal_Q(a, b MalType) bool {
 	}
 }
 
+// MarshalJSON serialises keyword keys as their bare name (:a → "a"),
+// as Clojure JSON emitters do. (Before 0.4 the internal ʞ prefix leaked
+// into the JSON output.) A map holding both :x and "x" produces
+// duplicate JSON keys — of which one survives, unspecified.
 func (hm HashMap) MarshalJSON() ([]byte, error) {
-	return json.Marshal(hm.Val)
+	m := make(map[string]MalType, len(hm.Items))
+	for k, v := range hm.Items {
+		switch k := k.(type) {
+		case string:
+			m[k] = v
+		case Keyword:
+			m[string(k)] = v
+		default:
+			return nil, fmt.Errorf("cannot JSON-encode a hash-map key of type %T", k)
+		}
+	}
+	return json.Marshal(m)
 }
 
 func (v Vector) MarshalJSON() ([]byte, error) {
@@ -361,8 +430,8 @@ func (s Set) MarshalJSON() ([]byte, error) {
 func ConvertFrom(from MalType) ([]MalType, MalType, error) {
 	switch from := from.(type) {
 	case Set:
-		keys := make([]MalType, 0, len(from.Val))
-		for k := range from.Val {
+		keys := make([]MalType, 0, len(from.Items))
+		for k := range from.Items {
 			keys = append(keys, k)
 		}
 		return keys, from.Meta, nil
@@ -381,9 +450,12 @@ func ConvertFrom(from MalType) ([]MalType, MalType, error) {
 func ConvertTo(from []MalType, _to MalType, meta MalType) (MalType, error) {
 	switch _to.(type) {
 	case Set:
-		to := Set{Val: map[string]struct{}{}}
+		to := Set{Items: map[MalType]struct{}{}}
 		for _, k := range from {
-			to.Val[k.(string)] = struct{}{}
+			if !ValidKey(k) {
+				return nil, errors.New("set items must be strings or keywords")
+			}
+			to.Items[k] = struct{}{}
 		}
 		return to, nil
 	case List:


### PR DESCRIPTION
## What

Keywords become a dedicated Go type, `types.Keyword`, replacing the historical ʞ-prefixed-string representation (kanaka/mal heritage). Hash-map keys and set elements become `map[types.MalType]…`, restricted to string|keyword by construction-time validation (`ValidKey`), with a total order (`KeyLess`: strings first, then keywords) that keeps seqable iteration and the data printer deterministic.

**Lisp code is unaffected** — `:foo` reads, prints, compares and hashes as before. The type split fixes real correctness bugs:

- **Keyword smuggling closed**: a JSON value `"ʞx"` used to *become* the keyword `:x` (`(keyword? s)` → true, `(= s :x)` → true). It now stays a string. This was a data-driven type confusion open to every input path (json-decode, lib/web, lib/sql, files) and `--integrity` runs.
- **`json-encode` no longer leaks the prefix**: `{:a 1}` → `{"a":1}` (was `{"ʞa":1}`).
- **Literal `ʞ` in strings survives reading**: the reader used the same rune as its unescape sentinel and corrupted it to `\`; replaced by a single-pass unescaper.
- `(seq :ab)` errors instead of splitting the keyword as a string.

## Breaking (Go embedders)

Three deliberate compile-time breaks — see the **Migration** section added to CHANGELOG:

1. `HashMap.Val` / `Set.Val` → renamed **`Items`** with the new key type (loud break; keeping the old name would let `hm.Val["ʞa"]` compile and silently return nil).
2. `"ʞ…"` literals → `types.KW("…")`.
3. `NewKeyword` returns `Keyword` (kept as deprecated alias of the new `types.KW`).

Behaviour: **keyword JSON round-trips are lossy now, by design** (encode → bare names, decode → string keys, Clojure parity; the old losslessness *was* the leak, marked TODO in the step tests). Builtin surface: `keyword` accepts string|keyword, `contains?` takes any key, `get` reports per-container key-type errors. `AddPreamble` and all of `lnotation` keep their signatures.

## Validation

- Full test suite green, 31 packages, both tag sets (default and `debugger`).
- MAL1 and a map-heavy lisp loop (2000 assoc+get) within noise of `develop` — matching the estimate in `ROADMAP-keywords.md` §5 (raw map ops lose the Go `faststr` path, but interpreter overhead dominates).
- Design rationale, caller audits and prototype findings: `ROADMAP-keywords.md` (§3, §7).

Groundwork this unlocks: Tier-2 arbitrary-value sets/maps are now just relaxing `ValidKey` and extending `KeyLess`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)