### PR TITLE
feat(core): 0.4 consolidation — loop destructuring, key/val, Clojure reduce-kv, preamble errors, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ pre-1.0, so minor tags can carry behaviour changes; the ones that may
 need action when upgrading are called out under **Changed** with a
 migration note.
 
-## 0.4 (unreleased, branch `proto/keyword-type`)
+## 0.4.0 (unreleased)
+
+Everything since v0.2.24 ships in one release. The headline change is
+the keyword representation — a compile-time break for Go embedders
+(see the Migration section below); lisp code is almost entirely
+unaffected.
 
 ### ⚠️ Changed — keywords are a first-class type
 
@@ -95,8 +100,6 @@ A quick sweep finds the risky spots:
 grep -rn 'ʞ' --include='*.go' .
 grep -rn 'case string\|\.(string)\|Keyword_Q' --include='*.go' .
 ```
-
-## Unreleased (since v0.2.24)
 
 ### ⚠️ Changed — file I/O moved from `core` to `system`
 
@@ -262,6 +265,23 @@ Migration: hex/octal/binary literals used *arithmetically* must become
 decimal (or be wrapped in your own conversion); literals used as
 identifiers or bit patterns keep working and now survive any width.
 
+### ⚠️ Changed — `reduce-kv` folds an associative collection
+
+`reduce-kv` now matches Clojure: it takes a hash-map (calling
+`(f acc k v)` for every entry) or a vector (`(f acc idx v)` per
+element); `nil` folds to `init`. The previous form — a *flat* sequence
+`k1 v1 k2 v2 …` — is gone. New entry accessors `key` and `val` read a
+`[k v]` entry. Migration: `(reduce-kv f init (list k1 v1 …))` becomes
+`(reduce-kv f init (apply hash-map (list k1 v1 …)))`, or restructure
+the data as a map up front.
+
+### Fixed — preamble placeholder parse errors surface
+
+`READWithPreamble` used to silently bind `nil` for a placeholder whose
+value did not parse, deferring the failure to an unrelated error deep
+inside the program; it now returns a read error naming the
+placeholder.
+
 ### Added — seqable hash-maps and sets, sequential destructuring
 
 Hash-maps and sets are now **seqable**, as in Clojure. A hash-map seqs
@@ -289,12 +309,13 @@ Binding forms gained **sequential destructuring**: a vector pattern in
 and recursively (`(fn [[k v]] …)`, `(let [[a [b c]] x] …)`), missing
 elements bind `nil`, extra elements are ignored, and `&` binds the
 remainder as a list. Top-level `fn` arity checking stays strict.
-`loop`/`recur` bindings remain symbol-only for now.
+`loop`/`recur` accept the same patterns, re-destructuring on every
+iteration.
 
 ⚠️ One behaviour change: `(seq #{})` now returns `nil` (Clojure
 parity), where it previously returned `()`. `(seq {})` is also `nil`.
 
-### Other notable additions since v0.2.24
+### Other notable additions
 
 Non-breaking, for context (see `git log v0.2.24..` for the full list):
 

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -103,8 +103,8 @@ look like JSON objects (`{"…"}`) print back with `¬` delimiters.
 | ------- | ---- | ----- |
 | `(a b c)` | list | Also a call form when evaluated (see below). |
 | `[a b c]` | vector | Indexed; the usual choice for data. |
-| `{:k v :k2 v2}` | hash-map | Alternating key/value pairs. |
-| `#{a b}` | set | **Strings and keywords only** (hashed, unordered). |
+| `{:k v :k2 v2}` | hash-map | Alternating key/value pairs; keys are immutable scalars (nil, booleans, numbers, strings, keywords). |
+| `#{a b}` | set | Members are immutable scalars, like hash-map keys (hashed, unordered). |
 
 ### Comments and reader macros
 
