### PR TITLE
feat(log): lib/log structured JSON logging; remove web-log/web-wrap-log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,23 @@ the latter two only compare by identity — and error at construction.
 `json-encode` of a map with non-string/keyword keys errors (JSON
 objects require string keys).
 
+### Added — `lib/log`, structured JSON logging
+
+New `log` namespace: `log-debug` / `log-info` / `log-warn` /
+`log-error` emit one slog-style JSON line to stderr with alternating
+key/value attributes — `(log-info "user created" :id 42)`. Keys are
+keywords or strings (keywords lose their sigil); primitive values pass
+through as JSON, anything else renders via the Lisp printer. The
+minimum level comes from the `LOG_LEVEL` environment variable
+(`debug`/`info`/`warn`/`error`, default `info`), read at load time.
+
+### ⚠️ Removed — `web-log` and `web-wrap-log`
+
+Logging moves out of `lib/web` into `lib/log`. Migration:
+`(web-log :info "msg" "k" v)` becomes `(log-info "msg" :k v)` (per
+level), and `web-wrap-log` users write the one-liner middleware over
+`log-info` themselves (example in `lib/web/README.md`).
+
 ### ⚠️ Changed — `reduce-kv` folds an associative collection
 
 `reduce-kv` now matches Clojure: it takes a hash-map (calling

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -493,7 +493,6 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-repla
 | `web-bad-request` | `[& msg]` | A 400 JSON response. |
 | `web-encode-json` | `[value]` | Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → "id"), as core json-encode also does. |
 | `web-json` | `[status-or-body & maybe-body]` | A JSON response: encodes body and sets content-type. (web-json data) is 200; (web-json status data) sets the status. |
-| `web-log` | `[level msg & kv]` | Emits a structured JSON log line to stderr at level (:debug/:info/:warn/:error) with alternating key/value attributes. |
 | `web-not-found` | `[& msg]` | A 404 JSON response. |
 | `web-redirect` | `[location & status]` | A redirect response (status 302 unless given as the second arg). |
 | `web-response` | `[status body & headers]` | Builds a response map with the given status and body, plus optional header pairs. |
@@ -505,7 +504,6 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-repla
 | `web-wrap-identity` | `[handler]` | Middleware: promotes a verified mTLS client certificate to :identity {:kind :mtls :subject cn}. |
 | `web-wrap-json-body` | `[handler]` | Middleware: when the request body is a non-empty JSON object, decodes it under :json (nil on parse error). |
 | `web-wrap-jwt` | `[config handler]` | Middleware: verifies a Bearer JWT against config (see web-verify-jwt) and sets :identity {:kind :jwt :claims …}; responds 401 when missing or invalid. config is the JWKS/issuer map. |
-| `web-wrap-log` | `[handler]` | Middleware: logs one structured JSON line per request with method, uri, status and elapsed ms. |
 | `web-wrap-recover` | `[handler]` | Middleware: turns any error escaping the handler into a 500 JSON response instead of dropping the connection. |
 
 ### git
@@ -570,6 +568,15 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-repla
 | `test/run-tests!` | `[]` | Runs every registered test and returns the results as data. |
 | `test/with-out-str*` | `[thunk]` | Runs thunk capturing standard output and returns it as a string; (with-out-str …) expands to this. |
 | `with-out-str ⁽ᵐ⁾` | `[& body]` | Evaluates body capturing standard output and returns it as a string (Clojure-style); output from concurrent goroutines is captured too. |
+
+### log
+
+| Name | Arguments | Description |
+| ---- | --------- | ----------- |
+| `log-debug` | `[msg & kv]` | Emits a structured JSON log line to stderr at debug level with alternating keyword/value attributes; suppressed unless LOG_LEVEL=debug. |
+| `log-error` | `[msg & kv]` | Emits a structured JSON log line to stderr at error level with alternating keyword/value attributes. |
+| `log-info` | `[msg & kv]` | Emits a structured JSON log line to stderr at info level with alternating keyword/value attributes, e.g. (log-info "user created" :id 42). |
+| `log-warn` | `[msg & kv]` | Emits a structured JSON log line to stderr at warn level with alternating keyword/value attributes. |
 
 ⁽ᵐ⁾ = macro (arguments are not evaluated before the call).
 

