### PR TITLE
chore: renumber unreleased versions — 0.5.0 (pre-keyword) and 0.6.0 (keywords)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ pre-1.0, so minor tags can carry behaviour changes; the ones that may
 need action when upgrading are called out under **Changed** with a
 migration note.
 
-## 0.4.0 (unreleased)
+> **Version numbering note.** The 0.3.x tags were published
+> prematurely and are **retracted** (`@latest` resolves to v0.2.24);
+> the 0.4.x numbers are **skipped forever** (guarded by a `retract`
+> range) because pre-release documents used "0.4" for the keyword
+> work. The pre-keyword line ships as **v0.5.0** and the keyword
+> migration as **v0.6.0**.
 
-On top of v0.3.0. The headline change is the keyword
+## 0.6.0 (unreleased)
+
+On top of 0.5.0. The headline change is the keyword
 representation — a compile-time break for Go embedders (see the
 Migration section below); lisp code is almost entirely unaffected.
 
@@ -66,7 +73,7 @@ the data as a map up front.
 ### Added — destructuring in `loop`/`recur`
 
 `loop` bindings accept the same vector patterns as `fn` parameters and
-`let` bindings (introduced in v0.3.0), re-destructuring on every
+`let` bindings (introduced in 0.5.0), re-destructuring on every
 `recur`. Sequential destructuring now covers every binding form. Also
 new: `key`/`val` entry accessors in `coreextended`.
 