@@ -152,9 +152,9 @@ Handled directly by the evaluator (they control when their arguments are evaluat
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
 | `def` | `[symbol value]` | Binds symbol to the evaluated value in the current environment. |
-| `fn` | `[params & body]` | Creates an anonymous function with the given parameter vector and body. |
+| `fn` | `[params & body]` | Creates an anonymous function with the given parameter vector and body. Parameters are symbols or vector patterns (sequential destructuring); & collects the remaining arguments. |
 | `defmacro` | `[name fn]` | Binds name to a macro (a function expanded at evaluation time). |
-| `let` | `[bindings & body]` | Evaluates body in a new scope with the vector's symbol/value bindings; returns the last body form. |
+| `let` | `[bindings & body]` | Evaluates body in a new scope with the vector's binding/value pairs; returns the last body form. A binding is a symbol or a vector pattern (sequential destructuring: [a b], [a [b c]], [x & rest]). |
 | `do` | `[& body]` | Evaluates each form in order and returns the value of the last. |
 | `if` | `[test then else]` | Evaluates test; returns then when it is truthy, else otherwise (else is optional). |
 | `quote` | `[form]` | Returns form unevaluated. |
@@ -163,7 +163,7 @@ Handled directly by the evaluator (they control when their arguments are evaluat
 | `try` | `[expr & clauses]` | Evaluates expr, dispatching to a (catch …) and/or (finally …) clause on error. |
 | `catch` | `[binding & body]` | Inside try: binds the caught error and evaluates body. |
 | `finally` | `[& body]` | Inside try: body is always evaluated for side effects, error or not. |
-| `loop` | `[bindings & body]` | Like let, but a recursion point: recur in tail position rebinds the bindings and jumps back, in constant stack. |
+| `loop` | `[bindings & body]` | Like let (patterns included), but a recursion point: recur in tail position rebinds the bindings and jumps back, in constant stack. |
 | `recur` | `[& args]` | In tail position, rebinds the nearest recursion point — the enclosing loop's bindings, or the enclosing function's parameters — to args and iterates. |
 | `context` | `[& body]` | Provides a Go context to the enclosed forms. |
 
@@ -218,9 +218,9 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `hash-set` | `[& items]` | Creates a set of the given items. |
 | `inc` | `[x]` | Returns x + 1. |
 | `json-decode` | `[factory json]` | Decodes a JSON string into a lisp value. |
-| `json-encode` | `[obj]` | Encodes a lisp value (or Go object) to a JSON string. |
+| `json-encode` | `[obj]` | Encodes a lisp value (or Go object) to a JSON string. Keyword keys and values serialise as their bare name (:a → "a"). |
 | `keys` | `[map]` | Vector of the map's keys. |
-| `keyword` | `[name]` | Creates a keyword from a string. |
+| `keyword` | `[name]` | Creates a keyword from a string; returns a keyword unchanged. |
 | `keyword?` | `[x]` | Whether x is a keyword. |
 | `list` | `[& items]` | Creates a list of the given items. |
 | `list?` | `[x]` | Whether x is a list. |
@@ -234,7 +234,7 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `nil?` | `[x]` | Whether x is nil. |
 | `not` | `[a]` | Logical negation: false when a is truthy, true otherwise. |
 | `not=` | `[a b]` | Logical negation of =. |
-| `nth` | `[coll n]` | The element of coll at zero-based index n. |
+| `nth` | `[coll n]` | The element of coll at zero-based index n (lists, vectors and [k v] entries; not hash-maps or sets, which are unordered). |
 | `number?` | `[x]` | Whether x is a number. |
 | `or ⁽ᵐ⁾` | `[& xs]` | Evaluates its arguments in order, returning the first truthy one, or nil. |
 | `panic` | `[value]` | Raises value as a Go panic. |
@@ -247,7 +247,7 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `read-string` | `[string]` | Reads the first lisp form from string. |
 | `rename-keys` | `[map keymap]` | Copy of map with keys renamed according to keymap. |
 | `rest` | `[coll]` | All but the first element of coll, as a list. |
-| `seq` | `[coll]` | coll as a sequence, or nil when empty. |
+| `seq` | `[coll]` | coll as a sequence, or nil when empty. Hash-maps seq as [key value] entry vectors and sets as their elements, both in sorted order. |
 | `sequential?` | `[x]` | Whether x is a list or vector. |
 | `set` | `[coll]` | Creates a set from the elements of coll. |
 | `set?` | `[x]` | Whether x is a set. |
@@ -346,6 +346,7 @@ Higher-order helpers written in lisp (the prelude): reduce, map, partial, protoc
 | `format` | `[fmt & args]` | Formats args into fmt using Go verbs (%s %d %f %v %q %x ...); collections and keywords render in their lisp form. Returns the string. |
 | `identity` | `[x]` | Returns its argument unchanged. |
 | `into` | `[to from]` | Pours every item of from into to using conj; the result keeps to's type. |
+| `key` | `[entry]` | Returns the key of a [k v] map entry (as produced by seq on a hash-map). |
 | `max` | `[a & more]` | Largest of one or more numbers. |
 | `memoize` | `[f]` | Returns a caching version of f: results are stored by argument and reused. |
 | `min` | `[a & more]` | Smallest of one or more numbers. |
@@ -358,7 +359,7 @@ Higher-order helpers written in lisp (the prelude): reduce, map, partial, protoc
 | `printf` | `[fmt & args]` | Prints (format fmt args...) without a trailing newline; returns nil. |
 | `quot` | `[a b]` | Integer quotient of a divided by b, truncated toward zero. |
 | `reduce` | `[f init xs]` | Left fold: (f (.. (f (f init x1) x2) ..) xn) over the elements of xs. |
-| `reduce-kv` | `[f init xs]` | Left fold over a sequence of key/value pairs: applies (f acc k v) across xs. |
+| `reduce-kv` | `[f init m]` | Left fold over an associative collection: applies (f acc k v) for every      entry of a hash-map, or (f acc idx v) for every element of a vector.      nil folds to init. |
 | `rem` | `[a b]` | Remainder of (quot a b); the sign follows the dividend a. |
 | `remove` | `[pred xs]` | List of the items in xs for which (pred x) is falsy. |
 | `run-fn-for` | `[fn max-secs]` | Returns how many times the no-arg function fn runs in max-secs seconds (after a warm-up). |
@@ -366,6 +367,7 @@ Higher-order helpers written in lisp (the prelude): reduce, map, partial, protoc
 | `some` | `[pred xs]` | Returns the first truthy (pred x) over xs, or nil. |
 | `take-while` | `[pred xs]` | Leading items of xs while (pred x) is truthy. |
 | `time ⁽ᵐ⁾` | `[exp]` | Evaluates exp, prints the elapsed time, and returns its value. |
+| `val` | `[entry]` | Returns the value of a [k v] map entry (as produced by seq on a hash-map). |
 | `zero?` | `[n]` | Whether n equals 0. |
 
 ### system
@@ -489,7 +491,7 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-repla
 | ---- | --------- | ----------- |
 | `web--bearer-token` | `[req]` | Extracts the bearer token from a request's Authorization header, or nil. |
 | `web-bad-request` | `[& msg]` | A 400 JSON response. |
-| `web-encode-json` | `[value]` | Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → "id"), unlike core json-encode. |
+| `web-encode-json` | `[value]` | Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → "id"), as core json-encode also does. |
 | `web-json` | `[status-or-body & maybe-body]` | A JSON response: encodes body and sets content-type. (web-json data) is 200; (web-json status data) sets the status. |
 | `web-log` | `[level msg & kv]` | Emits a structured JSON log line to stderr at level (:debug/:info/:warn/:error) with alternating key/value attributes. |
 | `web-not-found` | `[& msg]` | A 404 JSON response. |