--- a/cmd/lisp/main.go
+++ b/cmd/lisp/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jig/lisp/lib/git/nsgit"
 	"github.com/jig/lisp/lib/integrity/nsintegrity"
 	"github.com/jig/lisp/lib/lazy/nslazy"
+	"github.com/jig/lisp/lib/log/nslog"
 	"github.com/jig/lisp/lib/regexp/nsregexp"
 	"github.com/jig/lisp/lib/require/nsrequire"
 	"github.com/jig/lisp/lib/sql/nssql"
@@ -54,6 +55,9 @@ func libraries(scriptArgs []string) []library {
 		{"git", nsgit.Load},
 		{"term", nsterm.Load},
 		{"test", nstest.Load},
+
+		// new libraries on jig/lisp v0.6.0
+		{"log", nslog.Load},
 	}
 }
 

--- a/docgen/libraries.go
+++ b/docgen/libraries.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jig/lisp/lib/git/nsgit"
 	"github.com/jig/lisp/lib/integrity/nsintegrity"
 	"github.com/jig/lisp/lib/lazy/nslazy"
+	"github.com/jig/lisp/lib/log/nslog"
 	"github.com/jig/lisp/lib/regexp/nsregexp"
 	"github.com/jig/lisp/lib/require/nsrequire"
 	"github.com/jig/lisp/lib/sql/nssql"
@@ -49,6 +50,7 @@ func standardLibraries() []library {
 		{"git", nsgit.Load},
 		{"term", nsterm.Load},
 		{"test", nstest.Load},
+		{"log", nslog.Load},
 	}
 }
 

--- a/lib/log/README.md
+++ b/lib/log/README.md
@@ -1,0 +1,38 @@
+# lib/log — structured JSON logging
+
+Structured logging for jig/lisp scripts, backed by Go's `log/slog`.
+Each call emits one JSON line to stderr:
+
+```clojure
+(log-info "user created" :id 42 :name "ada")
+```
+
+```json
+{"time":"2026-07-25T15:04:05Z","level":"INFO","msg":"user created","id":42,"name":"ada"}
+```
+
+## Builtins
+
+| Function | Signature | Level |
+|---|---|---|
+| `log-debug` | `[msg & kv]` | DEBUG |
+| `log-info` | `[msg & kv]` | INFO |
+| `log-warn` | `[msg & kv]` | WARN |
+| `log-error` | `[msg & kv]` | ERROR |
+
+`kv` are alternating key/value pairs. Keys are keywords (or strings);
+keywords lose their sigil in the output (`:id` → `"id"`). Primitive
+values (strings, numbers, booleans, nil, keywords) pass through as
+JSON; anything else (vectors, maps, errors…) is rendered with the Lisp
+printer. An odd number of `kv` arguments is an error.
+
+## Level filtering
+
+The minimum level comes from the `LOG_LEVEL` environment variable —
+`debug`, `info`, `warn` or `error` — read when the namespace loads.
+Unset (or unrecognised) means `info`, so `log-debug` lines are
+suppressed by default:
+
+```sh
+LOG_LEVEL=debug lisp run service.lisp
+```

--- a/lib/log/export_test.go
+++ b/lib/log/export_test.go
@@ -1,0 +1,8 @@
+package log
+
+import "io"
+
+// SetOutput redirects the package logger for tests.
+func SetOutput(w io.Writer) {
+	logger = newLogger(w)
+}