@@ -124,7 +131,11 @@ grep -rn 'ʞ' --include='*.go' .
 grep -rn 'case string\|\.(string)\|Keyword_Q' --include='*.go' .
 ```
 
-## v0.3.0 — 2026-07-24
+## 0.5.0 (unreleased)
+
+Everything since v0.2.24 up to (excluding) the keyword-type
+migration. Briefly tagged `v0.3.0` on 2026-07-24; that tag is
+retracted — this content ships as v0.5.0.
 
 ### ⚠️ Changed — file I/O moved from `core` to `system`
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,66 +1,75 @@
 # Releasing jig/lisp
 
-How a tagged release is cut. The goal of this document (roadmap item
-5.4) is that every future tag ships with notes — the historical tags up
-to `v0.2.24` have none.
+How versions are published. Rewritten 2026-07-25 after the 0.3.x
+incident; the previous `main`-based flow is retired.
 
-## Branch model
+## Ground rules
 
-- **`develop`** — integration branch; every PR merges here.
-- **`main`** — release branch; only fast-forwarded/merged from `develop`
-  at release time. `origin/HEAD` points here.
-- **Tags** `vMAJOR.MINOR.PATCH` live on `main`.
+- **Tags are the release mechanism.** They are placed directly on the
+  commit to release (normally on `develop`, or on a `release/*` branch
+  when cherry-picking). `main` is not part of the flow and stays
+  untouched; GitHub Releases are not used for now.
+- **A public semver tag is immediately live**: the Go module proxy
+  archives it — immutably — the first time anyone resolves it, and a
+  plain release tag becomes the `@latest` answer at once. There is no
+  such thing as a quiet release tag. Do not create `vX.Y.Z` until that
+  version should be what `go install …@latest` delivers.
+- **Pre-release tags are the validation tool.** `vX.Y.Z-rc.N` (or
+  `-beta.N`) can be tagged and shared freely: the go command never
+  selects pre-releases for `@latest` while any release version exists,
+  so users can `go install …@v0.6.0-rc.1` explicitly without affecting
+  everyone else.
+- **`@latest` currently must resolve to `v0.2.24`** until embedders
+  have been validated against the new features. Nothing above v0.2.24
+  gets a release (non-pre-release) tag until then.
 
-Pre-1.0, so a **minor** bump may carry breaking changes (e.g. the
-`coreextented` → `coreextended` rename and the error-format change land
-in 0.3). Anything users must act on goes in `CHANGELOG.md` under
-**Changed** with a migration note.
+## Version numbering
+
+| Range | Status |
+| ----- | ------ |
+| ≤ v0.2.24 | Historical releases; v0.2.24 is the current `@latest`. |
+| v0.3.0, v0.3.1 | **Retracted** (published prematurely; v0.3.1 is retraction-only). Never reuse. |
+| v0.4.x | **Skipped forever** — pre-release documents used "0.4" for the keyword work; a `retract [v0.4.0, v0.4.99]` guard hides any accidental tag. |
+| v0.5.0 | Will ship the pre-keyword line: everything since v0.2.24 up to (excluding) the keyword-type migration — the tree at the merge of #133 (`30349af`). |
+| v0.6.0 | Will ship the keyword-type migration (the Go-embedder breaking change) and everything after. |
+
+The `retract` block in `go.mod` **must be carried unchanged into every
+future release**: the go command reads retractions from the highest
+published version, so dropping the block would resurrect the retracted
+versions in listings.
 
 ## Cutting a release
 
-1. **Make sure `develop` is green** — the `test`, `race`, `fuzz` and
-   `quality` CI jobs all pass.
-
-2. **Finalise the changelog.** In `CHANGELOG.md`, rename the
-   `## Unreleased (since vX)` heading to `## vNEW — YYYY-MM-DD` and open
-   a fresh empty `## Unreleased` above it. This section becomes the
-   release notes, so keep the **Changed / breaking** items at the top.
-
-3. **Merge `develop` into `main`.**
+1. `develop` green in CI (test, race, fuzz, quality, golangci).
+2. Finalise `CHANGELOG.md`: rename the target `## X.Y.Z (unreleased)`
+   heading to `## vX.Y.Z — YYYY-MM-DD` (keep ⚠️ items at the top) and
+   merge that via PR.
+3. Check `go.mod` still contains the `retract` block.
+4. Tag the release commit with an **annotated tag** and push it:
 
    ```bash
-   git checkout main && git merge --ff-only develop   # or a merge commit
-   git push origin main
+   git tag -a vX.Y.Z -m "jig/lisp vX.Y.Z"
+   git push origin vX.Y.Z
    ```
 
-4. **Tag `main` with an annotated tag** (historical tags are lightweight;
-   prefer annotated from now on so `git describe` and the release carry a
-   message):
+   For a validation cycle, tag `vX.Y.Z-rc.N` instead — same commands.
+5. Verify resolution and installation:
 
    ```bash
-   git tag -a vNEW -m "jig/lisp vNEW"
-   git push origin vNEW
+   go list -m github.com/jig/lisp@vX.Y.Z     # forces the proxy to index it
+   go install -tags debugger github.com/jig/lisp/cmd/lisp@vX.Y.Z
+   go list -m github.com/jig/lisp@latest     # release tags only: confirm the flip
    ```
 
-5. **Publish the GitHub release** with the changelog section as the body:
+   The sum DB may answer 500 for a brand-new tag; retry after a few
+   seconds. `@latest` may lag a few minutes behind (proxy cache).
 
-   ```bash
-   # notes taken from the just-finalised CHANGELOG section
-   gh release create vNEW --title "vNEW" --notes-file <(sed -n '/## vNEW/,/## v/p' CHANGELOG.md)
-   # or let GitHub auto-generate from merged PRs and edit afterwards:
-   # gh release create vNEW --generate-notes
-   ```
+## Undoing a mistake
 
-6. **Verify** the module is installable at the new tag:
-
-   ```bash
-   go install -tags debugger github.com/jig/lisp/cmd/lisp@vNEW
-   ```
-
-## Backfilling older tags (optional)
-
-The tags up to `v0.2.24` predate the changelog and have no GitHub
-release. Backfilling is optional; if wanted, `gh release create <tag>
---generate-notes` produces reasonable notes from the merged PRs between
-tags. Start with the next release rather than spending effort on old
-ones.
+A published version cannot be unpublished (proxy and sum DB are
+immutable). The correct tool is `retract`: add the bad version to the
+`retract` block and publish a new highest version carrying it (a
+retraction-only patch release based on the last good tree, as v0.3.1
+does). `@latest` then falls back to the highest non-retracted version.
+Keep the git tag of the bad version pointing at the tree the proxy
+recorded, so `GOPROXY=direct` users do not get checksum mismatches.

--- a/ROADMAP-keywords.md
+++ b/ROADMAP-keywords.md
@@ -1,5 +1,11 @@
 # ROADMAP: first-class keyword type
 
+> **Version numbering note (2026-07-25).** This document predates the
+> renumbering: what it calls "0.4" ships as **v0.6.0**, and the
+> pre-keyword line ("0.3.x" here) ships as **v0.5.0**. The 0.3.x tags
+> are retracted and the 0.4.x numbers are skipped forever. See
+> RELEASING.md.
+
 Study (2026-07-24) on replacing the current keyword representation — a Go
 `string` with the `ʞ` (U+029E) prefix, inherited from kanaka/mal — with a
 dedicated Go type. Includes the related gap that `seq`, `map`, `filter` and

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ go 1.25.0
 retract (
 	v0.3.0 // Published prematurely; use v0.2.24.
 	v0.3.1 // Contains only this retraction.
+	[v0.4.0, v0.4.99] // Never published: the 0.4 numbers are skipped (pre-release docs used "0.4" for what ships as 0.6.0).
 )
 
 require (

--- a/types/types.go
+++ b/types/types.go
@@ -82,7 +82,7 @@ func KW(s string) Keyword {
 // NewKeyword builds the keyword :s from its name (without the colon).
 //
 // Deprecated: use KW. NewKeyword returned the prefixed-string
-// representation before 0.4 and is kept so embedder code keeps
+// representation before 0.6.0 and is kept so embedder code keeps
 // compiling; it now returns a Keyword.
 func NewKeyword(s string) Keyword {
 	return Keyword(s)
@@ -423,7 +423,7 @@ func Equal_Q(a, b MalType) bool {
 }
 
 // MarshalJSON serialises keyword keys as their bare name (:a → "a"),
-// as Clojure JSON emitters do. (Before 0.4 the internal ʞ prefix leaked
+// as Clojure JSON emitters do. (Before 0.6.0 the internal ʞ prefix leaked
 // into the JSON output.) A map holding both :x and "x" produces
 // duplicate JSON keys — of which one survives, unspecified.
 func (hm HashMap) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Implements the agreed version renumbering:

- **0.3.x**: retracted (already done), never reused.
- **0.4.x**: skipped forever — pre-release docs used "0.4" for the keyword work; a `retract [v0.4.0, v0.4.99]` guard in go.mod hides any accidental tag.
- **0.5.0**: the pre-keyword line (everything since v0.2.24 up to and excluding the keyword migration; the tree at the merge of #133).
- **0.6.0**: the keyword-type migration and everything after.

Changes: CHANGELOG sections renamed (0.4.0→0.6.0; the briefly-tagged v0.3.0 section → 0.5.0 unreleased) with a numbering note; `types.go` comments updated (the keyword change ships in 0.6.0); numbering note atop ROADMAP-keywords.md; **RELEASING.md rewritten** for the new policy: tags directly on commits, `main` untouched, no GitHub Releases, `-rc.N` pre-release tags for validation (they never capture `@latest`), and `@latest` pinned to v0.2.24 until embedders are validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)