@@ -628,7 +630,17 @@ Mostly for readers coming from Clojure or from other mal implementations:
   int makes it big — but big ints and floats do not mix, machine-int
   overflow wraps (no auto-promotion), and `(= 0x0A 10)` is `false`
   (distinct types).
-- **Sets are limited:** only strings and keywords as members.
+- **Hash-map keys and set members are immutable scalars** — nil,
+  booleans, ints, floats, strings, keywords. Composite values, symbols
+  and big ints are not valid keys.
+- **Hash-maps and sets are seqable** (Clojure-style): `seq`, `map`,
+  `filter`, `reduce`, `first`/`rest` and `(into {} …)` see a hash-map
+  as `[key value]` entry vectors and a set as its elements, in sorted
+  (key-type, then value) order. `nth` on them errors: they are not
+  indexed collections.
+- **Sequential destructuring** works in `fn` parameters and `let`/`loop`
+  bindings: `(fn [[k v]] …)`, `(let [[a [b c]] x] …)`, `[x & rest]`.
+  Missing elements bind `nil`; top-level `fn` arity stays strict.
 - **`let` returns its last body form** (Clojure-like) and evaluates
   every body form; `(do)` returns `nil` (it does not error).
 - **`(range a b)`** returns a *vector* of integers `a … b-1`.