--- a/lib/log/log.go
+++ b/lib/log/log.go
@@ -1,0 +1,130 @@
+// Package log adds structured JSON logging to jig/lisp, backed by Go's
+// log/slog. Four builtins — log-debug, log-info, log-warn, log-error —
+// emit one JSON line to stderr with alternating key/value attributes:
+//
+//	(log-info "user created" :id 42)
+//	{"time":"…","level":"INFO","msg":"user created","id":42}
+//
+// Keys are keywords (or strings); keywords lose their sigil in the
+// output. Values pass through as JSON when primitive and render via the
+// Lisp printer otherwise. The minimum level is set by the LOG_LEVEL
+// environment variable (debug/info/warn/error; anything else, or unset,
+// means info), read when the namespace loads.
+package log
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/jig/lisp/lib/call"
+	"github.com/jig/lisp/printer"
+	. "github.com/jig/lisp/types"
+)
+
+var (
+	level  = new(slog.LevelVar)
+	logger = newLogger(os.Stderr)
+)
+
+func newLogger(w io.Writer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level}))
+}
+
+// parseLevel maps a LOG_LEVEL value to a slog level; unknown or empty
+// values mean Info.
+func parseLevel(s string) slog.Level {
+	switch s {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// logKey renders a log attribute key: keywords lose their sigil,
+// strings pass verbatim.
+func logKey(fnName string, v MalType) (string, error) {
+	switch v := v.(type) {
+	case Keyword:
+		return string(v), nil
+	case string:
+		return v, nil
+	default:
+		return "", fmt.Errorf("%s: expected a keyword or string key, got %T", fnName, v)
+	}
+}
+
+// logValue renders a Lisp value for a log attribute: keywords lose
+// their sigil, primitives pass through as themselves, everything else
+// is printed.
+func logValue(v MalType) any {
+	switch v := v.(type) {
+	case Keyword:
+		return string(v)
+	case string:
+		return v
+	case int, float32, float64, bool, nil:
+		return v
+	default:
+		return printer.Pr_str(v, false)
+	}
+}
+
+// logAt logs msg at level with alternating key/value attributes.
+func logAt(fnName string, level slog.Level, msg string, kv []MalType) (MalType, error) {
+	if len(kv)%2 != 0 {
+		return nil, fmt.Errorf("%s: odd number of key/value arguments", fnName)
+	}
+	attrs := make([]any, 0, len(kv))
+	for i := 0; i < len(kv); i += 2 {
+		key, err := logKey(fnName, kv[i])
+		if err != nil {
+			return nil, err
+		}
+		attrs = append(attrs, key, logValue(kv[i+1]))
+	}
+	logger.Log(context.Background(), level, msg, attrs...)
+	return nil, nil
+}
+
+func logDebug(msg string, kv ...MalType) (MalType, error) {
+	return logAt("log-debug", slog.LevelDebug, msg, kv)
+}
+
+func logInfo(msg string, kv ...MalType) (MalType, error) {
+	return logAt("log-info", slog.LevelInfo, msg, kv)
+}
+
+func logWarn(msg string, kv ...MalType) (MalType, error) {
+	return logAt("log-warn", slog.LevelWarn, msg, kv)
+}
+
+func logError(msg string, kv ...MalType) (MalType, error) {
+	return logAt("log-error", slog.LevelError, msg, kv)
+}
+
+// Load registers the log builtins and reads LOG_LEVEL.
+func Load(env EnvType) {
+	level.Set(parseLevel(os.Getenv("LOG_LEVEL")))
+
+	call.CallOverrideFN(env, "log-debug", logDebug)
+	call.CallOverrideFN(env, "log-info", logInfo)
+	call.CallOverrideFN(env, "log-warn", logWarn)
+	call.CallOverrideFN(env, "log-error", logError)
+
+	call.Doc(env, "log-debug", "[msg & kv]",
+		"Emits a structured JSON log line to stderr at debug level with alternating keyword/value attributes; suppressed unless LOG_LEVEL=debug.")
+	call.Doc(env, "log-info", "[msg & kv]",
+		"Emits a structured JSON log line to stderr at info level with alternating keyword/value attributes, e.g. (log-info \"user created\" :id 42).")
+	call.Doc(env, "log-warn", "[msg & kv]",
+		"Emits a structured JSON log line to stderr at warn level with alternating keyword/value attributes.")
+	call.Doc(env, "log-error", "[msg & kv]",
+		"Emits a structured JSON log line to stderr at error level with alternating keyword/value attributes.")
+}

--- a/lib/log/log_test.go
+++ b/lib/log/log_test.go
@@ -1,0 +1,125 @@
+package log_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core/nscore"
+	liblog "github.com/jig/lisp/lib/log"
+	"github.com/jig/lisp/lib/log/nslog"
+	"github.com/jig/lisp/types"
+)
+
+// newEnv builds an environment with the log namespace loaded (reading
+// LOG_LEVEL) and the package logger redirected to the returned buffer.
+func newEnv(t *testing.T, logLevel string) (types.EnvType, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("LOG_LEVEL", logLevel)
+	ns := env.NewEnv()
+	if err := nscore.Load(ns); err != nil {
+		t.Fatal(err)
+	}
+	if err := nslog.Load(ns); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	liblog.SetOutput(&buf)
+	return ns, &buf
+}
+
+func eval(t *testing.T, ns types.EnvType, src string) {
+	t.Helper()
+	if _, err := lisp.REPL(context.Background(), ns, src, types.NewCursorFile(t.Name())); err != nil {
+		t.Fatalf("EVAL %s: %v", src, err)
+	}
+}
+
+// lines decodes each JSON log line in buf.
+func lines(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("log line is not JSON: %q: %v", line, err)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func TestLogAttributes(t *testing.T) {
+	ns, buf := newEnv(t, "")
+	eval(t, ns, `(log-info "user created" :id 42 "name" "ada" :ok true :ratio 1.5 :tags [1 2])`)
+	got := lines(t, buf)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 log line, got %d", len(got))
+	}
+	m := got[0]
+	if m["level"] != "INFO" || m["msg"] != "user created" {
+		t.Fatalf("unexpected level/msg: %v", m)
+	}
+	if m["id"] != float64(42) || m["name"] != "ada" || m["ok"] != true || m["ratio"] != 1.5 {
+		t.Fatalf("unexpected attributes: %v", m)
+	}
+	if m["tags"] != "[1 2]" {
+		t.Fatalf("composite value should render via the printer, got %v", m["tags"])
+	}
+	if _, ok := m["time"]; !ok {
+		t.Fatalf("missing time: %v", m)
+	}
+}
+
+func TestLogLevels(t *testing.T) {
+	ns, buf := newEnv(t, "")
+	eval(t, ns, `(log-debug "d")`)
+	eval(t, ns, `(log-info "i")`)
+	eval(t, ns, `(log-warn "w")`)
+	eval(t, ns, `(log-error "e")`)
+	got := lines(t, buf)
+	if len(got) != 3 {
+		t.Fatalf("default level must drop debug; got %d lines: %v", len(got), got)
+	}
+	for i, want := range []string{"INFO", "WARN", "ERROR"} {
+		if got[i]["level"] != want {
+			t.Fatalf("line %d: expected level %s, got %v", i, want, got[i]["level"])
+		}
+	}
+}
+
+func TestLogLevelEnv(t *testing.T) {
+	ns, buf := newEnv(t, "debug")
+	eval(t, ns, `(log-debug "d" :k :v)`)
+	got := lines(t, buf)
+	if len(got) != 1 || got[0]["level"] != "DEBUG" || got[0]["k"] != "v" {
+		t.Fatalf("LOG_LEVEL=debug must emit debug lines: %v", got)
+	}
+
+	ns, buf = newEnv(t, "error")
+	eval(t, ns, `(log-warn "w")`)
+	eval(t, ns, `(log-error "e")`)
+	got = lines(t, buf)
+	if len(got) != 1 || got[0]["level"] != "ERROR" {
+		t.Fatalf("LOG_LEVEL=error must drop warn: %v", got)
+	}
+}
+
+func TestLogBadArguments(t *testing.T) {
+	ns, _ := newEnv(t, "")
+	for _, src := range []string{
+		`(log-info "msg" :dangling)`,
+		`(log-info "msg" 42 "value")`,
+	} {
+		if _, err := lisp.REPL(context.Background(), ns, src, types.NewCursorFile(t.Name())); err == nil {
+			t.Fatalf("%s did not error", src)
+		}
+	}
+}

--- a/lib/log/nslog/nslog.go
+++ b/lib/log/nslog/nslog.go
@@ -1,0 +1,12 @@
+// Package nslog loads the log namespace into a jig/lisp environment.
+package nslog
+
+import (
+	"github.com/jig/lisp/lib/log"
+	"github.com/jig/lisp/types"
+)
+
+func Load(env types.EnvType) error {
+	log.Load(env)
+	return nil
+}

--- a/lib/web/README.md
+++ b/lib/web/README.md
@@ -16,7 +16,6 @@ no socket required.
         [["/ping"        {:get (fn [req] (web-json {:pong true}))}]
          ["/certs/:id"   {:get (fn [req] (web-json {:id (get (get req :path-params) :id)}))}]])
       web-wrap-json-body     ; decodes a JSON body under :json
