### PR TITLE
feat(types): scalar hash-map keys and set elements (Tier 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,20 @@ producing plain string keys (as in Clojure), so
 `(get … "a")`. The old losslessness existed only because the prefix
 leaked into the wire format.
 
+### Added — scalar hash-map keys and set elements
+
+Hash-map keys and set elements accept any **immutable scalar**: nil,
+booleans, ints, floats, strings and keywords (previously strings and
+keywords only). `#{1 2 3}`, `{1 "one"}`, `(assoc m 42 v)`,
+`(contains? #{1.5} 1.5)` all work; entries and elements order by type
+group (nil < booleans < ints < floats < strings < keywords) then
+value, and `pr-str`/`str` now print maps and sets in that
+deterministic order. Composite values (vectors, maps, sets), symbols
+and radix big ints remain invalid keys — the first are not hashable,
+the latter two only compare by identity — and error at construction.
+`json-encode` of a map with non-string/keyword keys errors (JSON
+objects require string keys).
+
 ### Migration (embedders — Go code using jig/lisp)
 
 Scripts and lisp data files need no changes. Go code embedding the

--- a/ROADMAP-keywords.md
+++ b/ROADMAP-keywords.md
@@ -294,10 +294,17 @@ Findings and decisions made while implementing:
   when refactoring.
 
 CHANGELOG now carries the 0.4 section with the embedder migration
-guide. Still pending for the real 0.4 PR: LANGUAGE.md wording,
+guide. Tier-2 landed on `feat/tier2-collections`: `ValidKey` accepts
+any immutable scalar (nil/bool/int/float/string/keyword), `KeyLess`
+orders by type group then value, and `Pr_str` prints maps and sets in
+that order (deterministic printing). Composites, symbols and big ints
+stay invalid (unhashable / identity-compared). Found on the way:
+`READWithPreamble` swallows placeholder parse errors (`item, _ :=`),
+which had been silently defining `nil` for an unreadable placeholder in
+`TestPassingLispDataFromGo` since before the migration — candidate for
+the robustness backlog. Still pending for 0.4: LANGUAGE.md wording,
 docgen/docs sweep, deciding whether `lnotation` gains keyword-key
-helpers, Tier-2 arbitrary sets/maps (now a small step: relax
-`ValidKey` and extend `KeyLess`).
+helpers.
 
 ## 8. Conclusion
 

--- a/debugadapter/server.go
+++ b/debugadapter/server.go
@@ -529,25 +529,30 @@ func (s *Server) childrenOf(v types.MalType) []Variable {
 	case types.HashMap:
 		out := make([]Variable, 0, len(v.Items))
 		for k, val := range v.Items {
-			displayKey, _ := k.(string)
-			if kw, ok := k.(types.Keyword); ok {
-				displayKey = ":" + string(kw)
-			}
-			out = append(out, s.formatVariable(displayKey, val))
+			out = append(out, s.formatVariable(displayKey(k), val))
 		}
 		return out
 	case types.Set:
 		out := make([]Variable, 0, len(v.Items))
 		for k := range v.Items {
-			name, _ := k.(string)
-			if kw, ok := k.(types.Keyword); ok {
-				name = ":" + string(kw)
-			}
-			out = append(out, s.formatVariable(name, k))
+			out = append(out, s.formatVariable(displayKey(k), k))
 		}
 		return out
 	}
 	return nil
+}
+
+// displayKey renders a hash-map key or set element as a variable name:
+// strings verbatim, keywords with their sigil, other scalars printed.
+func displayKey(k types.MalType) string {
+	switch k := k.(type) {
+	case string:
+		return k
+	case types.Keyword:
+		return ":" + string(k)
+	default:
+		return printer.Pr_str(k, true)
+	}
 }
 
 // formatVariable produces a DAP Variable for the given name/value pair.

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -866,7 +866,7 @@ func assoc(a ...MalType) (MalType, error) {
 		for i := 1; i < len(a); i += 2 {
 			key := a[i]
 			if !ValidKey(key) {
-				return nil, errors.New("assoc called with non-string non-keyword key")
+				return nil, errors.New("assoc requires a scalar key (string, keyword, number, boolean or nil)")
 			}
 			new_hm.Items[key] = a[i+1]
 		}
@@ -892,7 +892,7 @@ func assoc(a ...MalType) (MalType, error) {
 		new_s := copy_set(ms)
 		for _, value := range a[1:] {
 			if !ValidKey(value) {
-				return nil, errors.New("assoc called with non-string non-keyword key")
+				return nil, errors.New("assoc requires a scalar key (string, keyword, number, boolean or nil)")
 			}
 			new_s.Items[value] = struct{}{}
 		}
@@ -913,7 +913,7 @@ func dissoc(a ...MalType) (MalType, error) {
 		for i := 1; i < len(a); i += 1 {
 			key := a[i]
 			if !ValidKey(key) {
-				return nil, errors.New("dissoc called with non-string non-keyword key")
+				return nil, errors.New("dissoc requires a scalar key (string, keyword, number, boolean or nil)")
 			}
 			delete(new_hm.Items, key)
 		}
@@ -922,7 +922,7 @@ func dissoc(a ...MalType) (MalType, error) {
 		new_s := copy_set(ms)
 		for _, value := range a[1:] {
 			if !ValidKey(value) {
-				return nil, errors.New("dissoc called with non-string non-keyword key")
+				return nil, errors.New("dissoc requires a scalar key (string, keyword, number, boolean or nil)")
 			}
 			delete(new_s.Items, value)
 		}
@@ -936,17 +936,11 @@ func get(hm, key MalType) (MalType, error) {
 	if Nil_Q(hm) {
 		return nil, nil
 	}
-	switch key.(type) {
-	case string, Keyword:
-	case int:
-	default:
-		return nil, errors.New("get called with non-string, non-keyword, non-int key")
-	}
 	ms := hm
 	switch ms := ms.(type) {
 	case HashMap:
 		if !ValidKey(key) {
-			return nil, errors.New("get on a hash-map requires a string or keyword key")
+			return nil, errors.New("get on a hash-map requires a scalar key (string, keyword, number, boolean or nil)")
 		}
 		return ms.Items[key], nil
 	case Vector:
@@ -963,7 +957,7 @@ func get(hm, key MalType) (MalType, error) {
 		return ms.Val[i], nil
 	case Set:
 		if !ValidKey(key) {
-			return nil, errors.New("get on a set requires a string or keyword key")
+			return nil, errors.New("get on a set requires a scalar key (string, keyword, number, boolean or nil)")
 		}
 		if _, ok := ms.Items[key]; ok {
 			return key, nil
@@ -1353,7 +1347,7 @@ func conj(a ...MalType) (MalType, error) {
 		for i := 1; i < len(a); i += 2 {
 			key := a[i]
 			if !ValidKey(key) {
-				return nil, errors.New("conj called with non-string non-keyword key")
+				return nil, errors.New("conj requires a scalar key (string, keyword, number, boolean or nil)")
 			}
 			new_hm.Items[key] = a[i+1]
 		}
@@ -1362,7 +1356,7 @@ func conj(a ...MalType) (MalType, error) {
 		new_s := copy_set(seq)
 		for _, key := range a[1:] {
 			if !ValidKey(key) {
-				return nil, errors.New("conj called with non-string non-keyword key")
+				return nil, errors.New("conj requires a scalar key (string, keyword, number, boolean or nil)")
 			}
 			new_s.Items[key] = struct{}{}
 		}
@@ -1387,7 +1381,7 @@ func isMapEntry(v MalType) bool {
 }
 
 // conjMapEntry adds one entry — a [key value] pair or a whole map — to hm
-// in place. Keys must be strings or keywords, as elsewhere for maps.
+// in place. Keys must be valid scalar keys, as elsewhere for maps.
 func conjMapEntry(hm HashMap, entry MalType) error {
 	if e, ok := entry.(HashMap); ok {
 		for k, v := range e.Items {
@@ -1401,7 +1395,7 @@ func conjMapEntry(hm HashMap, entry MalType) error {
 	}
 	key := slc[0]
 	if !ValidKey(key) {
-		return errors.New("conj called with non-string non-keyword key")
+		return errors.New("conj requires a scalar key (string, keyword, number, boolean or nil)")
 	}
 	hm.Items[key] = slc[1]
 	return nil

--- a/placeholder_test.go
+++ b/placeholder_test.go
@@ -660,9 +660,12 @@ func TestPassingLispDataFromGo(t *testing.T) {
 		},
 	}
 	v := []string{"hello", "world"}
-	vs := []MarshalExample{
-		{A: 0, B: "hello"},
-		{A: 1, B: "world"},
+	// Wrapped in LispMarshalExample so the placeholder prints readably
+	// via MarshalHashMap ({:a 0 :b "hello"}); the bare struct would print
+	// as Go's %v ({0 hello}), which is not valid lisp.
+	vs := []LispMarshalExample{
+		{MarshalExample{A: 0, B: "hello"}},
+		{MarshalExample{A: 1, B: "world"}},
 	}
 	source := `(do
 					(def hm $HM)
@@ -673,7 +676,7 @@ func TestPassingLispDataFromGo(t *testing.T) {
 					(assert (= 2 l))
 					(assert (contains? s "bob"))
 					(assert (= "hello" (get v 0)))
-					;; (assert (= "hello" (get-in vs [1 "b"])))
+					(assert (= "world" (get-in vs [1 :b])))
 					true)`
 	sentCode, err := AddPreamble(source, map[string]MalType{
 		"$HM": HM(m),

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -56,8 +56,11 @@ func Pr_str(obj types.MalType, print_readably bool) string {
 	case types.HashMap:
 		return hashMapToString(tobj, print_readably)
 	case types.Set:
-		str_list := make([]string, 0, len(tobj.Items))
-		for k := range tobj.Items {
+		// GetSlice yields the elements in KeyLess order, so sets print
+		// deterministically.
+		elems, _ := types.GetSlice(tobj)
+		str_list := make([]string, 0, len(elems))
+		for _, k := range elems {
 			str_list = append(str_list, Pr_str(k, print_readably))
 		}
 		return "#{" + strings.Join(str_list, " ") + "}"
@@ -135,10 +138,14 @@ func bigIntToHex(i *big.Int) string {
 }
 
 func hashMapToString(tobj types.HashMap, print_readably bool) string {
-	str_list := make([]string, 0, len(tobj.Items)*2)
-	for k, v := range tobj.Items {
-		str_list = append(str_list, Pr_str(k, print_readably))
-		str_list = append(str_list, Pr_str(v, print_readably))
+	// GetSlice yields [key value] entries in KeyLess order, so maps
+	// print deterministically.
+	entries, _ := types.GetSlice(tobj)
+	str_list := make([]string, 0, len(entries)*2)
+	for _, e := range entries {
+		kv := e.(types.Vector).Val
+		str_list = append(str_list, Pr_str(kv[0], print_readably))
+		str_list = append(str_list, Pr_str(kv[1], print_readably))
 	}
 	return "{" + strings.Join(str_list, " ") + "}"
 }

--- a/scalarkeys_test.go
+++ b/scalarkeys_test.go
@@ -1,0 +1,74 @@
+package lisp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jig/lisp/types"
+)
+
+// Hash-map keys and set elements accept any immutable scalar — nil,
+// booleans, ints, floats, strings and keywords — ordered by type group
+// then value (types.KeyLess), so sequencing stays deterministic.
+func TestScalarCollectionKeys(t *testing.T) {
+	ns := seqEnv(t)
+	cases := []struct{ src, want string }{
+		// set literals and constructors
+		{"#{1 2 3}", "#{1 2 3}"},
+		{"(set [3 1 2])", "#{1 2 3}"},
+		{"(= #{1 2} (set [2 1]))", "true"},
+		{"(contains? #{1 2} 2)", "true"},
+		{"(contains? #{1 2} 3)", "false"},
+		{"(contains? #{1.5} 1.5)", "true"},
+		{"(count (into #{} [1 2 2 3]))", "3"},
+		{"(seq #{3 1 2})", "(1 2 3)"},
+		// map literals and access
+		{"(get {1 \"one\" :a 2} 1)", "\"one\""},
+		{"(get {true \"t\"} true)", "\"t\""},
+		{"(get {nil \"n\"} nil)", "\"n\""},
+		{"(get (assoc {} 42 \"x\") 42)", "\"x\""},
+		{"(count (dissoc {1 \"a\" 2 \"b\"} 1))", "1"},
+		{"(contains? {1 \"a\"} 1)", "true"},
+		// deterministic cross-type entry order: nil < booleans < ints <
+		// floats < strings < keywords
+		{"(seq {5 \"a\" 1 \"b\"})", "([1 \"b\"] [5 \"a\"])"},
+		{"(seq {\"s\" 3 :k 4 3 2 true 1 nil 0})", "([nil 0] [true 1] [3 2] [\"s\" 3] [:k 4])"},
+		{"(into {} (map (fn [[k v]] [k (* 2 v)]) {1 10 2 20}))", "{1 20 2 40}"},
+	}
+	for _, c := range cases {
+		res, err := REPL(context.Background(), ns, c.src, types.NewCursorFile(t.Name()))
+		if err != nil {
+			t.Errorf("eval %q: %v", c.src, err)
+			continue
+		}
+		if res.(string) != c.want {
+			t.Errorf("eval %q = %s, want %s", c.src, res, c.want)
+		}
+	}
+}
+
+// Composite values, symbols and big ints are not valid keys: composites
+// are not hashable as Go map keys, and symbols and big ints only compare
+// by identity.
+func TestNonScalarKeysRejected(t *testing.T) {
+	ns := seqEnv(t)
+	for src, wantErr := range map[string]string{
+		"(set [[1 2]])":          "set items must be scalar values",
+		"(assoc {} [1] 2)":       "scalar key",
+		"(assoc #{} [1])":        "scalar key",
+		"{[1] 2}":                "hash-map keys must be scalar values",
+		"(assoc {} 0x0A 1)":      "scalar key",
+		"(dissoc {\"a\" 1} [1])": "scalar key",
+		"(json-encode {1 2})":    "cannot JSON-encode",
+	} {
+		_, err := REPL(context.Background(), ns, src, types.NewCursorFile(t.Name()))
+		if err == nil {
+			t.Errorf("eval %q: expected error, got none", src)
+			continue
+		}
+		if !strings.Contains(err.Error(), wantErr) {
+			t.Errorf("eval %q: error %q, want it to contain %q", src, err, wantErr)
+		}
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -97,33 +97,63 @@ func String_Q(obj MalType) bool {
 }
 
 // ValidKey reports whether obj can be a hash-map key or a set element:
-// a string or a keyword. Restricting keys keeps every map operation
-// panic-free (both types are comparable) and gives them a total order
-// (KeyLess) for deterministic sequencing and printing.
+// any immutable scalar — nil, boolean, int, float, string or keyword.
+// Restricting keys to these keeps every map operation panic-free (all
+// are comparable Go types with value semantics) and gives them a total
+// order (KeyLess) for deterministic sequencing and printing. Composite
+// values (vectors, maps, sets), symbols and big ints are rejected: the
+// first are not hashable as Go map keys, the latter two only compare
+// by pointer identity, which would break lisp value equality.
 func ValidKey(obj MalType) bool {
 	switch obj.(type) {
-	case string, Keyword:
+	case nil, bool, int, float32, string, Keyword:
 		return true
 	}
 	return false
 }
 
+// keyRank groups valid keys by type for KeyLess: nil, booleans,
+// numbers, strings, keywords. (Strings before keywords matches the
+// order the sorted legacy ʞ encoding produced.)
+func keyRank(k MalType) int {
+	switch k.(type) {
+	case nil:
+		return 0
+	case bool:
+		return 1
+	case int:
+		return 2
+	case float32:
+		return 3
+	case string:
+		return 4
+	case Keyword:
+		return 5
+	}
+	return 6
+}
+
 // KeyLess is the total order over valid hash-map keys and set elements:
-// strings first, then keywords, each lexicographically. (Strings-first
-// matches the order the sorted legacy encoding produced, keywords
-// carrying a prefix above ASCII.)
+// by type group (keyRank), then by value within the group.
 func KeyLess(a, b MalType) bool {
-	as, aIsStr := a.(string)
-	bs, bIsStr := b.(string)
-	if aIsStr != bIsStr {
-		return aIsStr
+	ra, rb := keyRank(a), keyRank(b)
+	if ra != rb {
+		return ra < rb
 	}
-	if aIsStr {
-		return as < bs
+	switch a := a.(type) {
+	case bool:
+		return !a && b.(bool)
+	case int:
+		return a < b.(int)
+	case float32:
+		return a < b.(float32)
+	case string:
+		return a < b.(string)
+	case Keyword:
+		return a < b.(Keyword)
+	default: // nil, or invalid keys during error paths
+		return false
 	}
-	ak, _ := a.(Keyword)
-	bk, _ := b.(Keyword)
-	return ak < bk
 }
 
 type ExternalCall func(context.Context, []MalType) (MalType, error)
@@ -239,8 +269,8 @@ func GetSlice(seq MalType) ([]MalType, error) {
 
 // Hash Maps
 type HashMap struct {
-	// Items maps keys to values. Keys are restricted to string and
-	// Keyword (see ValidKey); every constructor validates, so map
+	// Items maps keys to values. Keys are restricted to immutable
+	// scalars (see ValidKey); every constructor validates, so map
 	// operations never hit a non-comparable key.
 	Items  map[MalType]MalType
 	Meta   MalType
@@ -268,7 +298,7 @@ func NewHashMap(cursor *Position, seq MalType) (MalType, error) {
 	m := map[MalType]MalType{}
 	for i := 0; i < len(lst); i += 2 {
 		if !ValidKey(lst[i]) {
-			return nil, fmt.Errorf("expected hash-map key string or keyword (found %T)", lst[i])
+			return nil, fmt.Errorf("hash-map keys must be scalar values — string, keyword, number, boolean or nil (found %T)", lst[i])
 		}
 		m[lst[i]] = lst[i+1]
 	}
@@ -297,7 +327,7 @@ func NewSet(seq MalType) (Set, error) {
 	m := map[MalType]struct{}{}
 	for _, item := range lst {
 		if !ValidKey(item) {
-			return Set{}, errors.New("set items must be strings or keywords")
+			return Set{}, fmt.Errorf("set items must be scalar values — string, keyword, number, boolean or nil (found %T)", item)
 		}
 		m[item] = struct{}{}
 	}
@@ -453,7 +483,7 @@ func ConvertTo(from []MalType, _to MalType, meta MalType) (MalType, error) {
 		to := Set{Items: map[MalType]struct{}{}}
 		for _, k := range from {
 			if !ValidKey(k) {
-				return nil, errors.New("set items must be strings or keywords")
+				return nil, fmt.Errorf("set items must be scalar values — string, keyword, number, boolean or nil (found %T)", k)
 			}
 			to.Items[k] = struct{}{}
 		}


### PR DESCRIPTION
## What

Hash-map keys and set elements accept any **immutable scalar** — nil, booleans, ints, floats, strings and keywords (previously strings and keywords only): `#{1 2 3}`, `{1 "one"}`, `(assoc m 42 v)`, `(contains? #{1.5} 1.5)`, `(into #{} [1 2 2 3])`.

- `ValidKey` relaxed to the scalar set; `KeyLess` becomes a total order by type group (nil < booleans < ints < floats < strings < keywords) then value, preserving the deterministic sequencing that `seq`/`first`/`rest` require.
- `pr-str`/`str` now print maps and sets in that order — `Pr_str` previously iterated the Go map (random per call); only the data printer was deterministic.
- Composite values (vectors, maps, sets), symbols and radix big ints remain invalid keys with a clear construction-time error: composites are not hashable as Go map keys, and symbols/big ints only compare by pointer identity (value-equality would break). Supporting them would be a Tier-3 canonical-form-hashing exercise.
- `json-encode` of non-string/keyword keys keeps erroring (JSON objects require string keys).

## Note

`TestPassingLispDataFromGo` was silently defining `vs` as nil: its `[]MarshalExample` placeholder printed as Go's `%v` (`{0 hello}`), failed to parse, and `READWithPreamble` swallows placeholder parse errors (`item, _ :=`) — with the corresponding assert commented out. Int keys becoming readable surfaced it. The test now wraps the structs in the marshaler type (prints `{:a 0 :b "hello"}`) and the assert is restored; the swallowed-error robustness issue is noted in `ROADMAP-keywords.md` for the backlog.

Full suite green on both tag sets; golangci v2 clean. CHANGELOG 0.4 section updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)