--- a/README.md
+++ b/README.md
@@ -519,6 +519,9 @@ definitions are published under a namespace prefix (Clojure style):
 
 (require "geometry" :refer ["area"])    ; import selected names unqualified
 (area 2)                                ; (geometry/area still available)
+
+(require "geometry" :refer :all)        ; import every definition unqualified
+(perimeter 2)
 ```
 
 Module-internal references stay unqualified: the module's functions

--- a/docmeta/docmeta.go
+++ b/docmeta/docmeta.go
@@ -32,8 +32,8 @@ func (Entry) Kind() string { return "special form" }
 // documenting anything that resolves as a value instead.
 var SpecialForms = map[string]Entry{
 	"def":         {"[symbol value]", "special-forms", "Binds symbol to the evaluated value in the current environment."},
-	"let":         {"[bindings & body]", "special-forms", "Evaluates body in a new scope with the vector's symbol/value bindings; returns the last body form."},
-	"fn":          {"[params & body]", "special-forms", "Creates an anonymous function with the given parameter vector and body."},
+	"let":         {"[bindings & body]", "special-forms", "Evaluates body in a new scope with the vector's binding/value pairs; returns the last body form. A binding is a symbol or a vector pattern (sequential destructuring: [a b], [a [b c]], [x & rest])."},
+	"fn":          {"[params & body]", "special-forms", "Creates an anonymous function with the given parameter vector and body. Parameters are symbols or vector patterns (sequential destructuring); & collects the remaining arguments."},
 	"do":          {"[& body]", "special-forms", "Evaluates each form in order and returns the value of the last."},
 	"if":          {"[test then else]", "special-forms", "Evaluates test; returns then when it is truthy, else otherwise (else is optional)."},
 	"quote":       {"[form]", "special-forms", "Returns form unevaluated."},
@@ -44,6 +44,6 @@ var SpecialForms = map[string]Entry{
 	"catch":       {"[binding & body]", "special-forms", "Inside try: binds the caught error and evaluates body."},
 	"finally":     {"[& body]", "special-forms", "Inside try: body is always evaluated for side effects, error or not."},
 	"context":     {"[& body]", "special-forms", "Provides a Go context to the enclosed forms."},
-	"loop":        {"[bindings & body]", "special-forms", "Like let, but a recursion point: recur in tail position rebinds the bindings and jumps back, in constant stack."},
+	"loop":        {"[bindings & body]", "special-forms", "Like let (patterns included), but a recursion point: recur in tail position rebinds the bindings and jumps back, in constant stack."},
 	"recur":       {"[& args]", "special-forms", "In tail position, rebinds the nearest recursion point — the enclosing loop's bindings, or the enclosing function's parameters — to args and iterates."},
 }

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -57,7 +57,7 @@ var coreDocs = []struct{ name, arglist, doc string }{
 	{"conj", "[coll & items]", "Adds items to a collection (position depends on the collection type)."},
 	{"first", "[coll]", "First element of coll, or nil."},
 	{"rest", "[coll]", "All but the first element of coll, as a list."},
-	{"nth", "[coll n]", "The element of coll at zero-based index n."},
+	{"nth", "[coll n]", "The element of coll at zero-based index n (lists, vectors and [k v] entries; not hash-maps or sets, which are unordered)."},
 	{"count", "[coll]", "Number of elements in coll."},
 	{"get", "[coll key]", "Value at key in a map/vector, or nil."},
 	{"get-in", "[coll keys]", "Nested value reached by following the vector of keys."},
@@ -74,7 +74,7 @@ var coreDocs = []struct{ name, arglist, doc string }{
 	{"take", "[n coll]", "First n elements of coll."},
 	{"drop", "[n coll]", "coll without its first n elements."},
 	{"empty?", "[coll]", "Whether coll has no elements."},
-	{"seq", "[coll]", "coll as a sequence, or nil when empty."},
+	{"seq", "[coll]", "coll as a sequence, or nil when empty. Hash-maps seq as [key value] entry vectors and sets as their elements, both in sorted order."},
 	{"vec", "[coll]", "coll as a vector."},
 
 	// Strings & symbols
@@ -85,7 +85,7 @@ var coreDocs = []struct{ name, arglist, doc string }{
 	{"starts-with?", "[s prefix]", "Whether string s starts with prefix."},
 	{"ends-with?", "[s suffix]", "Whether string s ends with suffix."},
 	{"read-string", "[string]", "Reads the first lisp form from string."},
-	{"keyword", "[name]", "Creates a keyword from a string."},
+	{"keyword", "[name]", "Creates a keyword from a string; returns a keyword unchanged."},
 	{"symbol", "[name]", "Creates a symbol from a string."},
 
 	// I/O
@@ -146,7 +146,7 @@ var coreDocs = []struct{ name, arglist, doc string }{
 	{"unbase64", "[string]", "Decodes a base64 string to a byte string."},
 	{"str2binary", "[string]", "Converts a string to a byte string."},
 	{"binary2str", "[bytes]", "Converts a byte string to a string."},
-	{"json-encode", "[obj]", "Encodes a lisp value (or Go object) to a JSON string."},
+	{"json-encode", "[obj]", "Encodes a lisp value (or Go object) to a JSON string. Keyword keys and values serialise as their bare name (:a → \"a\")."},
 	{"json-decode", "[factory json]", "Decodes a JSON string into a lisp value."},
 	{"hash-map-decode", "[factory json]", "Decodes JSON into a Go-backed hash-map."},
 

--- a/lib/coreextended/header-coreextended.lisp
+++ b/lib/coreextended/header-coreextended.lisp
@@ -50,16 +50,35 @@
       init
       (reduce f (f init (first xs)) (rest xs))))
 
+  (defn key
+    "Returns the key of a [k v] map entry (as produced by seq on a hash-map)."
+    [entry]
+    (nth entry 0))
+
+  (defn val
+    "Returns the value of a [k v] map entry (as produced by seq on a hash-map)."
+    [entry]
+    (nth entry 1))
+
   (defn reduce-kv
-    "Left fold over a sequence of key/value pairs: applies (f acc k v) across xs."
-    [f init xs]
-    ;; f      : Accumulator Element -> Accumulator
+    "Left fold over an associative collection: applies (f acc k v) for every
+     entry of a hash-map, or (f acc idx v) for every element of a vector.
+     nil folds to init."
+    [f init m]
+    ;; f      : Accumulator Key Value -> Accumulator
     ;; init   : Accumulator
-    ;; xs     : sequence of key-value pairs k1-v1 k2-v2...
+    ;; m      : hash-map (entries) | vector (index/element) | nil
     ;; return : Accumulator
-    (if (empty? xs)
+    (if (nil? m)
       init
-      (reduce-kv f (f init (nth xs 0) (nth xs 1)) (rest (rest xs)))))
+      (if (map? m)
+        (reduce (fn [acc [k v]] (f acc k v)) init (seq m))
+        (if (vector? m)
+          (loop [i 0 acc init]
+            (if (< i (count m))
+              (recur (+ i 1) (f acc i (nth m i)))
+              acc))
+          (throw (str "reduce-kv requires a hash-map, vector or nil (got " (type? m) ")"))))))
 
   ;; The natural implementation for 'foldr' is not tail-recursive, and
   ;; the one based on 'reduce' constructs many intermediate functions, so we

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -633,7 +633,7 @@ func Load(env EnvType) {
 		"Emits a structured JSON log line to stderr at level (:debug/:info/:warn/:error) with alternating key/value attributes.")
 	call.CallOverrideFN(env, "web-encode-json", webEncodeJSON)
 	call.Doc(env, "web-encode-json", "[value]",
-		"Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → \"id\"), unlike core json-encode.")
+		"Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → \"id\"), as core json-encode also does.")
 	call.Doc(env, "web-serve", "[config]",
 		"Starts an HTTP(S) server and blocks until interrupted. config is a hash-map: :handler (a Ring handler fn), :port or :addr, and optional :tls {:cert :key :client-ca :client-auth} for HTTPS/mTLS.")
 	call.CallOverrideFN(env, "web-router", webRouter)

--- a/mal.go
+++ b/mal.go
@@ -147,11 +147,20 @@ func READWithPreamble(str string, cursor *Position, ns EnvType) (MalType, error)
 			})
 		}
 		placeholderValue := lineItems[0][2]
-		item, _ := reader.Read_str(placeholderValue, &Position{
+		placeholderKey := lineItems[0][1][3:]
+		// A placeholder that does not parse is an error: silently binding
+		// it to nil defers the failure to an unrelated "symbol not found"
+		// (or worse, a wrong nil) deep inside the evaluated program.
+		item, err := reader.Read_str(placeholderValue, &Position{
 			Row: i + 1,
 			Col: 1,
 		}, nil, ns)
-		placeholderKey := lineItems[0][1][3:]
+		if err != nil {
+			return nil, lisperror.NewLispError(fmt.Errorf("invalid preamble value for %s: %s", placeholderKey, err), &Position{
+				Row: i + 1,
+				Col: 1,
+			})
+		}
 		placeholderMap.Items[placeholderKey] = item
 	}
 }
@@ -648,17 +657,16 @@ func evalInternal(ctx context.Context, ast MalType, env EnvType) (res MalType, e
 				return nil, lisperror.NewLispError(errors.New("loop: odd elements on binding vector"), a1)
 			}
 			loop_env := NewSubordinateEnv(env)
-			syms := make([]Symbol, 0, len(arr1)/2)
+			patterns := make([]MalType, 0, len(arr1)/2)
 			for i := 0; i < len(arr1); i += 2 {
-				if !Q[Symbol](arr1[i]) {
-					return nil, lisperror.NewLispError(errors.New("loop: non-symbol bind value"), a1)
-				}
 				val, e := evalInternal(ctx, arr1[i+1], loop_env)
 				if e != nil {
 					return nil, e
 				}
-				loop_env.Set(arr1[i].(Symbol), val)
-				syms = append(syms, arr1[i].(Symbol))
+				if e := Bind(loop_env, arr1[i], val); e != nil {
+					return nil, lisperror.NewLispError(fmt.Errorf("loop: %s", e), a1)
+				}
+				patterns = append(patterns, arr1[i])
 			}
 			astRef := ast.(List)
 			for {
@@ -670,11 +678,13 @@ func evalInternal(ctx context.Context, ast MalType, env EnvType) (res MalType, e
 				if !ok {
 					return res, nil
 				}
-				if len(rv.args) != len(syms) {
-					return nil, lisperror.NewLispError(fmt.Errorf("recur: got %d arguments but loop has %d bindings", len(rv.args), len(syms)), ast)
+				if len(rv.args) != len(patterns) {
+					return nil, lisperror.NewLispError(fmt.Errorf("recur: got %d arguments but loop has %d bindings", len(rv.args), len(patterns)), ast)
 				}
-				for i, sym := range syms {
-					loop_env.Set(sym, rv.args[i])
+				for i, p := range patterns {
+					if e := Bind(loop_env, p, rv.args[i]); e != nil {
+						return nil, lisperror.NewLispError(fmt.Errorf("recur: %s", e), ast)
+					}
 				}
 			}
 		case "recur":

--- a/seqable_hashmap_test.go
+++ b/seqable_hashmap_test.go
@@ -138,6 +138,68 @@ func TestSequentialDestructuring(t *testing.T) {
 	}
 }
 
+// loop bindings accept the same vector patterns as fn and let, and
+// recur re-destructures on every iteration.
+func TestLoopDestructuring(t *testing.T) {
+	ns := seqEnv(t)
+	cases := []struct{ src, want string }{
+		{"(loop [[a b] [1 10] n 0] (if (< n 3) (recur [b (+ a b)] (+ n 1)) [a b]))", "[21 32]"},
+		{"(loop [[x & xs] [1 2 3] acc 0] (if (nil? x) acc (recur xs (+ acc x))))", "6"},
+		{"(loop [[k v] (first {:a 41})] [k (+ v 1)])", "[:a 42]"},
+	}
+	for _, c := range cases {
+		res, err := REPL(context.Background(), ns, c.src, types.NewCursorFile(t.Name()))
+		if err != nil {
+			t.Errorf("eval %q: %v", c.src, err)
+			continue
+		}
+		if res.(string) != c.want {
+			t.Errorf("eval %q = %s, want %s", c.src, res, c.want)
+		}
+	}
+}
+
+// key/val read map entries; reduce-kv folds associative collections with
+// (f acc k v) as in Clojure (index/element for vectors).
+func TestEntryAccessorsAndReduceKV(t *testing.T) {
+	ns := seqEnv(t)
+	cases := []struct{ src, want string }{
+		{"(key (first {:a 1}))", ":a"},
+		{"(val (first {:a 1}))", "1"},
+		{"(reduce-kv (fn [acc k v] (+ acc v)) 0 {:a 1 :b 2})", "3"},
+		{"(reduce-kv (fn [acc k v] (assoc acc v k)) {} {:a 1 :b 2})", "{1 :a 2 :b}"},
+		{"(reduce-kv (fn [acc i v] (+ acc (* i v))) 0 [10 20 30])", "80"},
+		{"(reduce-kv (fn [acc k v] (+ acc v)) 7 {})", "7"},
+		{"(reduce-kv (fn [acc k v] (+ acc v)) 7 nil)", "7"},
+	}
+	for _, c := range cases {
+		res, err := REPL(context.Background(), ns, c.src, types.NewCursorFile(t.Name()))
+		if err != nil {
+			t.Errorf("eval %q: %v", c.src, err)
+			continue
+		}
+		if res.(string) != c.want {
+			t.Errorf("eval %q = %s, want %s", c.src, res, c.want)
+		}
+	}
+	if _, err := REPL(context.Background(), ns, "(reduce-kv (fn [acc k v] acc) 0 \"nope\")", types.NewCursorFile(t.Name())); err == nil {
+		t.Error("reduce-kv on a string: expected an error, got none")
+	}
+}
+
+// A preamble placeholder that does not parse must surface as a read
+// error, not silently bind nil (which used to defer the failure to an
+// unrelated error deep inside the program).
+func TestPreambleParseErrorSurfaces(t *testing.T) {
+	_, err := READWithPreamble(";; $X {0 hello\n\n(+ 1 1)", types.NewCursorFile(t.Name()), nil)
+	if err == nil {
+		t.Fatal("expected an error for an unparseable placeholder, got none")
+	}
+	if !strings.Contains(err.Error(), "invalid preamble value for $X") {
+		t.Fatalf("error %q, want it to mention the placeholder $X", err)
+	}
+}
+
 // Maps and sets seq but are not indexed: nth must reject them instead of
 // returning a nondeterministic element (Clojure errors here too).
 func TestNthRejectsMapsAndSets(t *testing.T) {


### PR DESCRIPTION
## What

The remaining 0.4 polish, in one PR:

- **`loop`/`recur` destructuring**: loop bindings accept the same vector patterns as `fn` and `let`, re-destructuring on every iteration. Sequential destructuring now covers all binding forms.
- **`key`/`val`** entry accessors (coreextended).
- **⚠️ `reduce-kv` is now Clojure's**: folds an associative collection — `(f acc k v)` per hash-map entry, `(f acc idx v)` per vector element, `nil` → `init`. The old flat `k1 v1 …` sequence form is gone (breaking; CHANGELOG has the migration line).
- **`READWithPreamble` surfaces placeholder parse errors** instead of silently binding `nil` (the robustness issue found while landing Tier-2).
- **Docs**: LANGUAGE.md collections/gotchas updated for scalar keys, seqable maps/sets and destructuring; `fn`/`let`/`loop` docmeta mention patterns; stale docstrings refreshed (`seq`, `nth`, `keyword`, `json-encode`, `web-encode-json`); builtin reference regenerated.
- **CHANGELOG consolidated into a single `0.4.0 (unreleased)` section** covering everything since v0.2.24 — the 0.3/0.4 split stopped making sense once the keyword break merged to develop.
- README: document `require :refer :all` (small doc improvement).

Full suite green on both tag sets; golangci v2 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)