-      web-wrap-log           ; one structured JSON log line per request
       web-wrap-recover))     ; errors become 500 instead of dropping the connection
 
 (web-serve {:port 8443
@@ -93,8 +92,8 @@ underlying primitive if you need the claims directly.
 ## Middleware
 
 Middleware is `handler → handler`; compose with `->`. Built-in:
-`web-wrap-recover`, `web-wrap-log`, `web-wrap-json-body`,
-`web-wrap-identity`, `web-wrap-jwt`. Write your own the same way:
+`web-wrap-recover`, `web-wrap-json-body`, `web-wrap-identity`,
+`web-wrap-jwt`. Write your own the same way:
 
 ```clojure
 (defn wrap-require-role [role handler]
@@ -102,6 +101,21 @@ Middleware is `handler → handler`; compose with `->`. Built-in:
     (if (contains? (get-in req [:identity :claims :realm_access :roles]) role)
       (handler req)
       (web-unauthorized "forbidden"))))
+```
+
+For an access log, combine it with `lib/log`:
+
+```clojure
+(defn wrap-log [handler]
+  (fn [req]
+    (let [start (time-ms)
+          resp  (handler req)]
+      (log-info "http request"
+        :method (get req :method)
+        :uri (get req :uri)
+        :status (get resp :status)
+        :ms (- (time-ms) start))
+      resp)))
 ```
 
 ## Not yet

--- a/lib/web/header-web.lisp
+++ b/lib/web/header-web.lisp
@@ -3,7 +3,7 @@
 ;; Ring-style response helpers and middleware for the web library.
 ;; A response is {:status :headers :body}; a handler is (fn [req] resp);
 ;; middleware is (fn [handler] (fn [req] resp)). Compose middleware with
-;; -> , e.g. (-> app http/wrap-json-body http/wrap-log http/wrap-recover).
+;; -> , e.g. (-> app web-wrap-json-body web-wrap-recover).
 (do
     (defn web-response
         "Builds a response map with the given status and body, plus optional header pairs."
@@ -62,19 +62,6 @@
                 (if (and (string? body) (not (= "" body)))
                     (handler (assoc req :json (try (json-decode {} body) (catch e nil))))
                     (handler req)))))
-
-    (defn web-wrap-log
-        "Middleware: logs one structured JSON line per request with method, uri, status and elapsed ms."
-        [handler]
-        (fn [req]
-            (let [start (time-ms)
-                  resp  (handler req)]
-                (web-log :info "http request"
-                    "method" (get req :method)
-                    "uri" (get req :uri)
-                    "status" (get resp :status)
-                    "ms" (- (time-ms) start))
-                resp)))
 
     (defn web-wrap-identity
         "Middleware: promotes a verified mTLS client certificate to :identity {:kind :mtls :subject cn}."

--- a/lib/web/nsweb/nsweb.go
+++ b/lib/web/nsweb/nsweb.go
@@ -1,6 +1,6 @@
 // Package nsweb loads the web (Ring-style HTTP server) namespace into a
 // jig/lisp environment: the Go builtins (web-serve, web-router,
-// web-verify-jwt, web-log) plus the response helpers and middleware
+// web-verify-jwt) plus the response helpers and middleware
 // defined in header-web.lisp.
 package nsweb
 

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"maps"
 	"net/http"
 	"os"
@@ -579,58 +578,10 @@ func webVerifyJWT(token string, config MalType) (MalType, error) {
 	return jsonToMal(generic), nil
 }
 
-// --- logging -------------------------------------------------------------
-
-// webLogger emits structured JSON to stderr, matching the slog-JSON
-// convention used across the surrounding Go services.
-var webLogger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
-
-// logValue renders a Lisp value for a log attribute: keywords lose their
-// sigil, strings/numbers pass through, everything else is printed.
-func logValue(v MalType) any {
-	switch v := v.(type) {
-	case Keyword:
-		return string(v)
-	case string:
-		return v
-	case int, float32, float64, bool, nil:
-		return v
-	default:
-		return printer.Pr_str(v, false)
-	}
-}
-
-// webLog logs msg at level with alternating key/value attributes:
-// (web-log :info "message" "key" value …).
-func webLog(level MalType, msg string, kv ...MalType) (MalType, error) {
-	attrs := make([]any, 0, len(kv))
-	for i, v := range kv {
-		if i%2 == 0 {
-			attrs = append(attrs, kwName(v))
-		} else {
-			attrs = append(attrs, logValue(v))
-		}
-	}
-	switch kwName(level) {
-	case "debug":
-		webLogger.Debug(msg, attrs...)
-	case "warn":
-		webLogger.Warn(msg, attrs...)
-	case "error":
-		webLogger.Error(msg, attrs...)
-	default:
-		webLogger.Info(msg, attrs...)
-	}
-	return nil, nil
-}
-
 // Load registers the web builtins. The Ring response helpers and
 // middleware are added by the header (see nsweb.Load).
 func Load(env EnvType) {
 	call.CallOverrideFN(env, "web-serve", webServe)
-	call.CallOverrideFN(env, "web-log", webLog)
-	call.Doc(env, "web-log", "[level msg & kv]",
-		"Emits a structured JSON log line to stderr at level (:debug/:info/:warn/:error) with alternating key/value attributes.")
 	call.CallOverrideFN(env, "web-encode-json", webEncodeJSON)
 	call.Doc(env, "web-encode-json", "[value]",
 		"Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → \"id\"), as core json-encode also does.")


### PR DESCRIPTION
## Summary

- New `lib/log` namespace backed by `log/slog`: `log-debug` / `log-info` / `log-warn` / `log-error` emit one JSON line to stderr with alternating keyword/value attributes: `(log-info "user created" :id 42)`.
- Keys are keywords or strings (keywords lose their sigil); primitive values pass through as JSON, anything else renders via the Lisp printer; an odd number of key/value arguments is an error.
- Minimum level from the `LOG_LEVEL` env var (`debug`/`info`/`warn`/`error`, default `info`), read at namespace load.
- **Removed** `web-log` and `web-wrap-log` from `lib/web` (never shipped in a stable release); the web README shows the equivalent access-log middleware written over `log-info`. CHANGELOG carries the migration note under 0.6.0.
- Registered in `cmd/lisp` and `docgen`; `LANGUAGE.md` regenerated.

## Test plan

- `go test ./...` green; new `lib/log` tests cover attribute rendering (keywords, strings, numbers, booleans, composites via printer), level filtering (default info, `LOG_LEVEL=debug`/`error`), and bad-argument errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)