### PR TITLE
feat(integrity): lisp-integrity binary — always-on integrity vs HEAD, journald attestation (spec v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,45 @@ Logging moves out of `lib/web` into `lib/log`. Migration:
 level), and `web-wrap-log` users write the one-liner middleware over
 `log-info` themselves (example in `lib/web/README.md`).
 
+### ⚠️ Changed — integrity moves to the `lisp-integrity` binary
+
+`--integrity REF` and `--integrity-keys FILE` are **removed** from the
+`lisp` binary. The new **`lisp-integrity`** binary is always-on: it
+runs only script files (no REPL, `-e`, stdin, test/fmt/debug or
+DAP/LSP modes) and verifies the script — and, in cascade, every file
+loaded as code — against **`HEAD`**. There is no ref argument:
+pinning a release is a property of the checkout
+(`git checkout --detach v1.4.2`); state commits advance `HEAD` as
+children of the release, so restarts keep verifying.
+
+- **Keys**: the flag is replaced by the fixed path
+  `/etc/lisp/allowed_signers` (authorized_keys format, root-owned).
+  Its presence activates the signature rule for every run on the
+  host: state commits above the release must each be signed, and the
+  release commit must be signed itself or via a signed annotated tag
+  pointing at it. The same set drives ssh-agent signing of
+  `git-commit` / `git-tag` / `state-save`, as `--integrity-keys` did.
+- **Consent**: after the green block, `lisp-integrity` asks
+  `proceed? [y/N]`; `-y` skips, and a non-TTY stdin without `-y`
+  fails closed (systemd units say `lisp-integrity -y …`).
+- **Attestation**: every run emits a start record (`COMMIT`, `REPO`,
+  `TRACE_ID`, `ARGV`, `SIGNER`, `PROTECTED`) and an end record
+  (`EXIT_CODE`) to journald — required on Linux, XDG state-file
+  fallback on macOS with `PROTECTED=false` — and every `log-*` record
+  carries the same run fields. A start without an end means abnormal
+  termination. Never pass secrets on the command line: `ARGV` is
+  recorded in append-only storage.
+- **`(assert-integrity)`** now suggests `lisp-integrity` in its error
+  and gains **`(assert-integrity :with-signature)`**, which throws
+  unless the signature rule was applied.
+- INTEGRITY.md is rewritten as the v2 specification (v1 differences
+  are summarised at its end).
+
+Migration: `lisp --integrity v1.4.2 s.lisp` becomes
+`git checkout --detach v1.4.2 && lisp-integrity -y s.lisp`, and
+`--integrity-keys FILE` becomes installing FILE at
+`/etc/lisp/allowed_signers`.
+
 ### ⚠️ Changed — `reduce-kv` folds an associative collection
 
 `reduce-kv` now matches Clojure: it takes a hash-map (calling

--- a/INTEGRITY-REVIEW.md
+++ b/INTEGRITY-REVIEW.md
@@ -8,7 +8,7 @@ without stepping outside the threat model below.
 ## Objective and assets
 
 The mode promises the operator launching
-`lisp --integrity <ref> script.lisp` that every byte evaluated as code
+`lisp-integrity script.lisp` that every byte evaluated as code
 matches the repository content at `<ref>`, and that state read through
 `state-load` matches what a completed `state-save` committed. A
 successful attack makes the interpreter **run code (or accept state)

--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -1,13 +1,19 @@
-# Integrity mode
+# Integrity mode — `lisp-integrity`
 
-`lisp --integrity <ref>` runs a script *if and only if* the code being
-executed matches what is committed in its Git repository at `<ref>`.
+`lisp-integrity` is a separate binary that runs a script *if and only
+if* the code being executed matches what is committed in its Git
+repository at `HEAD`, and leaves an append-only audit trail of every
+run in the system journal. There are no mode flags: integrity is
+always on, in every execution, and cannot be disabled. The regular
+`lisp` binary has no integrity mode at all.
+
 This document is both the user guide and the specification the
 implementation is held to (`lib/integrity/mode.go`, `state.go`;
-enforced by `lib/integrity/mode_test.go` and `command/integrity_test.go`).
+enforced by `lib/integrity/mode_test.go` and
+`command/integrity_test.go`).
 
 Runnable mini-examples of every concept below — basic verification,
-the require cascade, signed refs, the state store, and what each
+the require cascade, signatures, the state store, and what each
 failure looks like — live in
 [examples-integrity/](./examples-integrity/), with a `demo.sh` that
 replays all of them in throwaway repositories. Reviewers trying to
@@ -16,123 +22,157 @@ break the mode should start from the adversarial review brief in
 
 ## Purpose and threat model
 
-The goal is **operational assurance for the operator launching a
-script**: what runs is exactly what was committed (and, with
-signatures, exactly what a trusted key released) — no accidental
-drift, no uncommitted edits, no locally patched copy.
+Two guarantees, deliberately distinct:
 
-It is **not a security boundary** against an attacker who can already
-write to the repository, the keys file or the `lisp` binary. The
-interpreter cannot protect itself from whoever controls what it reads;
-that separation belongs to the operating system (see
+- **Consistency** (prevention): what runs is exactly what is
+  committed — no accidental drift, no uncommitted edits, no locally
+  patched copy. Enforced at startup and on every code load;
+  violations refuse to run.
+- **Attestation** (detection): every run leaves start/end records in
+  systemd-journald — append-only storage the executing user cannot
+  alter or delete, with kernel-verified metadata (`_UID`, `_EXE`,
+  `_PID`) the process cannot forge. An auditor can always answer
+  *what code ran, when, as whom, with what arguments, and how it
+  ended*.
+
+It is **not a security boundary** against whoever controls the
+repository checkout, `/etc/lisp/allowed_signers` or the binary; that
+separation belongs to the operating system (see
 [Deployment](#deployment-hardening-the-assurance-into-a-boundary)).
+An attacker can always run modified code with some other tool — what
+they cannot do is produce a *verified-looking* attestation for it.
+
+## CLI
+
+```bash
+lisp-integrity script.lisp [args…]
+lisp-integrity -y service.lisp [args…]
+```
+
+- Only script-file execution. No REPL, no `-e`, no stdin, no
+  `--test` / `--fmt` / `--debug`, no DAP/LSP servers, no environment
+  variables selecting behaviour (`LOG_LEVEL` for verbosity is the one
+  exception, inherited from `lib/log`). Use `lisp` for everything
+  else.
+- After verification succeeds and the green block is printed,
+  `lisp-integrity` asks for confirmation on the terminal
+  (`proceed? [y/N]`) before evaluating anything.
+  - `-y` skips the question.
+  - If stdin is **not a TTY** and `-y` was not given, the run fails
+    closed. A systemd unit must therefore state its consent
+    explicitly: `ExecStart=/usr/local/bin/lisp-integrity -y …`.
+
+There is no ref argument. **Pinning a release is a property of the
+checkout, not of the invocation**: deploy with
+`git checkout --detach v1.4.2` and `HEAD` stays on that commit across
+restarts (`git pull` does not move a detached `HEAD`; only the
+script's own `state-save` commits advance it, as children of it).
 
 ## The invariant
 
 Definitions:
 
-- **ref** — the argument of `--integrity`: a commit hash, tag or
-  branch name, resolved in the repository enclosing the script.
-  A commit hash is immutable and therefore the strongest choice; a
-  signed tag is equivalent when `--integrity-keys` is used.
 - **code file** — any file evaluated as code: the script, every module
   loaded through `require`, and every file loaded through `load-file` /
   `load-file-once` (which read via the `slurp-source` builtin).
 - **state path** — any path under `.state/` at the repository root.
 
-At startup (`--integrity <ref>`):
+At startup:
 
-1. The script must lie inside a Git repository; `<ref>` must resolve
-   to a commit `C` in it.
-2. `HEAD` must be `C`, **or** a descendant of `C` through a linear
-   chain of commits each touching only state paths (the commits
-   `state-save` creates). Anything else fails.
-3. With `--integrity-keys FILE`: the ref must carry an SSH
-   signature by one of the public keys in `FILE` — the tag signature
-   if the ref is an annotated tag, the commit signature otherwise — and
-   **every state commit** between `C` and `HEAD` (point 2) must
-   likewise be signed by a listed key. The whole chain from ref to
-   `HEAD` is thus signed by a trusted key.
-4. The script must byte-match its blob in `C`'s tree.
+1. The script must lie inside a Git repository with a resolvable
+   `HEAD` commit `C`.
+2. The script must byte-match its blob in `C`'s tree.
+3. If `/etc/lisp/allowed_signers` exists: walking from `C` down
+   through consecutive state-save commits (commits with one parent
+   touching only state paths), each such commit must carry an SSH
+   signature by a listed key, and the first non-state commit under
+   them — the **release commit** — must be signed itself or via an
+   annotated tag pointing at it. The release signer is reported in
+   the green block and the start record.
 
 At runtime, while the mode is active:
 
-5. Every code file, when loaded, must lie inside the verified
+4. Every code file, when loaded, must lie inside the verified
    repository and byte-match its blob in `C`'s tree. A code file
    resolving outside the repository (an `-i` include dir elsewhere,
    `~/.config/lisp/`, `/usr/local/share/lisp/`) is refused.
-6. Every state file, when read through `state-load`, must byte-match
+5. Every state file, when read through `state-load`, must byte-match
    its blob at the **current** `HEAD` (the commit the last
    `state-save` created). Missing-but-committed, present-but-
    uncommitted, and differing files all fail closed.
 
 Uncommitted repository files that are never interpreted do not affect
-any check. Point 2 is what makes the **same `--integrity <ref>` valid
-across restarts** no matter how many state commits have accumulated:
-the operator keeps launching with the release ref (or signed tag) and
-never needs to chase state-commit hashes.
+any check.
 
-Concepts 1–2 and 4–6 are demonstrated by
-[examples-integrity/01-basic](./examples-integrity/01-basic) and
-[02-requires](./examples-integrity/02-requires); concept 3 by
-[03-signed](./examples-integrity/03-signed); the state paths of 2 and
-6 by [04-state](./examples-integrity/04-state).
+## Audit trail (journald)
 
-## CLI
+On Linux the destination is **systemd-journald and nothing else** —
+if the journal socket is unavailable, `lisp-integrity` refuses to
+run. On macOS (development convenience; explicitly weaker) records
+fall back to `~/.local/state/lisp/<script>.log` and carry
+`PROTECTED=false`.
+
+Every record shares three fields:
+
+- `COMMIT` — the verified `HEAD` hash.
+- `REPO` — the `origin` remote URL, or the repository root's basename
+  when there is no remote.
+- `TRACE_ID` — 128-bit random hex, constant for the whole run.
+
+Records emitted by the runtime itself (exactly two, never more):
+
+- **start** — after verification and confirmation, before evaluation:
+  `MESSAGE="run started"`, `ARGV` (script and arguments, as JSON),
+  `SIGNER` when rule 3 applied, `PROTECTED`.
+- **end** — from a deferred handler covering normal return, error and
+  panic: `MESSAGE="run ended"`, `EXIT_CODE` (and `PANIC` on one). A
+  start record with no matching end record means abnormal termination
+  (SIGKILL, power loss) — that asymmetry is signal, not defect.
+
+Every `log-debug` / `log-info` / `log-warn` / `log-error` call from
+the script carries the three shared fields in addition to its own.
+`SYSLOG_IDENTIFIER` is the script basename; read a run back with:
 
 ```bash
-lisp --integrity v1.4.2 service.lisp
-lisp --integrity 9fceb02d service.lisp
-lisp --integrity v1.4.2 --integrity-keys /etc/lisp/release-keys service.lisp
+journalctl -t <script> TRACE_ID=<id> -o json
 ```
 
-- `--integrity REF` — enable the mode. Requires a script file;
-  incompatible with `-e`, `--test`, `--fmt`, `--debug`, stdin (`-`)
-  and the DAP/LSP server modes.
-- `--integrity-keys FILE` — additionally require the ref to be
-  SSH-signed by a key listed in FILE. **authorized_keys / `.pub`
-  format**: one public key per line, `<type> <base64> [comment]`
-  (e.g. `ssh-ed25519 AAAA… alice`), blank lines and `#` comments
-  skipped — the same format `git-verify-commit` takes. This is **not**
-  git's `allowed_signers` format (which puts the principal first); such
-  a line is rejected, not silently accepted, so the trust anchor is the
-  set of keys, matched by key — no principal or validity constraints
-  (rotate keys by editing the file, not by expiry). This same key set
-  also **drives signing**: while `--integrity-keys` is active, every
-  `git-commit`, annotated `git-tag` and `state-save` made during the run
-  is SSH-signed with the **ssh-agent** key whose public key is listed
-  here (no private key ever enters the process; fails closed if no
-  listed key is loaded in the agent). Requires
-  `--integrity`.
-
-The result is reported to stderr for the audit trail. On an
-**interactive terminal** it is a human-readable block — green when
-integrity is satisfied, red when not — with the ref, commit and (when
-keys were required) signer each on their own line:
-
-```
-✓ integrity verified
-    ref     v1.4.2
-    commit  9fceb02da8f3c1…
-    signer  alice
-```
-
-When stderr is **redirected** (a pipe or file — the server/log-ingestion
-case) it is instead one structured JSON line:
-`{"msg":"integrity: entry script and ref verified","ref":…,"commit":…,"signer":…}`.
-Either way it attests the pinned ref and the entry script only; each
-cascaded `require` / `load-file` is verified as it loads and aborts the
-run on mismatch, so a green block does not mean the whole run is already
-verified. Color also honours `NO_COLOR` / `CLICOLOR_FORCE`.
+> `ARGV` is recorded verbatim and the journal is append-only by
+> design: **never pass secrets on the command line** (they would also
+> land in shell history). Use files or the state store.
 
 ## Builtins
 
 | Builtin | Behaviour |
 |---|---|
-| `(assert-integrity)` | Throws unless running under `--integrity`; returns the verified commit hash. Committed code uses it to demand the mode — effective as long as operators know the program is supposed to carry it. |
-| `(state-save name value & [message])` | Writes `value` as canonical lisp data to `.state/name.lisp` and **commits it in the same operation**; returns the commit hash. The commit `message` defaults to `state: name`. Under `--integrity-keys` the commit is SSH-signed with the ssh-agent key listed there (no per-call key). Saving an unchanged value is a no-op returning the current commit. Works with or without the mode; requires a Git repository. |
-| `(state-load name)` / `(state-load name default)` | Reads the state back as pure data (READ, never EVAL — state cannot smuggle code). Returns `default`, or throws without one, when the state does not exist. Under the mode, enforces invariant 6. |
-| `(slurp-source path)` | `slurp` for files about to be evaluated: identical, plus invariant 5 under the mode. `load-file` builds on it. |
+| `(assert-integrity)` | Throws unless running under `lisp-integrity`; returns the verified commit hash. Committed code uses it to demand the mode — effective as long as operators know the program is supposed to carry it. |
+| `(assert-integrity :with-signature)` | Additionally throws unless startup rule 3 was applied (an `/etc/lisp/allowed_signers` file existed and the chain verified). For code that must not run unsigned even on hosts lacking the keys file. |
+| `(state-save name value & [message])` | Writes `value` as canonical lisp data to `.state/name.lisp` and **commits it in the same operation**; returns the commit hash. The commit `message` defaults to `state: name`. With an allowed-signers set active, the commit is SSH-signed via ssh-agent (no per-call key). Saving an unchanged value is a no-op returning the current commit. Works with or without the mode; requires a Git repository. |
+| `(state-load name)` / `(state-load name default)` | Reads the state back as pure data (READ, never EVAL — state cannot smuggle code). Returns `default`, or throws without one, when the state does not exist. Under the mode, enforces invariant 5. |
+| `(slurp-source path)` | `slurp` for files about to be evaluated: identical, plus invariant 4 under the mode. `load-file` builds on it. |
+
+## Keys
+
+`/etc/lisp/allowed_signers` — **authorized_keys / `.pub` format**:
+one public key per line, `<type> <base64> [comment]`
+(e.g. `ssh-ed25519 AAAA… alice`), blank lines and `#` comments
+skipped. This is **not** git's `allowed_signers` format (which puts a
+principal first); such a line is rejected, not silently accepted, so
+the trust anchor is the set of keys, matched by key — no principal or
+validity constraints (rotate keys by editing the file, not by
+expiry).
+
+The file's **mere presence activates rule 3** for every
+`lisp-integrity` run on the host. It must be owned by root, outside
+the repository and outside the process user's write reach. The same
+key set also **drives signing**: while it is present, every
+`git-commit`, annotated `git-tag` and `state-save` made during a run
+is SSH-signed with the **ssh-agent** key whose public key is listed
+(no private key ever enters the process; fails closed if no listed
+key is loaded in the agent).
+
+Future evolution: keys baked into the binary at build time
+(`-ldflags -X`), shrinking the trust anchor to the binary alone.
 
 ## The state store
 
@@ -148,8 +188,8 @@ integrity envelope:
 - **Commit protocol** — write file → `git add` → `git commit`, all
   inside `state-save`. Committed state is therefore always the product
   of a completed save. State commits are authored `state-save
-  <state-save@lisp>`; they are Git-compatible SSH-signed when
-  `--integrity-keys` is active (ssh-agent key), unsigned otherwise.
+  <state-save@lisp>`; they are Git-compatible SSH-signed when an
+  allowed-signers set is active (ssh-agent key), unsigned otherwise.
 - **Crash recovery** — a save interrupted between write and commit
   leaves the file differing from `HEAD`; the next `state-load` under
   the mode fails closed and the operator resolves it (commit the
@@ -161,31 +201,23 @@ integrity envelope:
   state that must be trustworthy they are **discouraged** in favour of
   `state-load`/`state-save`: they participate in no invariant.
 
-## Signatures and trust anchors
-
-Without `--integrity-keys` the trust anchor is the local repository
-state: the mode proves consistency ("matches what is committed here"),
-which stops drift but not history rewriting by whoever can write to
-the repository.
-
-With `--integrity-keys` the anchor becomes the key list plus the
-binary: the ref must be signed by a trusted key, so verification
-survives cloning the repository onto other machines and re-tagging by
-someone without the key. Keep the keys file outside the repository
-and outside the process user's write reach.
-
 ## Deployment: hardening the assurance into a boundary
 
 The mode becomes a real boundary only when the OS guarantees the
 attacker cannot write to what the interpreter reads:
 
-- repository checkout, keys file and `lisp` binary owned by `root`
-  (or a dedicated `deploy` user);
+- repository checkout, `/etc/lisp/allowed_signers` and the
+  `lisp-integrity` binary owned by `root` (or a dedicated `deploy`
+  user);
 - the process running as an unprivileged user with **no write access**
   to any of the three;
 - if `state-save` is used, grant the process user write access to
   `.state/` and `.git` only — or accept that state (unlike code) is
   writable by the process by design;
+- persistent journald (`/var/log/journal/` present) on hosts where
+  the audit trail must survive reboots; journald FSS sealing
+  (`journalctl --setup-keys`) adds cryptographic tamper-evidence —
+  orthogonal to this spec, with its own keys;
 - binary provenance (signed releases, package manager verification) is
   outside the interpreter's scope but completes the chain.
 
@@ -194,10 +226,12 @@ attacker cannot write to what the interpreter reads:
 - `eval` over strings obtained by other means (`slurp`, network) is
   not covered — the verified code that chooses to do that is
   responsible for it.
-- Preamble placeholders (`-P`) inject operator-supplied expressions;
-  the operator is the trusted party in this model.
 - A self-verifying binary is deliberately **not** attempted: an
   attacker who can replace the binary can also remove the check.
+- Anyone with commit access to the checkout can run code that
+  verifies green: without an allowed-signers set the anchor is
+  consistency, not authorization. The attestation records what ran;
+  signatures (rule 3) add who released it.
 - Verification compares the **worktree bytes** against the **raw
   committed blob**. A repository that applies EOL normalization or a
   clean/smudge filter (`.gitattributes`: `text eol=crlf`, `filter=…`)
@@ -208,10 +242,19 @@ attacker cannot write to what the interpreter reads:
   on-disk path that resolves to it must match exactly; a mismatch
   fails closed rather than verifying the wrong file.
 
-## Future revisions (not implemented)
+## Changes from v1 (`lisp --integrity <ref>`)
 
-- **Keys baked into the binary** — accept allowed signers via
-  `-ldflags -X` at build time, shrinking the trust anchor to the
-  binary alone.
-- **Data-repository variant** — keep state in a separate repository
-  for multi-writer or high-churn scenarios.
+- `--integrity REF` and `--integrity-keys FILE` are **removed**; the
+  `lisp` binary loses the mode entirely. The new `lisp-integrity`
+  binary is always-on and verifies against `HEAD`; pinning moved to
+  the checkout (`git checkout --detach <tag>`).
+- Keys moved from a flag to the fixed path
+  `/etc/lisp/allowed_signers`; presence activates the signature rule.
+- Interactive confirmation (`[y/N]`; `-y` to skip; non-TTY without
+  `-y` fails closed).
+- Mandatory journald attestation: start/end records with
+  `COMMIT` / `REPO` / `TRACE_ID` / `ARGV` / `EXIT_CODE`; `log-*`
+  records enriched with the same fields; macOS falls back to the XDG
+  state file with `PROTECTED=false`.
+- `(assert-integrity)` gained the `:with-signature` variant.
+- The preamble flags (`-P`) are not part of `lisp-integrity`.

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -385,7 +385,7 @@ Host OS: environment variables, files (slurp/spit, load-file), working directory
 | `remove-all` | `[path]` | Recursively removes path and everything under it; does not error if path is absent. |
 | `setenv` | `[name value]` | Sets the environment variable name to value. |
 | `slurp` | `[filename]` | Reads a file and returns its contents as a string. |
-| `slurp-source` | `[filename]` | Reads a source file like slurp and, under --integrity, verifies it against the pinned commit; load-file builds on it. |
+| `slurp-source` | `[filename]` | Reads a source file like slurp and, under lisp-integrity, verifies it against the verified HEAD commit; load-file builds on it. |
 | `spit` | `[filename s & opts]` | Writes string s to a file, creating or truncating it; with :append true, appends instead. |
 | `unsetenv` | `[name]` | Removes the environment variable name. |
 
@@ -456,18 +456,18 @@ Command-line option parsing (clojure/tools.cli style).
 
 ### integrity
 
-Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integrity mode).
+Attest and verify lisp source (formatting, hashing, Ed25519 signatures, the lisp-integrity mode).
 
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
-| `assert-integrity` | `[]` | Throws unless the interpreter runs under --integrity; returns the verified commit hash. |
+| `assert-integrity` | `[& [:with-signature]]` | Throws unless the interpreter runs under lisp-integrity; returns the verified commit hash. With :with-signature it additionally throws unless the run's signature rule was applied (an allowed-signers set was present and HEAD verified against it). |
 | `ed25519-generate` | `[]` | Generates an Ed25519 key pair, as a map {:public :private} of base64 strings. |
 | `ed25519-sign` | `[private s]` | Signs string s with a base64 Ed25519 private key; returns the base64 signature (deterministic). |
 | `ed25519-verify` | `[public s signature]` | Reports whether the base64 signature of string s verifies against the base64 Ed25519 public key. |
 | `fmt` | `[s]` | Formats lisp source s into its canonical form (as lisp --fmt does); errors if s does not parse. |
 | `sha2-256` | `[s]` | SHA2-256 digest of string s, as lowercase hex. |
-| `state-load` | `[name & [default]]` | Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under --integrity the file must match its committed version at HEAD. |
-| `state-save` | `[name value & [message]]` | Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. message is the commit message (default "state: name"). Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there. Under --integrity the commit keeps the verified ref valid. |
+| `state-load` | `[name & [default]]` | Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under lisp-integrity the file must match its committed version at HEAD. |
+| `state-save` | `[name value & [message]]` | Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. message is the commit message (default "state: name"). When an allowed-signers set is active (lisp-integrity with /etc/lisp/allowed_signers) the commit is SSH-signed with the ssh-agent key listed there. |
 
 ### regexp
 
@@ -516,7 +516,7 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-repla
 | `git-checkout` | `[repo ref & {:create :force}]` | Checks out a branch, tag or revision; :create true creates the branch first. |
 | `git-clone` | `[url path & {:auth :branch :depth :single-branch :bare}]` | Clones url into path and returns a handle; see git-push for the :auth map. |
 | `git-close` | `[repo]` | Closes a repository handle. |
-| `git-commit` | `[repo msg & {:author {:name :email} :committer :all :allow-empty :amend}]` | Commits staged changes and returns the commit map. Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there; otherwise it is unsigned (there is no per-call key option). |
+| `git-commit` | `[repo msg & {:author {:name :email} :committer :all :allow-empty :amend}]` | Commits staged changes and returns the commit map. When an allowed-signers set is active the commit is SSH-signed with the ssh-agent key listed there; otherwise it is unsigned (there is no per-call key option). |
 | `git-fetch` | `[repo & {:auth :remote :refspecs :depth :prune :force}]` | Fetches from :remote (default origin); returns :ok or :up-to-date. |
 | `git-head` | `[repo]` | Returns {:name :branch :hash} for HEAD. |
 | `git-init` | `[path & {:bare :object-format}]` | Creates a repository at path and returns a handle; :object-format "sha256" for a SHA-256 repo. |
@@ -528,7 +528,7 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-repla
 | `git-remotes` | `[repo]` | Returns a vector of {:name :urls} for the configured remotes. |
 | `git-show` | `[repo rev]` | Returns the commit map for rev (hash, "HEAD", branch or tag name). |
 | `git-status` | `[repo]` | Returns {:clean bool :files {path {:staging kw :worktree kw}}} for the worktree. |
-| `git-tag` | `[repo name & {:at :message :tagger {:name :email}}]` | Creates a tag at HEAD (or :at rev); :message makes it annotated. Under --integrity-keys an annotated tag is SSH-signed with the ssh-agent key listed there. |
+| `git-tag` | `[repo name & {:at :message :tagger {:name :email}}]` | Creates a tag at HEAD (or :at rev); :message makes it annotated. When an allowed-signers set is active an annotated tag is SSH-signed with the ssh-agent key listed there. |
 | `git-tag-verified?` | `[repo name allowed-keys]` | (git-tag-verified? repo name allowed-keys) is true when the tag's SSH signature verifies against allowed-keys. |
 | `git-tags` | `[repo]` | Returns a vector of {:name :hash :target :annotated} for all tags. |
 | `git-verified?` | `[repo rev allowed-keys]` | (git-verified? repo rev allowed-keys) is true when the commit's SSH signature verifies against allowed-keys. |

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Changes respect to [kanaka/mal](https://github.com/kanaka/mal):
 - `spit`, the write counterpart of `slurp` (Clojure-style): `(spit filename s)` creates or truncates, `(spit filename s :append true)` appends
 - `*FILE*` holds the absolute path of the script being executed (cf. Clojure's `*file*`), so a script can read its own source; unset in the REPL and `-e`
 - `cli` library for command-line option parsing, modelled on [clojure/tools.cli](https://github.com/clojure/tools.cli) — `(cli-parse-opts *ARGV* specs)`. See [./lib/cli/README.md](./lib/cli/README.md)
-- `integrity` library to attest and verify lisp source: `fmt` (canonical formatting, as `lisp --fmt`), `sha2-256`, and deterministic Ed25519 signatures (`ed25519-generate`, `ed25519-sign`, `ed25519-verify`); plus the interpreter's integrity mode (`--integrity`, with the `assert-integrity` builtin). See [./lib/integrity/README.md](./lib/integrity/README.md)
+- `integrity` library to attest and verify lisp source: `fmt` (canonical formatting, as `lisp --fmt`), `sha2-256`, and deterministic Ed25519 signatures (`ed25519-generate`, `ed25519-sign`, `ed25519-verify`); plus the interpreter's integrity mode (the `lisp-integrity` binary, with the `assert-integrity` builtin). See [./lib/integrity/README.md](./lib/integrity/README.md)
 
 ## Embed jig/lisp in Go code
 
@@ -395,56 +395,55 @@ evaled to (first-arg second-arg)
 42
 ```
 
-### Run only committed code (--integrity)
+### Run only committed code (lisp-integrity)
 
-`--integrity REF` makes the interpreter run a script *if and only if*
-it matches what is committed in its Git repository at `REF` (a commit
-hash, tag or branch — an immutable commit hash is the strongest
-choice):
+The separate `lisp-integrity` binary runs a script *if and only if*
+it matches what is committed in its Git repository at `HEAD`, and
+attests every run to systemd-journald. Integrity is always on and
+cannot be disabled; there is no REPL, no `-e`, no stdin mode:
 
-- `HEAD` must be exactly the commit `REF` resolves to (or a
-  state-only descendant of it, see below),
-- the script must byte-match the blob committed at `REF`, and
+- the script must byte-match the blob committed at `HEAD`,
 - the check cascades to every file evaluated as code: `require`
   modules and `load-file`/`load-file-once` targets must resolve inside
   the same repository and match their committed blobs; files resolving
-  outside it (e.g. `~/.config/lisp/`) are refused.
+  outside it (e.g. `~/.config/lisp/`) are refused,
+- after the green verification block, it asks `proceed? [y/N]` on the
+  terminal (`-y` skips; without a terminal `-y` is mandatory), and
+- the run is attested to the journal: a start record (commit, repo,
+  trace id, argv), an end record (exit code), and every `log-*` call
+  in between carrying the same run fields.
 
 ```bash
-lisp --integrity v1.4.2 service.lisp
-lisp --integrity 9fceb02d service.lisp
+lisp-integrity service.lisp
+lisp-integrity -y service.lisp     # unattended (systemd units)
 ```
 
-A script can demand the flag with the `assert-integrity` builtin,
-which throws unless the run is verified (and returns the verified
-commit hash), so a committed program cannot silently be run
-unverified — as long as the operator knows it is supposed to carry
-that call:
+Pinning a release is a property of the checkout, not of the
+invocation: deploy with `git checkout --detach v1.4.2` and every
+restart runs exactly that commit. A script can demand the mode with
+the `assert-integrity` builtin, which throws unless the run is
+verified (and returns the verified commit hash):
 
 ```lisp
 (def release (assert-integrity))
 ```
 
-With `--integrity-keys FILE`, `REF` must additionally carry an SSH
-signature by one of the public keys listed in `FILE`
-(authorized_keys format, one key per line — the same format
-`git-verify-commit` takes). For an annotated tag the tag's signature
-is checked; otherwise the commit's. This upgrades the guarantee from
-"matches the local repository" to "matches what a trusted key signed",
-which survives cloning the repository onto other machines:
-
-```bash
-lisp --integrity v1.4.2 --integrity-keys /etc/lisp/release-keys service.lisp
-```
+If `/etc/lisp/allowed_signers` exists on the host (authorized_keys
+format, root-owned), every run additionally requires the `HEAD` chain
+to be SSH-signed by a listed key — the release commit itself or an
+annotated tag pointing at it, plus each state commit above it. This
+upgrades the guarantee from "matches the local repository" to
+"matches what a trusted key signed". `(assert-integrity
+:with-signature)` lets a script refuse to run unsigned even on hosts
+without the file.
 
 A verified program persists state through the `.state/` store instead
 of raw file writes: `(state-save "db" value)` writes
 `.state/db.lisp` (canonical lisp data, at the repository root next to
 `.lisp/`) and commits it in the same operation; `(state-load "db")`
-reads it back as pure data and, under `--integrity`, requires it to
-match its committed version at `HEAD`. State commits keep the original
-`--integrity REF` valid across restarts: the startup check accepts
-`HEAD` being a linear chain of state-only commits above `REF`.
+reads it back as pure data and requires it to match its committed
+version at `HEAD`. State commits advance `HEAD` as children of the
+release commit, so restarts keep verifying.
 
 Scope: this is an operational assurance for the operator — no
 accidental drift, no uncommitted edits — not a security boundary

--- a/cmd/lisp-integrity/docs_test.go
+++ b/cmd/lisp-integrity/docs_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/jig/lisp/docgen"
+	"github.com/jig/lisp/env"
+)
+
+// TestLibrariesMatchDocgen guards this binary's libraries list against
+// drifting from docgen's (which cmd/lisp's own sync test ties to the
+// lisp binary): both must build exactly the same environment.
+func TestLibrariesMatchDocgen(t *testing.T) {
+	ns := env.NewEnv()
+	for _, lib := range libraries(nil) {
+		if err := lib.load(ns); err != nil {
+			t.Fatalf("load %q: %v", lib.name, err)
+		}
+	}
+	ours := ns.(*env.Env).LocalSymbols()
+	sort.Strings(ours)
+
+	standard, err := docgen.StandardSymbols()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(standard)
+
+	if !reflect.DeepEqual(ours, standard) {
+		t.Fatalf("lisp-integrity loads a different environment than the lisp binary/docgen")
+	}
+}

--- a/cmd/lisp-integrity/main.go
+++ b/cmd/lisp-integrity/main.go
@@ -1,0 +1,85 @@
+// Command lisp-integrity runs a jig/lisp script if and only if it (and,
+// in cascade, everything it loads as code) matches what is committed in
+// its Git repository at HEAD, and attests the run to systemd-journald.
+// Integrity is always on and cannot be disabled; there is no REPL, no
+// -e and no stdin mode — use the lisp binary for those. See
+// INTEGRITY.md for the specification.
+package main
+
+import (
+	"errors"
+	"log"
+	"os"
+
+	"github.com/jig/lisp/command"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/cli/nscli"
+	"github.com/jig/lisp/lib/concurrent/nsconcurrent"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/lib/coreextended/nscoreextended"
+	"github.com/jig/lisp/lib/git/nsgit"
+	"github.com/jig/lisp/lib/integrity/nsintegrity"
+	"github.com/jig/lisp/lib/lazy/nslazy"
+	"github.com/jig/lisp/lib/log/nslog"
+	"github.com/jig/lisp/lib/regexp/nsregexp"
+	"github.com/jig/lisp/lib/require/nsrequire"
+	"github.com/jig/lisp/lib/sql/nssql"
+	"github.com/jig/lisp/lib/system/nssystem"
+	"github.com/jig/lisp/lib/term/nsterm"
+	"github.com/jig/lisp/lib/test/nstest"
+	"github.com/jig/lisp/lib/web/nsweb"
+	"github.com/jig/lisp/types"
+)
+
+type library struct {
+	name string
+	load func(ns types.EnvType) error
+}
+
+// libraries mirrors cmd/lisp's list exactly (kept in sync by
+// TestLibrariesMatchDocgen) so a verified script sees the same
+// environment the lisp binary provides.
+func libraries(scriptArgs []string) []library {
+	return []library{
+		{"core mal", nscore.Load},
+		{"core mal with input", nscore.LoadInput},
+		{"command line args", nscore.LoadCmdLineArgs(scriptArgs)},
+		{"concurrent", nsconcurrent.Load},
+		{"core mal extended", nscoreextended.Load},
+		{"system", nssystem.Load},
+
+		// new libraries on jig/lisp v0.3.0
+		{"lazy", nslazy.Load},
+		{"require", nsrequire.Load("lisp")},
+		{"sql", nssql.Load},
+		{"cli", nscli.Load},
+		{"integrity", nsintegrity.Load},
+		{"regexp", nsregexp.Load},
+		{"web", nsweb.Load},
+		{"git", nsgit.Load},
+		{"term", nsterm.Load},
+		{"test", nstest.Load},
+
+		// new libraries on jig/lisp v0.6.0
+		{"log", nslog.Load},
+	}
+}
+
+func main() {
+	ns := env.NewEnv()
+
+	for _, library := range libraries(command.PreParseIntegrityArgs(os.Args)) {
+		if err := library.load(ns); err != nil {
+			log.Fatalf("Library Load Error: %v\n", err)
+		}
+	}
+
+	if err := command.ExecuteIntegrity(os.Args, ns); err != nil {
+		// An integrity failure has already been shown to the user as its
+		// own red block; just exit non-zero without a second "Error:" line.
+		if errors.Is(err, command.ErrIntegrityReported) {
+			os.Exit(1)
+		}
+		log.Fatalf("Error: %v\n", err)
+	}
+}

--- a/command/command.go
+++ b/command/command.go
@@ -19,26 +19,24 @@ import (
 
 // args represents command line arguments for the Lisp interpreter
 type args struct {
-	Version       bool     `arg:"-v,--version" help:"show version information"`
-	Test          string   `arg:"-t,--test" help:"run the test suite from a directory or a single test file" placeholder:"DIR|FILE"`
-	TestJSON      string   `arg:"--test-json" help:"with --test, also write a JSON report to the given file" placeholder:"FILE"`
-	Coverage      string   `arg:"--coverage" help:"write an lcov coverage report of the executed lisp code (requires -tags debugger)" placeholder:"FILE"`
-	Debug         bool     `arg:"--debug" help:"enable DEBUG-EVAL support (requires -tags debugger)"`
-	Eval          string   `arg:"-e,--eval" help:"evaluate expression and exit" placeholder:"EXPR"`
-	Fmt           bool     `arg:"--fmt" help:"format lisp source (files given as arguments, or stdin) and print the result"`
-	Write         bool     `arg:"-w,--write" help:"with --fmt, rewrite each file in place instead of printing"`
-	Include       []string `arg:"-i,--include,separate" help:"add include directory for require (needs the require library loaded)" placeholder:"DIR"`
-	Integrity     string   `arg:"--integrity" help:"run the script only if it and its repo-local requires match Git REF and HEAD is at REF" placeholder:"REF"`
-	IntegrityKeys string   `arg:"--integrity-keys" help:"with --integrity, additionally require REF to be SSH-signed by a key listed in FILE (authorized_keys/.pub format, one key per line)" placeholder:"FILE"`
-	Preamble      []string `arg:"-P,--preamble,separate" help:"define a preamble placeholder for the script, e.g. -P '$NAME <expr>'" placeholder:"ASSIGN"`
-	DAP           bool     `arg:"--dap" help:"start a Debug Adapter Protocol server on stdio (requires -tags debugger)"`
-	DAPListen     string   `arg:"--dap-listen" help:"start a DAP server on the given TCP address (requires -tags debugger)" placeholder:"HOST:PORT"`
-	RunTest       string   `arg:"--run-test" help:"with --dap, run the named deftest after loading the script (used by the editor's Debug Test)" placeholder:"NAME"`
-	LSP           bool     `arg:"--lsp" help:"start a Language Server Protocol server on stdio (requires -tags debugger)"`
-	LSPListen     string   `arg:"--lsp-listen" help:"start an LSP server on the given TCP address (requires -tags debugger)" placeholder:"HOST:PORT"`
-	BatSyntax     bool     `arg:"--install-bat-syntax" help:"install the jig/lisp syntax into bat (writes to bat's config dir and rebuilds its cache)"`
-	Script        string   `arg:"positional" help:"lisp script to execute"`
-	Args          []string `arg:"positional" help:"arguments to pass to the script"`
+	Version   bool     `arg:"-v,--version" help:"show version information"`
+	Test      string   `arg:"-t,--test" help:"run the test suite from a directory or a single test file" placeholder:"DIR|FILE"`
+	TestJSON  string   `arg:"--test-json" help:"with --test, also write a JSON report to the given file" placeholder:"FILE"`
+	Coverage  string   `arg:"--coverage" help:"write an lcov coverage report of the executed lisp code (requires -tags debugger)" placeholder:"FILE"`
+	Debug     bool     `arg:"--debug" help:"enable DEBUG-EVAL support (requires -tags debugger)"`
+	Eval      string   `arg:"-e,--eval" help:"evaluate expression and exit" placeholder:"EXPR"`
+	Fmt       bool     `arg:"--fmt" help:"format lisp source (files given as arguments, or stdin) and print the result"`
+	Write     bool     `arg:"-w,--write" help:"with --fmt, rewrite each file in place instead of printing"`
+	Include   []string `arg:"-i,--include,separate" help:"add include directory for require (needs the require library loaded)" placeholder:"DIR"`
+	Preamble  []string `arg:"-P,--preamble,separate" help:"define a preamble placeholder for the script, e.g. -P '$NAME <expr>'" placeholder:"ASSIGN"`
+	DAP       bool     `arg:"--dap" help:"start a Debug Adapter Protocol server on stdio (requires -tags debugger)"`
+	DAPListen string   `arg:"--dap-listen" help:"start a DAP server on the given TCP address (requires -tags debugger)" placeholder:"HOST:PORT"`
+	RunTest   string   `arg:"--run-test" help:"with --dap, run the named deftest after loading the script (used by the editor's Debug Test)" placeholder:"NAME"`
+	LSP       bool     `arg:"--lsp" help:"start a Language Server Protocol server on stdio (requires -tags debugger)"`
+	LSPListen string   `arg:"--lsp-listen" help:"start an LSP server on the given TCP address (requires -tags debugger)" placeholder:"HOST:PORT"`
+	BatSyntax bool     `arg:"--install-bat-syntax" help:"install the jig/lisp syntax into bat (writes to bat's config dir and rebuilds its cache)"`
+	Script    string   `arg:"positional" help:"lisp script to execute"`
+	Args      []string `arg:"positional" help:"arguments to pass to the script"`
 }
 
 func (args) Description() string {
@@ -102,12 +100,6 @@ func Execute(cmdArgs []string, repl_env types.EnvType) error {
 
 	if parsedArgs.Eval != "" && (parsedArgs.Version || parsedArgs.Test != "") {
 		return fmt.Errorf("-e cannot be used with --version or --test")
-	}
-
-	// Integrity mode verifies the script (and, in cascade, its
-	// repo-local requires) against a Git ref before anything runs.
-	if err := setupIntegrity(parsedArgs); err != nil {
-		return err
 	}
 
 	// Formatting is a standalone text transformation; it loads no libraries

--- a/command/integrity.go
+++ b/command/integrity.go
@@ -1,17 +1,29 @@
 package command
 
 import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 
+	"github.com/alexflint/go-arg"
+	"github.com/coreos/go-systemd/v22/journal"
 	libgit "github.com/jig/lisp/lib/git"
 	"github.com/jig/lisp/lib/integrity"
+	liblog "github.com/jig/lisp/lib/log"
 	"github.com/jig/lisp/lib/require"
 	"github.com/jig/lisp/lib/system"
 	libterm "github.com/jig/lisp/lib/term"
+	"github.com/jig/lisp/types"
+	"golang.org/x/term"
 )
 
 // ErrIntegrityReported signals that the integrity failure has already
@@ -19,73 +31,188 @@ import (
 // re-printing it.
 var ErrIntegrityReported = errors.New("integrity check failed")
 
-// setupIntegrity validates the --integrity flags and enables integrity
-// mode: the script is verified against the given Git ref before it
-// runs, and the require and load-file loaders are hooked so every file
-// evaluated as code in the same repository is verified first (files
-// outside it are refused). No-op when --integrity was not given.
-func setupIntegrity(a args) error {
-	if a.Integrity == "" {
-		if a.IntegrityKeys != "" {
-			return fmt.Errorf("--integrity-keys requires --integrity")
+// allowedSignersPath is the host's trust anchor for signature
+// verification: its mere presence activates the signature rule for
+// every lisp-integrity run. Overridable in tests.
+var allowedSignersPath = "/etc/lisp/allowed_signers"
+
+// Test seams: journald availability, record emission, and the
+// confirmation prompt's TTY check.
+var (
+	journalEnabled  = journal.Enabled
+	emitRecord      = liblog.Record
+	stdinIsTerminal = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
+)
+
+// integrityArgs is the lisp-integrity CLI: a script, its arguments and
+// the consent flag — nothing else, by design (no REPL, no -e, no
+// environment overrides).
+type integrityArgs struct {
+	Yes    bool     `arg:"-y,--yes" help:"run without asking for confirmation (required when stdin is not a terminal)"`
+	Script string   `arg:"positional,required" help:"lisp script to execute"`
+	Args   []string `arg:"positional" help:"arguments to pass to the script"`
+}
+
+// PreParseIntegrityArgs extracts the script arguments before the
+// libraries load, mirroring PreParseArgs for the lisp binary.
+func PreParseIntegrityArgs(cmdArgs []string) []string {
+	var parsedArgs integrityArgs
+	parser, err := arg.NewParser(arg.Config{Program: "lisp-integrity"}, &parsedArgs)
+	if err != nil {
+		return []string{}
+	}
+	if len(cmdArgs) > 1 {
+		if err := parser.Parse(cmdArgs[1:]); err != nil {
+			return []string{}
 		}
-		return nil
 	}
-	if a.Script == "" || a.Script == "-" {
-		return fmt.Errorf("--integrity requires a script file")
+	return parsedArgs.Args
+}
+
+// ExecuteIntegrity is the main function of the lisp-integrity binary:
+// verify the script against HEAD (and, when the host has an
+// allowed-signers set, the signature rule), report the audit block,
+// ask for confirmation, attest the run to the journal and execute.
+func ExecuteIntegrity(cmdArgs []string, repl_env types.EnvType) error {
+	var parsedArgs integrityArgs
+	parser, err := arg.NewParser(arg.Config{Program: "lisp-integrity"}, &parsedArgs)
+	if err != nil {
+		return err
 	}
-	if a.Eval != "" || a.Test != "" || a.Fmt || a.Version || a.BatSyntax || a.Debug ||
-		a.DAP || a.DAPListen != "" || a.LSP || a.LSPListen != "" {
-		return fmt.Errorf("--integrity only runs a script file; it cannot be combined with --eval, --test, --fmt, --debug or the server modes")
-	}
-	keys := ""
-	if a.IntegrityKeys != "" {
-		b, err := os.ReadFile(a.IntegrityKeys)
+	if len(cmdArgs) > 1 {
+		err = parser.Parse(cmdArgs[1:])
+		if err == arg.ErrHelp {
+			parser.WriteHelp(os.Stdout)
+			return nil
+		}
 		if err != nil {
-			return fmt.Errorf("--integrity-keys: %w", err)
+			return err
 		}
-		keys = string(b)
 	}
-	if err := integrity.Enable(a.Script, a.Integrity, keys); err != nil {
+	if parsedArgs.Script == "" || parsedArgs.Script == "-" {
+		return fmt.Errorf("lisp-integrity requires a script file (stdin is not supported)")
+	}
+
+	// The audit trail must be protected before anything is attested:
+	// journald on Linux — or refuse; the XDG state file only on macOS
+	// (development convenience, explicitly weaker).
+	protected := journalEnabled()
+	if !protected && runtime.GOOS != "darwin" {
+		return fmt.Errorf("lisp-integrity requires systemd-journald for the audit trail (journal socket unavailable)")
+	}
+
+	keys := ""
+	if b, err := os.ReadFile(allowedSignersPath); err == nil {
+		keys = string(b)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("reading %s: %w", allowedSignersPath, err)
+	}
+
+	if err := integrity.Enable(parsedArgs.Script, keys); err != nil {
 		return reportIntegrity(false, "", "", "", err)
 	}
 	require.VerifyModule = integrity.VerifyFile
 	system.VerifySource = integrity.VerifyFile
 
-	// With --integrity-keys, git commits/tags and state-save made during
-	// the run are SSH-signed with the ssh-agent key that is listed in the
-	// keys file. No private key ever enters the process; the resolution
-	// is lazy and fails closed if no listed key is loaded in the agent.
+	// With an allowed-signers set, git commits/tags and state-save made
+	// during the run are SSH-signed with the ssh-agent key that is
+	// listed in it. No private key ever enters the process; the
+	// resolution is lazy and fails closed if no listed key is loaded.
 	if keys != "" {
 		libgit.SetSigningKeys(os.Getenv("SSH_AUTH_SOCK"), keys)
 	}
 
-	return reportIntegrity(true, integrity.Ref(), integrity.CommitHash(), integrity.Signer(), nil)
+	if err := reportIntegrity(true, integrity.RepoName(), integrity.CommitHash(), integrity.Signer(), nil); err != nil {
+		return err
+	}
+
+	// Explicit consent: ask on the terminal, or require -y. Never run
+	// on an unattended invocation that did not state its consent.
+	if !parsedArgs.Yes {
+		if !stdinIsTerminal() {
+			return fmt.Errorf("refusing to run without confirmation: stdin is not a terminal (pass -y)")
+		}
+		fmt.Fprint(os.Stderr, "proceed? [y/N] ")
+		line, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "y", "yes":
+		default:
+			return fmt.Errorf("run aborted by operator")
+		}
+	}
+
+	// Attestation: constant run fields on every record, a start record
+	// before evaluation and an end record from a deferred handler that
+	// also covers error returns and panics.
+	traceID := make([]byte, 16)
+	if _, err := rand.Read(traceID); err != nil {
+		return err
+	}
+	liblog.SetIdentifier(strings.TrimSuffix(filepath.Base(parsedArgs.Script), ".lisp"))
+	liblog.SetRunFields(map[string]string{
+		"commit":   integrity.CommitHash(),
+		"repo":     integrity.RepoName(),
+		"trace_id": hex.EncodeToString(traceID),
+	})
+	argv, err := json.Marshal(append([]string{parsedArgs.Script}, parsedArgs.Args...))
+	if err != nil {
+		return err
+	}
+	startFields := map[string]string{
+		"argv":      string(argv),
+		"protected": fmt.Sprintf("%t", protected),
+	}
+	if signer := integrity.Signer(); signer != "" {
+		startFields["signer"] = signer
+	}
+	if err := emitRecord(slog.LevelInfo, "run started", startFields); err != nil {
+		return err
+	}
+
+	exitCode := "1"
+	endLevel := slog.LevelError
+	defer func() {
+		fields := map[string]string{"exit_code": exitCode}
+		if r := recover(); r != nil {
+			fields["panic"] = fmt.Sprint(r)
+			_ = emitRecord(slog.LevelError, "run ended", fields)
+			panic(r)
+		}
+		_ = emitRecord(endLevel, "run ended", fields)
+	}()
+
+	result, err := runScript(context.Background(), repl_env, parsedArgs.Script, nil,
+		types.NewCursorHere(parsedArgs.Script, -3, 1))
+	if err != nil {
+		return err
+	}
+	exitCode, endLevel = "0", slog.LevelInfo
+	fmt.Println(result)
+	return nil
 }
 
 // reportIntegrity writes the audit outcome to stderr. On an interactive
 // terminal it prints a human-readable block — green when integrity is
-// satisfied, red when not; when stderr is redirected it emits the
-// machine-readable JSON line instead (JSON is the norm for log
-// ingestion). The block attests the pinned ref and the entry script
-// only: each require/load-file is verified as it loads and aborts the
-// run on mismatch, so a green block does not mean the whole run is
-// pre-verified. Returns nil on success, ErrIntegrityReported on a
-// terminal failure (already shown), or the cause when redirected.
-func reportIntegrity(ok bool, ref, commit, signer string, cause error) error {
+// satisfied, red when not; when stderr is redirected it emits a
+// machine-readable JSON line instead. The block attests the entry
+// script only: each require/load-file is verified as it loads and
+// aborts the run on mismatch, so a green block does not mean the whole
+// run is pre-verified. Returns nil on success, ErrIntegrityReported on
+// a terminal failure (already shown), or the cause when redirected.
+func reportIntegrity(ok bool, repo, commit, signer string, cause error) error {
 	if !libterm.StderrIsTerminal() {
 		if !ok {
 			return cause // the normal error path reports it
 		}
-		attrs := []any{"ref", ref, "commit", commit}
+		attrs := []any{"repo", repo, "commit", commit}
 		if signer != "" {
 			attrs = append(attrs, "signer", signer)
 		}
-		slog.New(slog.NewJSONHandler(os.Stderr, nil)).Info("integrity: entry script and ref verified", attrs...)
+		slog.New(slog.NewJSONHandler(os.Stderr, nil)).Info("integrity: entry script verified at HEAD", attrs...)
 		return nil
 	}
 
-	fmt.Fprint(os.Stderr, integrityBlock(ok, ref, commit, signer, cause))
+	fmt.Fprint(os.Stderr, integrityBlock(ok, repo, commit, signer, cause))
 	if ok {
 		return nil
 	}
@@ -93,7 +220,7 @@ func reportIntegrity(ok bool, ref, commit, signer string, cause error) error {
 }
 
 // integrityBlock renders the coloured, one-field-per-line audit block.
-func integrityBlock(ok bool, ref, commit, signer string, cause error) string {
+func integrityBlock(ok bool, repo, commit, signer string, cause error) string {
 	field := func(label, value string) string {
 		return fmt.Sprintf("    %-6s  %s\n", label, value)
 	}
@@ -102,7 +229,7 @@ func integrityBlock(ok bool, ref, commit, signer string, cause error) string {
 		return libterm.StderrStyle("red", true, "✗ integrity check failed") + "\n" +
 			libterm.StderrStyle("red", false, field("reason", reason))
 	}
-	body := field("ref", ref) + field("commit", commit)
+	body := field("repo", repo) + field("commit", commit)
 	if signer != "" {
 		body += field("signer", signer)
 	}

--- a/command/integrity_test.go
+++ b/command/integrity_test.go
@@ -2,9 +2,11 @@ package command
 
 import (
 	"errors"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -20,7 +22,7 @@ import (
 	"github.com/jig/lisp/types"
 )
 
-// newIntegrityEnv loads the namespaces an --integrity script needs:
+// newIntegrityEnv loads the namespaces a lisp-integrity script needs:
 // core, coreextended, require and integrity.
 func newIntegrityEnv(t *testing.T) types.EnvType {
 	t.Helper()
@@ -34,6 +36,37 @@ func newIntegrityEnv(t *testing.T) types.EnvType {
 		}
 	}
 	return ns
+}
+
+// record is one attestation record captured by stubAttestation.
+type record struct {
+	level  slog.Level
+	msg    string
+	fields map[string]string
+}
+
+// stubAttestation makes ExecuteIntegrity hermetic: journald is reported
+// available, records are captured instead of sent, stdin is reported as
+// a non-terminal, and the allowed-signers path points nowhere. Restores
+// everything on cleanup and returns the captured records.
+func stubAttestation(t *testing.T) *[]record {
+	t.Helper()
+	var records []record
+	origJournal, origEmit, origStdin, origPath := journalEnabled, emitRecord, stdinIsTerminal, allowedSignersPath
+	journalEnabled = func() bool { return true }
+	emitRecord = func(l slog.Level, msg string, fields map[string]string) error {
+		records = append(records, record{level: l, msg: msg, fields: fields})
+		return nil
+	}
+	stdinIsTerminal = func() bool { return false }
+	allowedSignersPath = filepath.Join(t.TempDir(), "no-signers")
+	t.Cleanup(func() {
+		journalEnabled = origJournal
+		emitRecord = origEmit
+		stdinIsTerminal = origStdin
+		allowedSignersPath = origPath
+	})
+	return &records
 }
 
 // runGit runs a git command in dir and returns its trimmed output,
@@ -59,7 +92,7 @@ func runGit(t *testing.T, dir string, args ...string) string {
 // requires .lisp/util.lisp and asserts integrity) and returns its dir
 // and HEAD hash. It uses the git CLI, chdirs into the repo (so require
 // resolves `.lisp/` there) and registers cleanup of the integrity
-// globals the Execute call under test mutates.
+// globals the ExecuteIntegrity call under test mutates.
 func gitRepoWithScript(t *testing.T) (dir, hash string) {
 	t.Helper()
 	dir = t.TempDir()
@@ -92,68 +125,133 @@ func gitRepoWithScript(t *testing.T) (dir, hash string) {
 }
 
 func TestExecuteIntegrityRunsVerifiedScript(t *testing.T) {
+	records := stubAttestation(t)
 	_, hash := gitRepoWithScript(t)
 	ns := newIntegrityEnv(t)
 	out, err := captureStdout(t, func() error {
-		return Execute([]string{"lisp", "--integrity", hash, "script.lisp"}, ns)
+		return ExecuteIntegrity([]string{"lisp-integrity", "-y", "script.lisp", "one", "two"}, ns)
 	})
 	if err != nil {
-		t.Fatalf("Execute: %v", err)
+		t.Fatalf("ExecuteIntegrity: %v", err)
 	}
 	if !strings.Contains(out, hash) || !strings.Contains(out, "hola") || !strings.Contains(out, "extra") {
 		t.Fatalf("output %q: want the commit hash, the module's and the load-file's values", out)
 	}
+
+	// The run is attested: a start record with argv, an end record with
+	// exit_code 0.
+	if len(*records) != 2 {
+		t.Fatalf("expected start+end records, got %d: %+v", len(*records), *records)
+	}
+	start, end := (*records)[0], (*records)[1]
+	if start.msg != "run started" || !strings.Contains(start.fields["argv"], `"script.lisp"`) ||
+		!strings.Contains(start.fields["argv"], `"two"`) {
+		t.Fatalf("unexpected start record: %+v", start)
+	}
+	if start.fields["protected"] != "true" || start.fields["signer"] != "" {
+		t.Fatalf("unexpected start record fields: %+v", start.fields)
+	}
+	if end.msg != "run ended" || end.fields["exit_code"] != "0" || end.level != slog.LevelInfo {
+		t.Fatalf("unexpected end record: %+v", end)
+	}
 }
 
 func TestExecuteIntegrityRejectsTamperedLoadFile(t *testing.T) {
-	dir, hash := gitRepoWithScript(t)
+	records := stubAttestation(t)
+	dir, _ := gitRepoWithScript(t)
 	if err := os.WriteFile(filepath.Join(dir, "extra.lisp"), []byte(`(def extra-val "evil")`+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	ns := newIntegrityEnv(t)
 	_, err := captureStdout(t, func() error {
-		return Execute([]string{"lisp", "--integrity", hash, "script.lisp"}, ns)
+		return ExecuteIntegrity([]string{"lisp-integrity", "-y", "script.lisp"}, ns)
 	})
 	if err == nil || !strings.Contains(err.Error(), "integrity") {
-		t.Fatalf("Execute with tampered load-file target = %v, want integrity error", err)
+		t.Fatalf("ExecuteIntegrity with tampered load-file target = %v, want integrity error", err)
+	}
+	// The failure happened mid-run: the end record reports exit_code 1.
+	end := (*records)[len(*records)-1]
+	if end.msg != "run ended" || end.fields["exit_code"] != "1" || end.level != slog.LevelError {
+		t.Fatalf("unexpected end record after failure: %+v", end)
 	}
 }
 
 func TestExecuteIntegrityRejectsTamperedModule(t *testing.T) {
-	dir, hash := gitRepoWithScript(t)
+	stubAttestation(t)
+	dir, _ := gitRepoWithScript(t)
 	if err := os.WriteFile(filepath.Join(dir, ".lisp", "util.lisp"), []byte(`(def hello (fn [] "evil"))`+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	ns := newIntegrityEnv(t)
 	_, err := captureStdout(t, func() error {
-		return Execute([]string{"lisp", "--integrity", hash, "script.lisp"}, ns)
+		return ExecuteIntegrity([]string{"lisp-integrity", "-y", "script.lisp"}, ns)
 	})
 	if err == nil || !strings.Contains(err.Error(), "integrity") {
-		t.Fatalf("Execute with tampered module = %v, want integrity error", err)
+		t.Fatalf("ExecuteIntegrity with tampered module = %v, want integrity error", err)
 	}
 }
 
-func TestExecuteAssertIntegrityWithoutFlag(t *testing.T) {
+func TestExecuteAssertIntegrityUnderPlainLisp(t *testing.T) {
 	gitRepoWithScript(t)
 	ns := newIntegrityEnv(t)
 	_, err := captureStdout(t, func() error {
 		return Execute([]string{"lisp", "script.lisp"}, ns)
 	})
 	if err == nil || !strings.Contains(err.Error(), "assert-integrity") {
-		t.Fatalf("Execute without --integrity = %v, want assert-integrity throw", err)
+		t.Fatalf("Execute under plain lisp = %v, want assert-integrity throw", err)
 	}
 }
 
-func TestExecuteIntegrityFlagValidation(t *testing.T) {
+func TestExecuteIntegrityRefusesWithoutConsent(t *testing.T) {
+	stubAttestation(t) // stdin reported as non-terminal
+	gitRepoWithScript(t)
+	ns := newIntegrityEnv(t)
+	_, err := captureStdout(t, func() error {
+		return ExecuteIntegrity([]string{"lisp-integrity", "script.lisp"}, ns)
+	})
+	if err == nil || !strings.Contains(err.Error(), "confirmation") {
+		t.Fatalf("ExecuteIntegrity without -y on non-terminal = %v, want refusal", err)
+	}
+}
+
+func TestExecuteIntegrityRequiresJournald(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("darwin falls back to the XDG state file")
+	}
+	stubAttestation(t)
+	journalEnabled = func() bool { return false }
+	gitRepoWithScript(t)
+	ns := newIntegrityEnv(t)
+	_, err := captureStdout(t, func() error {
+		return ExecuteIntegrity([]string{"lisp-integrity", "-y", "script.lisp"}, ns)
+	})
+	if err == nil || !strings.Contains(err.Error(), "journald") {
+		t.Fatalf("ExecuteIntegrity without journald = %v, want refusal", err)
+	}
+}
+
+func TestExecuteIntegrityArgValidation(t *testing.T) {
+	stubAttestation(t)
 	ns := newIntegrityEnv(t)
 	for _, cmdline := range [][]string{
-		{"lisp", "--integrity", "HEAD"},                          // no script
-		{"lisp", "--integrity", "HEAD", "-"},                     // stdin
-		{"lisp", "--integrity", "HEAD", "-e", "1", "x.lisp"},     // eval
-		{"lisp", "--integrity-keys", "keys.txt", "x.lisp"},       // keys alone
-		{"lisp", "--integrity", "HEAD", "--fmt", "x.lisp"},       // fmt
-		{"lisp", "--integrity", "HEAD", "--test", ".", "x.lisp"}, // test
-		{"lisp", "--integrity", "HEAD", "--debug", "x.lisp"},     // debugger hook
+		{"lisp-integrity"},                        // no script
+		{"lisp-integrity", "-y", "-"},             // stdin
+		{"lisp-integrity", "-e", "1", "x.lisp"},   // unknown flag
+		{"lisp-integrity", "--fmt", "x.lisp"},     // unknown flag
+		{"lisp-integrity", "--test", ".", "x.l"},  // unknown flag
+		{"lisp-integrity", "--integrity", "HEAD"}, // v1 flag is gone
+	} {
+		if err := ExecuteIntegrity(cmdline, ns); err == nil {
+			t.Errorf("ExecuteIntegrity(%v) did not fail", cmdline)
+		}
+	}
+}
+
+func TestExecuteRejectsRemovedIntegrityFlags(t *testing.T) {
+	ns := newIntegrityEnv(t)
+	for _, cmdline := range [][]string{
+		{"lisp", "--integrity", "HEAD", "x.lisp"},
+		{"lisp", "--integrity-keys", "keys.txt", "x.lisp"},
 	} {
 		if err := Execute(cmdline, ns); err == nil {
 			t.Errorf("Execute(%v) did not fail", cmdline)
@@ -165,8 +263,8 @@ func TestExecuteIntegrityFlagValidation(t *testing.T) {
 // header plus one field per line on success, a red header plus reason on
 // failure. Asserts the text (robust to whether color is on).
 func TestIntegrityBlockFormat(t *testing.T) {
-	ok := integrityBlock(true, "v1.2.3", "abc123def", "alice", nil)
-	for _, want := range []string{"integrity verified", "ref", "v1.2.3", "commit", "abc123def", "signer", "alice"} {
+	ok := integrityBlock(true, "git@github.com:jig/example.git", "abc123def", "alice", nil)
+	for _, want := range []string{"integrity verified", "repo", "example", "commit", "abc123def", "signer", "alice"} {
 		if !strings.Contains(ok, want) {
 			t.Errorf("success block missing %q:\n%s", want, ok)
 		}
@@ -175,7 +273,7 @@ func TestIntegrityBlockFormat(t *testing.T) {
 		t.Errorf("expected header + 3 fields (3 newlines), got %d:\n%s", n, ok)
 	}
 
-	noSigner := integrityBlock(true, "v1", "abc", "", nil)
+	noSigner := integrityBlock(true, "example", "abc", "", nil)
 	if strings.Contains(noSigner, "signer") {
 		t.Errorf("no signer line expected when signer is empty:\n%s", noSigner)
 	}

--- a/command/integrity_toctou_test.go
+++ b/command/integrity_toctou_test.go
@@ -36,7 +36,7 @@ func TestRunScriptPreambleTOCTOU(t *testing.T) {
 	if err := os.WriteFile(scriptPath, []byte(committed), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	hash := gitInitCommit(t, dir)
+	gitInitCommit(t, dir)
 	t.Chdir(dir)
 	t.Cleanup(func() {
 		integrity.Disable()
@@ -45,8 +45,8 @@ func TestRunScriptPreambleTOCTOU(t *testing.T) {
 	})
 
 	// Enable verifies the committed script; wire the hooks exactly as
-	// setupIntegrity does.
-	if err := integrity.Enable(scriptPath, hash, ""); err != nil {
+	// ExecuteIntegrity does.
+	if err := integrity.Enable(scriptPath, ""); err != nil {
 		t.Fatalf("Enable: %v", err)
 	}
 	require.VerifyModule = integrity.VerifyFile

--- a/command/preamble.go
+++ b/command/preamble.go
@@ -86,7 +86,7 @@ func runScript(ctx context.Context, env types.EnvType, fileName string, preamble
 	if err != nil {
 		return nil, err
 	}
-	// Under --integrity, verify the exact bytes about to be evaluated.
+	// Under lisp-integrity, verify the exact bytes about to be evaluated.
 	// integrity.Enable verified the script from an earlier, independent
 	// read; the preamble branch below evaluates *this* buffer directly
 	// (not through load-file/slurp-source), so without this check the

--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -57,7 +57,7 @@ var sectionBlurb = map[string]struct{ title, desc string }{
 	"require":             {"require", "Module loading by name through a search path."},
 	"sql":                 {"sql", "SQL database access."},
 	"cli":                 {"cli", "Command-line option parsing (clojure/tools.cli style)."},
-	"integrity":           {"integrity", "Attest and verify lisp source (formatting, hashing, Ed25519 signatures, --integrity mode)."},
+	"integrity":           {"integrity", "Attest and verify lisp source (formatting, hashing, Ed25519 signatures, the lisp-integrity mode)."},
 	"regexp":              {"regexp", "Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-replace and re-split."},
 }
 

--- a/examples-integrity/01-basic/service.lisp
+++ b/examples-integrity/01-basic/service.lisp
@@ -1,5 +1,5 @@
 ;; Minimal integrity-mode program: assert-integrity throws unless the
-;; interpreter runs under --integrity, and returns the verified commit
+;; interpreter is lisp-integrity, and returns the verified commit
 ;; hash — so this line both demands the mode and logs the release.
 (println "running release:" (assert-integrity))
 (println "hello from verified code")

--- a/examples-integrity/03-signed/service.lisp
+++ b/examples-integrity/03-signed/service.lisp
@@ -1,4 +1,4 @@
-;; With --integrity-keys, the ref must carry an SSH signature by a
-;; trusted key: the trust anchor becomes the key list, not the local
-;; repository state. See the README for creating the signed tag.
+;; With /etc/lisp/allowed_signers present, HEAD must carry an SSH
+;; signature by a trusted key: the trust anchor becomes the key list,
+;; not the local repository state. See the README for the signed tag.
 (println "running release signed by a trusted key:" (assert-integrity))

--- a/examples-integrity/04-state/service.lisp
+++ b/examples-integrity/04-state/service.lisp
@@ -1,9 +1,9 @@
 ;; The .state/ store: state-save writes canonical lisp data and commits
 ;; it in the same operation; state-load reads it back as pure data and,
-;; under --integrity, requires it to match its committed version at
-;; HEAD. The state commits do not invalidate the code ref: every
-;; restart uses the same --integrity argument.
-;; Run under --integrity-keys and the state commit is SSH-signed
+;; under lisp-integrity, requires it to match its committed version at
+;; HEAD. State commits advance HEAD as children of the release, so
+;; every restart keeps verifying the same code.
+;; With /etc/lisp/allowed_signers present the state commit is SSH-signed
 ;; automatically with the ssh-agent key listed there — no key in the code.
 (assert-integrity)
 

--- a/examples-integrity/README.md
+++ b/examples-integrity/README.md
@@ -4,21 +4,28 @@ Mini-examples for the concepts in [INTEGRITY.md](../INTEGRITY.md), one
 directory per concept. Each is a complete program plus the shell
 commands that take it from "files on disk" to "verified run".
 
-**The examples must run in their own repository.** `--integrity`
+**The examples must run in their own repository.** `lisp-integrity`
 verifies against the Git repository *enclosing the script* — run in
 place, that would be jig/lisp itself. Copy an example into a fresh
 directory and follow its steps, or run the whole tour non-interactively:
 
 ```bash
-./demo.sh                 # uses `lisp` from PATH
-LISP=/path/to/lisp ./demo.sh
+./demo.sh                 # uses `lisp` and `lisp-integrity` from PATH
+LISP=/path/to/lisp LISP_INTEGRITY=/path/to/lisp-integrity ./demo.sh
 ```
 
 `demo.sh` replays every walkthrough below in throwaway repositories,
 including the failure cases, and is kept runnable as a living check of
-this documentation.
+this documentation. Exception: 03-signed is manual — its trust anchor
+is `/etc/lisp/allowed_signers`, and a demo must never touch a real
+host's trust anchor.
 
-## 01-basic — verify a script against a ref
+The interactive runs below ask `proceed? [y/N]` after the green block;
+`demo.sh` passes `-y`. On Linux, `lisp-integrity` requires the
+systemd journal (every run is attested there); read a run back with
+`journalctl -t service -o json`.
+
+## 01-basic — verify a script against HEAD
 
 `assert-integrity` makes the program refuse to run unverified.
 
@@ -26,37 +33,40 @@ this documentation.
 cp 01-basic/service.lisp /tmp/demo && cd /tmp/demo
 git init && git add -A && git commit -m "release" && git tag v1
 
-lisp --integrity v1 service.lisp     # ✓ runs, prints the commit hash
+lisp-integrity service.lisp          # ✓ runs, prints the commit hash
 lisp service.lisp                    # ✗ assert-integrity throws
 echo ";; patched" >> service.lisp
-lisp --integrity v1 service.lisp     # ✗ differs from its committed version
+lisp-integrity service.lisp          # ✗ differs from its committed version
 ```
 
-A commit hash works exactly like the tag: `lisp --integrity $(git
-rev-parse v1) service.lisp`.
+Pin a release by checking it out: `git checkout --detach v1` — HEAD
+stays there across restarts, and `git pull` cannot move it.
 
 ## 02-requires — the check cascades to required modules
 
 `require` resolves `util` to `.lisp/util.lisp` in the same repository;
-under `--integrity` the module must match its committed blob too, and
-modules resolving *outside* the repository are refused.
+the module must match its committed blob too, and modules resolving
+*outside* the repository are refused.
 
 ```bash
 cp -r 02-requires/. /tmp/demo && cd /tmp/demo
-git init && git add -A && git commit -m "release" && git tag v1
+git init && git add -A && git commit -m "release"
 
-lisp --integrity v1 service.lisp     # ✓ script and module verified
+lisp-integrity service.lisp          # ✓ script and module verified
 echo "(def evil 1)" >> .lisp/util.lisp
-lisp --integrity v1 service.lisp     # ✗ util.lisp differs
+lisp-integrity service.lisp          # ✗ util.lisp differs
 ```
 
 The same cascade covers `load-file`/`load-file-once` targets.
 
-## 03-signed — trust a key, not the local repository
+## 03-signed — trust a key, not the local repository (manual)
 
-An SSH-signed tag plus `--integrity-keys` upgrades the guarantee
-from "matches this repository" to "matches what a trusted key
-released" — it survives cloning the repository elsewhere.
+When `/etc/lisp/allowed_signers` exists, every `lisp-integrity` run on
+the host requires the HEAD chain to be SSH-signed by a listed key —
+the guarantee upgrades from "matches this repository" to "matches what
+a trusted key released", and survives cloning the repository
+elsewhere. **Do this on a disposable host**: installing the file
+affects every `lisp-integrity` run on it.
 
 ```bash
 cp 03-signed/service.lisp /tmp/demo && cd /tmp/demo
@@ -65,37 +75,42 @@ git init && git add -A && git commit -m "release"
 ssh-keygen -t ed25519 -f release-key -N "" -C "release@example.com"
 git -c gpg.format=ssh -c user.signingkey=./release-key tag -s v1 -m "signed release"
 
-# The keys file is authorized_keys / .pub format — the .pub file as is,
-# NOT git's allowed_signers (a principal-first line would be rejected).
-# In production it lives OUTSIDE the repository (e.g. /etc/lisp/).
-lisp --integrity v1 --integrity-keys release-key.pub service.lisp   # ✓
+# The trust anchor is authorized_keys / .pub format — the .pub file as
+# is, NOT git's allowed_signers (a principal-first line is rejected).
+# Root-owned, outside any repository:
+sudo mkdir -p /etc/lisp
+sudo cp release-key.pub /etc/lisp/allowed_signers
 
-ssh-keygen -t ed25519 -f other-key -N ""
-lisp --integrity v1 --integrity-keys other-key.pub service.lisp     # ✗ no allowed key matches
-git tag -d v1 && git tag v1                                            # re-tag, unsigned
-lisp --integrity v1 --integrity-keys release-key.pub service.lisp   # ✗ tag is not signed
+lisp-integrity service.lisp          # ✓ signer reported in the green block
+
+git tag -d v1 && git tag v1          # re-tag, unsigned
+lisp-integrity service.lisp          # ✗ commit is not signed
+sudo rm /etc/lisp/allowed_signers    # clean up the host!
 ```
+
+`(assert-integrity :with-signature)` in the script makes it refuse to
+run on hosts *without* the file, closing the "quietly unsigned" gap.
 
 ## 04-state — persistent state inside the integrity envelope
 
 `state-save` writes `.state/db.lisp` as canonical lisp data and
 commits it in the same operation; `state-load` reads it back as pure
-data and requires it to match `HEAD`. The state commits are accepted
-by the startup check, so **every restart uses the same ref**:
+data and requires it to match `HEAD`. State commits advance HEAD as
+children of the release, so **every restart keeps verifying**:
 
 ```bash
 cp 04-state/service.lisp /tmp/demo && cd /tmp/demo
-git init && git add -A && git commit -m "release" && git tag v1
+git init && git add -A && git commit -m "release"
 
-lisp --integrity v1 service.lisp     # visit number 1
-lisp --integrity v1 service.lisp     # visit number 2  (same ref!)
-lisp --integrity v1 service.lisp     # visit number 3
+lisp-integrity service.lisp          # visit number 1
+lisp-integrity service.lisp          # visit number 2
+lisp-integrity service.lisp          # visit number 3
 git log --oneline                    # release + three "state: db" commits
 
 echo "{:visits 999}" > .state/db.lisp
-lisp --integrity v1 service.lisp     # ✗ differs from its committed version at HEAD
+lisp-integrity service.lisp          # ✗ differs from its committed version at HEAD
 git checkout .state/db.lisp          # operator resolves; runs again
 ```
 
-A commit touching anything outside `.state/` after the ref invalidates
-the run — code changes always require a new release ref.
+Code changes require a new commit (a new release checkout); only
+`.state/` moves between releases.

--- a/examples-integrity/demo.sh
+++ b/examples-integrity/demo.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 # Replays every walkthrough of README.md in throwaway repositories,
 # failure cases included. A living check that the examples work as
-# documented. Usage: ./demo.sh  (or LISP=/path/to/lisp ./demo.sh)
+# documented. Usage: ./demo.sh
+#   (or LISP=/path/to/lisp LISP_INTEGRITY=/path/to/lisp-integrity ./demo.sh)
+#
+# 03-signed is NOT replayed: the signature rule activates through
+# /etc/lisp/allowed_signers, and a demo must never touch a real host's
+# trust anchor. Follow 03-signed/README.md manually on a disposable
+# host; the rule itself is covered by the Go tests.
 set -euo pipefail
 
 LISP=${LISP:-lisp}
+LISP_INTEGRITY=${LISP_INTEGRITY:-lisp-integrity}
 HERE=$(cd "$(dirname "$0")" && pwd)
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
@@ -34,49 +41,32 @@ repo() { # repo <example-dir> → sets up $WORK/<example-dir> as a fresh tagged 
 	git tag v1
 }
 
-step "01-basic: verify a script against a ref"
+step "01-basic: verify a script against HEAD"
 repo 01-basic
-$LISP --integrity v1 service.lisp
-$LISP --integrity "$(git rev-parse v1)" service.lisp >/dev/null
-ok "a commit hash works like the tag"
-must_fail "running without --integrity (assert-integrity throws)" -- $LISP service.lisp
+$LISP_INTEGRITY -y service.lisp
+git checkout -q --detach v1
+$LISP_INTEGRITY -y service.lisp >/dev/null
+ok "a detached checkout pins the release across restarts"
+must_fail "running under plain lisp (assert-integrity throws)" -- $LISP service.lisp
 echo ";; patched" >> service.lisp
-must_fail "script modified after the release" -- $LISP --integrity v1 service.lisp
+must_fail "script modified after the release" -- $LISP_INTEGRITY -y service.lisp
 
 step "02-requires: the check cascades to required modules"
 repo 02-requires
-$LISP --integrity v1 service.lisp
+$LISP_INTEGRITY -y service.lisp
 echo "(def evil 1)" >> .lisp/util.lisp
-must_fail "module modified after the release" -- $LISP --integrity v1 service.lisp
-
-step "03-signed: trust a key, not the local repository"
-repo 03-signed
-git tag -d v1 >/dev/null
-ssh-keygen -q -t ed25519 -f release-key -N "" -C "release@example.com"
-git -c user.name=Demo -c user.email=demo@example.com \
-    -c gpg.format=ssh -c user.signingkey=./release-key tag -s v1 -m "signed release"
-$LISP --integrity v1 --integrity-keys release-key.pub service.lisp
-ssh-keygen -q -t ed25519 -f other-key -N ""
-must_fail "signed by a key not in the keys file" -- \
-	$LISP --integrity v1 --integrity-keys other-key.pub service.lisp
-# git allowed_signers format (principal-first) is refused, not misparsed.
-printf 'release@example.com %s\n' "$(cat release-key.pub)" > allowed_signers
-must_fail "allowed_signers format (principal-first) instead of .pub" -- \
-	$LISP --integrity v1 --integrity-keys allowed_signers service.lisp
-git tag -d v1 >/dev/null && git tag v1
-must_fail "unsigned tag with --integrity-keys" -- \
-	$LISP --integrity v1 --integrity-keys release-key.pub service.lisp
+must_fail "module modified after the release" -- $LISP_INTEGRITY -y service.lisp
 
 step "04-state: persistent state inside the integrity envelope"
 repo 04-state
-$LISP --integrity v1 service.lisp
-$LISP --integrity v1 service.lisp
-$LISP --integrity v1 service.lisp
-[ "$(git log --oneline | grep -c 'state: db')" -eq 3 ] && ok "three state commits, same ref throughout"
+$LISP_INTEGRITY -y service.lisp
+$LISP_INTEGRITY -y service.lisp
+$LISP_INTEGRITY -y service.lisp
+[ "$(git log --oneline | grep -c 'state: db')" -eq 3 ] && ok "three state commits, HEAD advances, still verifies"
 echo "{:visits 999}" > .state/db.lisp
-must_fail "state file edited out of band" -- $LISP --integrity v1 service.lisp
+must_fail "state file edited out of band" -- $LISP_INTEGRITY -y service.lisp
 git checkout -- .state/db.lisp
-$LISP --integrity v1 service.lisp >/dev/null
+$LISP_INTEGRITY -y service.lisp >/dev/null
 ok "operator restored the state; runs again"
 
-step "all examples behaved as documented"
+step "all examples behaved as documented (03-signed is manual, see its README)"

--- a/lib/git/README.md
+++ b/lib/git/README.md
@@ -26,7 +26,7 @@ nsgit.Load(env)
 
 ## Signed commits and tags
 
-There is **no per-call signing key**. `git-commit` and annotated `git-tag` are SSH-signed only when a signing policy is installed, which the interpreter does under `lisp --integrity-keys FILE`: it signs with the **ssh-agent** key whose public key is listed in FILE (the same trusted-key list that verifies the code ref). The private key never enters the process — it stays in the agent, unlocked however the agent is (keychain, `ssh-add`, …). No policy → commits and tags are unsigned.
+There is **no per-call signing key**. `git-commit` and annotated `git-tag` are SSH-signed only when a signing policy is installed, which the interpreter does when an allowed-signers set is active (`lisp-integrity` with `/etc/lisp/allowed_signers`): it signs with the **ssh-agent** key whose public key is listed in FILE (the same trusted-key list that verifies the code ref). The private key never enters the process — it stays in the agent, unlocked however the agent is (keychain, `ssh-add`, …). No policy → commits and tags are unsigned.
 
 The signature uses the SSH signature format with namespace `git` and SHA-512, exactly what `ssh-keygen -Y sign` and `git commit -S` produce with `gpg.format=ssh`. In sha256 repositories the commit signature is stored under the `gpgsig-sha256` header, as git expects; tag signatures are appended to the tag body in both formats. (Go embedders install their own policy with `git.SetSigner`.)
 

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -98,7 +98,7 @@ func Load(env EnvType) {
 	call.Doc(env, "git-add", "[repo path & {:all :glob}]",
 		"Stages path (\".\" for everything); :all true stages all modified/deleted files, :glob true treats path as a glob pattern.")
 	call.Doc(env, "git-commit", "[repo msg & {:author {:name :email} :committer :all :allow-empty :amend}]",
-		"Commits staged changes and returns the commit map. Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there; otherwise it is unsigned (there is no per-call key option).")
+		"Commits staged changes and returns the commit map. When an allowed-signers set is active the commit is SSH-signed with the ssh-agent key listed there; otherwise it is unsigned (there is no per-call key option).")
 	call.Doc(env, "git-log", "[repo & {:max :from :all :path}]",
 		"Returns a vector of commit maps from HEAD (or :from rev), newest first.")
 	call.Doc(env, "git-show", "[repo rev]",
@@ -114,7 +114,7 @@ func Load(env EnvType) {
 	call.Doc(env, "git-checkout", "[repo ref & {:create :force}]",
 		"Checks out a branch, tag or revision; :create true creates the branch first.")
 	call.Doc(env, "git-tag", "[repo name & {:at :message :tagger {:name :email}}]",
-		"Creates a tag at HEAD (or :at rev); :message makes it annotated. Under --integrity-keys an annotated tag is SSH-signed with the ssh-agent key listed there.")
+		"Creates a tag at HEAD (or :at rev); :message makes it annotated. When an allowed-signers set is active an annotated tag is SSH-signed with the ssh-agent key listed there.")
 	call.Doc(env, "git-tags", "[repo]",
 		"Returns a vector of {:name :hash :target :annotated} for all tags.")
 	call.Doc(env, "git-remote-add", "[repo name url]",
@@ -309,7 +309,7 @@ func gitCommit(rv MalType, msg string, params ...MalType) (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Signing is driven by the installed policy (--integrity-keys, via
+	// Signing is driven by the installed policy (allowed signers, via
 	// the ssh-agent), never a per-call key. It is done after the fact
 	// (see resignCommit) so the signature lands in the header matching
 	// the repo's object format; go-git's own Signer always writes gpgsig.

--- a/lib/git/git_test.go
+++ b/lib/git/git_test.go
@@ -97,7 +97,7 @@ func testKey(t *testing.T, comment string) (privPEM, authorized string) {
 }
 
 // signWith installs a signing policy from a PEM private key — the test
-// stand-in for --integrity-keys' ssh-agent signer — and clears it when
+// stand-in for the allowed signers' ssh-agent signer — and clears it when
 // the (sub)test ends. git-commit and annotated git-tag then sign.
 func signWith(t *testing.T, privPEM string) {
 	t.Helper()
@@ -278,7 +278,7 @@ func TestBranchesTagsStatus(t *testing.T) {
 	expectTrue(t, ns, `(= "master" (get (git-head r) :branch))`)
 
 	// tags: lightweight and annotated are unsigned; the signed one is
-	// created while a signing policy is active (as under --integrity-keys).
+	// created while a signing policy is active (as with allowed signers).
 	eval(t, ns, `(git-tag r "light")`)
 	eval(t, ns, `(git-tag r "annotated" {:message "v1" :tagger `+author+`})`)
 	signer, err := gossh.ParsePrivateKey([]byte(privPEM))

--- a/lib/git/sign.go
+++ b/lib/git/sign.go
@@ -26,7 +26,7 @@ const gitNamespace = "git"
 // nil when no signing policy is installed. It is the single knob for
 // signing — there is no per-call key option and no private key ever
 // enters the process. The command package installs it (SetSigningKeys)
-// when --integrity-keys is active; tests inject a signer with SetSigner.
+// when an allowed-signers set is active; tests inject a signer with SetSigner.
 var signerResolve func() (gossh.Signer, error)
 
 // SetSigner installs a signing policy: git-commit, git-tag and
@@ -39,11 +39,11 @@ func SetSigner(resolve func() (gossh.Signer, error)) { signerResolve = resolve }
 func ClearSigner() { signerResolve = nil }
 
 // SetSigningKeys installs the ssh-agent signing policy used under
-// --integrity-keys: commits and tags are signed with the agent key (at
+// an allowed-signers set: commits and tags are signed with the agent key (at
 // sshAuthSock) whose public key appears in allowedKeys (authorized_keys
 // / .pub format). Resolution is lazy and cached on first use, so a run
 // that never commits needs no agent; a run that commits under
-// --integrity-keys with no matching agent key fails closed.
+// an allowed-signers set with no matching agent key fails closed.
 func SetSigningKeys(sshAuthSock, allowedKeys string) {
 	var once sync.Once
 	var s gossh.Signer
@@ -59,7 +59,7 @@ func SetSigningKeys(sshAuthSock, allowedKeys string) {
 // process lifetime because the returned signer calls back over it.
 func resolveAgentSigner(sshAuthSock, allowedKeys string) (gossh.Signer, error) {
 	if sshAuthSock == "" {
-		return nil, fmt.Errorf("signing under --integrity-keys needs an ssh-agent, but SSH_AUTH_SOCK is unset")
+		return nil, fmt.Errorf("signing with an allowed-signers set needs an ssh-agent, but SSH_AUTH_SOCK is unset")
 	}
 	conn, err := net.Dial("unix", sshAuthSock)
 	if err != nil {
@@ -76,7 +76,7 @@ func resolveAgentSigner(sshAuthSock, allowedKeys string) (gossh.Signer, error) {
 		}
 	}
 	_ = conn.Close()
-	return nil, fmt.Errorf("no ssh-agent key is listed in --integrity-keys")
+	return nil, fmt.Errorf("no ssh-agent key is listed in the allowed signers")
 }
 
 // keyListed reports whether pub appears in allowedKeys (authorized_keys

--- a/lib/integrity/README.md
+++ b/lib/integrity/README.md
@@ -6,7 +6,7 @@ a `.lisp` file (formatting first, so cosmetic layout differences do not
 change the digest) and sign or verify it.
 
 The package also implements the interpreter's [integrity
-mode](#integrity-mode---integrity) (`lisp --integrity <ref>`).
+mode](#integrity-mode-lisp-integrity) (the `lisp-integrity` binary).
 
 ## Functions
 
@@ -17,8 +17,8 @@ mode](#integrity-mode---integrity) (`lisp --integrity <ref>`).
 | `(ed25519-generate)` | key pair `{:public "…" :private "…"}`, base64 |
 | `(ed25519-sign private s)` | base64 signature of `s` |
 | `(ed25519-verify public s signature)` | `true` or `false` |
-| `(assert-integrity)` | the verified commit hash; **throws** unless running under `--integrity` |
-| `(state-save name value & [message])` | writes `value` as canonical lisp data to `.state/name.lisp` and commits it (message defaults to `state: name`; SSH-signed with the ssh-agent key under `--integrity-keys`); returns the commit hash |
+| `(assert-integrity & [:with-signature])` | the verified commit hash; **throws** unless running under `lisp-integrity` (and, with `:with-signature`, unless the signature rule was applied) |
+| `(state-save name value & [message])` | writes `value` as canonical lisp data to `.state/name.lisp` and commits it (message defaults to `state: name`; SSH-signed with the ssh-agent key when an allowed-signers set is active); returns the commit hash |
 | `(state-load name & [default])` | the state read back as pure data (READ, never EVAL); `default` (or throws) when absent |
 
 Ed25519 signing is deterministic: the same key and message always yield
@@ -37,21 +37,22 @@ diff-friendly.
 (ed25519-verify (get keys :public) digest signature) ;; => true
 ```
 
-## Integrity mode (--integrity)
+## Integrity mode (lisp-integrity)
 
-`lisp --integrity <ref> script.lisp` runs `script.lisp` *if and only
-if* it matches what is committed in its enclosing Git repository at
-`<ref>` (a commit hash, tag or branch):
+`lisp-integrity script.lisp` runs `script.lisp` *if and only if* it
+matches what is committed in its enclosing Git repository at `HEAD`,
+and attests the run to systemd-journald:
 
-1. `HEAD` must be exactly the commit `<ref>` resolves to, or a linear
-   chain of `.state/`-only commits above it (the ones `state-save`
-   creates), so the same ref stays valid across restarts;
-2. the script must byte-match the blob committed at `<ref>`;
-3. in cascade, every file evaluated as code — `require` modules and
+1. the script must byte-match the blob committed at `HEAD` (pin a
+   release by checking it out: `git checkout --detach v1.4.2`);
+2. in cascade, every file evaluated as code — `require` modules and
    `load-file`/`load-file-once` targets — must resolve inside the same
    repository and byte-match its committed blob; a file resolving
    outside the repository (an `-i` directory elsewhere,
-   `~/.config/lisp/`, …) is refused.
+   `~/.config/lisp/`, …) is refused;
+3. the run leaves start/end records in the journal (commit, repo,
+   trace id, argv, exit code) and every `log-*` record carries the
+   same run fields.
 
 `(assert-integrity)` lets committed code demand the mode: it throws
 unless the run is verified, and returns the verified commit hash.
@@ -59,21 +60,23 @@ unless the run is verified, and returns the verified commit hash.
 state without leaving the integrity envelope (see
 [INTEGRITY.md](../../INTEGRITY.md), the full specification).
 
-With `--integrity-keys FILE` the ref must additionally carry an SSH
-signature made by one of the public keys in `FILE` (authorized_keys /
+When `/etc/lisp/allowed_signers` exists on the host (authorized_keys /
 `.pub` format, one key per line, as `git-verify-commit` — **not** git's
-`allowed_signers` format): the tag signature for annotated tags, the
-commit signature otherwise. The trust anchor then becomes the key list
-instead of the local repository state, so verification survives cloning
-the repository elsewhere.
+`allowed_signers` format), the `HEAD` chain must additionally be
+SSH-signed by a listed key: the release commit (itself or via a signed
+annotated tag pointing at it) and every state commit above it. The
+trust anchor then becomes the key list instead of the local repository
+state, so verification survives cloning the repository elsewhere.
+`(assert-integrity :with-signature)` demands that rule from code.
 
 What integrity mode is — and is not: it is an operational assurance
 for the operator launching the script (no accidental drift, no
-uncommitted edits, optionally "signed by a trusted key"). It is not a
-security boundary against an attacker who can rewrite the repository,
-the signers file or the `lisp` binary. `eval` over strings obtained by
-other means (`slurp`, network) is not covered, and uncommitted files
-that are never interpreted do not affect the check.
+uncommitted edits, optionally "signed by a trusted key") plus an
+append-only audit trail. It is not a security boundary against an
+attacker who can rewrite the repository, the signers file or the
+binary. `eval` over strings obtained by other means (`slurp`,
+network) is not covered, and uncommitted files that are never
+interpreted do not affect the check.
 
 ## Loading
 
@@ -88,4 +91,6 @@ nsintegrity.Load(env)
 The lisp-level functions have no dependencies beyond `core` (the
 example above uses `slurp` and `get` from core); the integrity mode
 machinery builds on go-git and `lib/git`'s SSH signature verification.
-The `lisp` binary loads the namespace by default.
+Both the `lisp` and `lisp-integrity` binaries load the namespace by
+default (under plain `lisp` the mode is never active, so
+`assert-integrity` always throws there).

--- a/lib/integrity/integrity.go
+++ b/lib/integrity/integrity.go
@@ -10,10 +10,10 @@
 // diff-friendly. Keys and signatures are exchanged as standard base64
 // strings; digests as lowercase hex.
 //
-// The package also implements the interpreter's integrity mode
-// (`lisp --integrity <ref>`, see mode.go), which runs a script if and
+// The package also implements the interpreter's integrity mode (the
+// `lisp-integrity` binary, see mode.go), which runs a script if and
 // only if it — and, in cascade, its repo-local requires — match what is
-// committed in its Git repository at <ref>; the (assert-integrity)
+// committed in its Git repository at HEAD; the (assert-integrity)
 // builtin lets a script demand that mode.
 package integrity
 
@@ -38,7 +38,7 @@ func Load(env EnvType) {
 	call.Call(env, ed25519_generate)
 	call.Call(env, ed25519_sign)
 	call.Call(env, ed25519_verify)
-	call.Call(env, assert_integrity)
+	call.Call(env, assert_integrity, 0, 1)
 	call.Call(env, state_save, 2, 3)
 	call.Call(env, state_load, 1, 2)
 
@@ -52,17 +52,28 @@ func Load(env EnvType) {
 		"Signs string s with a base64 Ed25519 private key; returns the base64 signature (deterministic).")
 	call.Doc(env, "ed25519-verify", "[public s signature]",
 		"Reports whether the base64 signature of string s verifies against the base64 Ed25519 public key.")
-	call.Doc(env, "assert-integrity", "[]",
-		"Throws unless the interpreter runs under --integrity; returns the verified commit hash.")
+	call.Doc(env, "assert-integrity", "[& [:with-signature]]",
+		"Throws unless the interpreter runs under lisp-integrity; returns the verified commit hash. With :with-signature it additionally throws unless the run's signature rule was applied (an allowed-signers set was present and HEAD verified against it).")
 	call.Doc(env, "state-save", "[name value & [message]]",
-		"Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. message is the commit message (default \"state: name\"). Under --integrity-keys the commit is SSH-signed with the ssh-agent key listed there. Under --integrity the commit keeps the verified ref valid.")
+		"Writes value as canonical lisp data to .state/name.lisp at the repository root and commits it; returns the commit hash. message is the commit message (default \"state: name\"). When an allowed-signers set is active (lisp-integrity with /etc/lisp/allowed_signers) the commit is SSH-signed with the ssh-agent key listed there.")
 	call.Doc(env, "state-load", "[name & [default]]",
-		"Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under --integrity the file must match its committed version at HEAD.")
+		"Reads .state/name.lisp back as data (READ, never EVAL); returns default (or throws) when absent. Under lisp-integrity the file must match its committed version at HEAD.")
 }
 
-func assert_integrity() (string, error) {
+func assert_integrity(opts ...MalType) (string, error) {
+	withSignature := false
+	for _, opt := range opts {
+		if kw, ok := opt.(Keyword); ok && string(kw) == "with-signature" {
+			withSignature = true
+			continue
+		}
+		return "", fmt.Errorf("assert-integrity: unknown option %v (only :with-signature is accepted)", opt)
+	}
 	if !Active() {
-		return "", fmt.Errorf("assert-integrity: source integrity is not verified (run with --integrity <ref>)")
+		return "", fmt.Errorf("assert-integrity: source integrity is not verified (run with lisp-integrity)")
+	}
+	if withSignature && !Signed() {
+		return "", fmt.Errorf("assert-integrity: signature verification was not performed (no allowed signers on this host)")
 	}
 	return CommitHash(), nil
 }

--- a/lib/integrity/mode.go
+++ b/lib/integrity/mode.go
@@ -1,26 +1,31 @@
 package integrity
 
-// This file implements integrity mode (`lisp --integrity <ref>`): the
-// interpreter runs a script if and only if it matches what is committed
-// in its Git repository at <ref>.
+// This file implements integrity mode (the `lisp-integrity` binary):
+// the interpreter runs a script if and only if it matches what is
+// committed in its Git repository at HEAD.
 //
-// Enable pins <ref> (a commit hash, tag or branch), requires HEAD to be
-// exactly that commit, and byte-compares the script against the blob
-// committed at it. The command package then installs VerifyFile as the
+// Enable anchors on HEAD and byte-compares the script against the blob
+// committed there. The command package then installs VerifyFile as the
 // require loader's vetting hook, so the check cascades: every module a
 // verified script requires must live in the same repository and match
 // its committed blob too; anything outside the repository is refused.
-// With an allowed-signers file, Enable additionally requires <ref> to
-// carry an SSH signature by one of the listed keys (the tag's signature
-// for annotated tags, the commit's otherwise), turning the guarantee
-// from "matches the local repository" into "matches what a trusted key
-// released".
+// Pinning a release is a property of the checkout, not of the
+// invocation: `git checkout --detach <tag>` keeps HEAD (and therefore
+// every restart) on that exact commit; only the script's own
+// state-save commits advance it, as children of it.
+//
+// With an allowed-signers file, Enable additionally requires the
+// anchor to carry an SSH signature by one of the listed keys: HEAD's
+// state-save commits (if any) must each be signed, and the release
+// commit under them must be signed itself or via an annotated tag
+// pointing at it — turning the guarantee from "matches the local
+// repository" into "matches what a trusted key released".
 //
 // This is an operational assurance for the operator launching the
 // script — no accidental drift, no uncommitted edits — not a security
 // boundary against an attacker who can already write to the repository
 // or replace the binary. Code the verified script chooses to load
-// outside the require mechanism (load-file, slurp+eval) is not covered.
+// outside the require mechanism (slurp+eval) is not covered.
 
 import (
 	"fmt"
@@ -34,22 +39,23 @@ import (
 	libgit "github.com/jig/lisp/lib/git"
 )
 
-// modeState is the pinned verification context of an --integrity run.
+// modeState is the pinned verification context of a lisp-integrity run.
 type modeState struct {
 	repo     *gogit.Repository
 	repoRoot string
-	ref      string
+	repoName string
 	signer   string
+	signed   bool
 	commit   *object.Commit
 	tree     *object.Tree
 }
 
-// mode is nil when the interpreter does not run under --integrity. It
+// mode is nil when the interpreter does not run under integrity. It
 // is written once by Enable before any lisp code is evaluated and only
 // read afterwards.
 var mode *modeState
 
-// Active reports whether the interpreter runs under --integrity.
+// Active reports whether the interpreter runs under integrity mode.
 func Active() bool { return mode != nil }
 
 // CommitHash returns the verified commit hash, or "" when inactive.
@@ -60,16 +66,18 @@ func CommitHash() string {
 	return mode.commit.Hash.String()
 }
 
-// Ref returns the ref --integrity was given, or "" when inactive.
-func Ref() string {
+// RepoName returns the verified repository's origin remote URL, or the
+// basename of its root directory when it has no origin; "" when
+// inactive.
+func RepoName() string {
 	if mode == nil {
 		return ""
 	}
-	return mode.ref
+	return mode.repoName
 }
 
 // Signer returns the comment of the allowed key that signed the
-// verified ref, or "" when inactive or no signers were required.
+// verified anchor, or "" when inactive or no signers were required.
 func Signer() string {
 	if mode == nil {
 		return ""
@@ -77,14 +85,30 @@ func Signer() string {
 	return mode.signer
 }
 
+// Signed reports whether signature verification was performed (an
+// allowed-signers set was present and the anchor verified against it).
+func Signed() bool { return mode != nil && mode.signed }
+
 // Disable turns integrity mode off. Exported for tests.
 func Disable() { mode = nil }
 
-// Enable verifies scriptPath against ref in its enclosing Git
+// repoName derives the attestation repository name: the origin remote
+// URL, or the repository root's basename without one.
+func repoName(repo *gogit.Repository, root string) string {
+	if remote, err := repo.Remote("origin"); err == nil {
+		if urls := remote.Config().URLs; len(urls) > 0 && urls[0] != "" {
+			return urls[0]
+		}
+	}
+	return filepath.Base(root)
+}
+
+// Enable verifies scriptPath against HEAD of its enclosing Git
 // repository and turns integrity mode on. allowedSigners, when
 // non-empty, holds authorized_keys-format public keys and makes Enable
-// additionally require ref to be SSH-signed by one of them.
-func Enable(scriptPath, ref, allowedSigners string) error {
+// additionally require the HEAD chain to be SSH-signed by them (see
+// verifyHeadSignature).
+func Enable(scriptPath, allowedSigners string) error {
 	abs, err := filepath.Abs(scriptPath)
 	if err != nil {
 		return fmt.Errorf("integrity: %w", err)
@@ -99,40 +123,18 @@ func Enable(scriptPath, ref, allowedSigners string) error {
 	}
 	root := wt.Filesystem().Root()
 
-	hash, err := repo.ResolveRevision(plumbing.Revision(ref))
-	if err != nil {
-		return fmt.Errorf("integrity: cannot resolve %q: %w", ref, err)
-	}
-	// An annotated tag resolves to the tag object; peel it to its
-	// target commit and keep it for the signature check.
-	tag, err := repo.TagObject(*hash)
-	commitHash := *hash
-	if err == nil {
-		commitHash = tag.Target
-	} else {
-		tag = nil
-	}
-	commit, err := repo.CommitObject(commitHash)
-	if err != nil {
-		return fmt.Errorf("integrity: %q does not resolve to a commit: %w", ref, err)
-	}
-
 	head, err := repo.Head()
 	if err != nil {
 		return fmt.Errorf("integrity: %w", err)
 	}
-	if head.Hash() != commit.Hash {
-		// HEAD may sit above the ref: state-save commits its writes,
-		// moving HEAD, and the code ref stays valid across restarts as
-		// long as every commit in between touches only .state/.
-		if err := verifyStateOnlyDescent(repo, head.Hash(), commit.Hash, allowedSigners); err != nil {
-			return fmt.Errorf("integrity: HEAD is at %s, not at %q (%s): %w", head.Hash(), ref, commit.Hash, err)
-		}
+	commit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		return fmt.Errorf("integrity: HEAD does not resolve to a commit: %w", err)
 	}
 
 	signer := ""
 	if allowedSigners != "" {
-		signer, err = verifyRefSignature(repo, ref, tag, commit, allowedSigners)
+		signer, err = verifyHeadSignature(repo, commit, allowedSigners)
 		if err != nil {
 			return fmt.Errorf("integrity: %w", err)
 		}
@@ -142,7 +144,15 @@ func Enable(scriptPath, ref, allowedSigners string) error {
 	if err != nil {
 		return fmt.Errorf("integrity: %w", err)
 	}
-	m := &modeState{repo: repo, repoRoot: root, ref: ref, signer: signer, commit: commit, tree: tree}
+	m := &modeState{
+		repo:     repo,
+		repoRoot: root,
+		repoName: repoName(repo, root),
+		signer:   signer,
+		signed:   allowedSigners != "",
+		commit:   commit,
+		tree:     tree,
+	}
 	content, err := os.ReadFile(abs)
 	if err != nil {
 		return fmt.Errorf("integrity: %w", err)
@@ -154,80 +164,97 @@ func Enable(scriptPath, ref, allowedSigners string) error {
 	return nil
 }
 
-// verifyRefSignature requires ref to be SSH-signed by an allowed key:
-// the tag signature when ref is an annotated tag, the commit signature
-// otherwise (plain commits, branches and lightweight tags). It returns
-// the signing key's comment.
-func verifyRefSignature(repo *gogit.Repository, ref string, tag *object.Tag, commit *object.Commit, allowedSigners string) (string, error) {
-	if tag == nil {
-		// ResolveRevision may already have peeled an annotated tag
-		// named ref to its commit; look the tag object up explicitly
-		// so its signature — not the commit's — is what gets checked.
-		if tref, err := repo.Reference(plumbing.NewTagReferenceName(ref), true); err == nil {
-			if t, err := repo.TagObject(tref.Hash()); err == nil {
-				tag = t
+// isStateOnly reports whether commit has exactly one parent and
+// touches only .state/ paths — the shape of a state-save commit.
+func isStateOnly(commit *object.Commit) (bool, error) {
+	if commit.NumParents() != 1 {
+		return false, nil
+	}
+	parent, err := commit.Parent(0)
+	if err != nil {
+		return false, err
+	}
+	curTree, err := commit.Tree()
+	if err != nil {
+		return false, err
+	}
+	parentTree, err := parent.Tree()
+	if err != nil {
+		return false, err
+	}
+	changes, err := object.DiffTree(parentTree, curTree)
+	if err != nil {
+		return false, err
+	}
+	for _, ch := range changes {
+		for _, name := range []string{ch.From.Name, ch.To.Name} {
+			if name != "" && !strings.HasPrefix(name, stateDir+"/") {
+				return false, nil
 			}
 		}
 	}
-	if tag != nil {
-		return libgit.VerifyTagSSH(tag, allowedSigners)
-	}
-	return libgit.VerifyCommitSSH(commit, allowedSigners)
+	return true, nil
 }
 
-// verifyStateOnlyDescent checks that ref is an ancestor of head through
-// a linear chain of commits that touch only .state/ paths — the commits
-// state-save creates. Any other divergence is an error. When
-// allowedSigners is non-empty (--integrity-keys), each state commit must
-// additionally carry an SSH signature by one of those keys, so the whole
-// chain from ref to HEAD is signed by a trusted key — state authenticity,
-// not just consistency.
-func verifyStateOnlyDescent(repo *gogit.Repository, head, ref plumbing.Hash, allowedSigners string) error {
-	cur, err := repo.CommitObject(head)
+// verifyHeadSignature enforces the signature rule on the HEAD chain:
+// every state-save commit from HEAD down to the release commit under
+// them must be SSH-signed by an allowed key, and the release commit
+// must be signed itself or via a signed annotated tag pointing at it.
+// It returns the release signer's key comment.
+func verifyHeadSignature(repo *gogit.Repository, head *object.Commit, allowedSigners string) (string, error) {
+	cur := head
+	for {
+		stateOnly, err := isStateOnly(cur)
+		if err != nil {
+			return "", err
+		}
+		if !stateOnly {
+			break
+		}
+		if _, err := libgit.VerifyCommitSSH(cur, allowedSigners); err != nil {
+			return "", fmt.Errorf("state commit %s is not signed by an allowed key: %w", cur.Hash, err)
+		}
+		cur, err = cur.Parent(0)
+		if err != nil {
+			return "", err
+		}
+	}
+	// cur is the release commit: its own signature, or a signed
+	// annotated tag targeting it.
+	signer, commitErr := libgit.VerifyCommitSSH(cur, allowedSigners)
+	if commitErr == nil {
+		return signer, nil
+	}
+	tags, err := repo.TagObjects()
 	if err != nil {
-		return err
+		return "", commitErr
 	}
-	for cur.Hash != ref {
-		if cur.NumParents() != 1 {
-			return fmt.Errorf("commit %s is not part of a linear state-only descent from the ref", cur.Hash)
-		}
-		if allowedSigners != "" {
-			if _, err := libgit.VerifyCommitSSH(cur, allowedSigners); err != nil {
-				return fmt.Errorf("state commit %s is not signed by an allowed key: %w", cur.Hash, err)
-			}
-		}
-		parent, err := cur.Parent(0)
+	defer tags.Close()
+	var tagErr error
+	for {
+		tag, err := tags.Next()
 		if err != nil {
-			return err
+			break
 		}
-		curTree, err := cur.Tree()
-		if err != nil {
-			return err
+		if tag.Target != cur.Hash || tag.TargetType != plumbing.CommitObject {
+			continue
 		}
-		parentTree, err := parent.Tree()
-		if err != nil {
-			return err
+		s, err := libgit.VerifyTagSSH(tag, allowedSigners)
+		if err == nil {
+			return s, nil
 		}
-		changes, err := object.DiffTree(parentTree, curTree)
-		if err != nil {
-			return err
-		}
-		for _, ch := range changes {
-			for _, name := range []string{ch.From.Name, ch.To.Name} {
-				if name != "" && !strings.HasPrefix(name, stateDir+"/") {
-					return fmt.Errorf("commit %s modifies %s outside %s/", cur.Hash, name, stateDir)
-				}
-			}
-		}
-		cur = parent
+		tagErr = err
 	}
-	return nil
+	if tagErr != nil {
+		return "", fmt.Errorf("commit %s: %w (and no annotated tag pointing at it is signed by an allowed key: %v)", cur.Hash, commitErr, tagErr)
+	}
+	return "", fmt.Errorf("commit %s: %w", cur.Hash, commitErr)
 }
 
 // VerifyFile checks that absPath lies inside the verified repository
-// and that content matches the blob committed at the pinned ref. It is
-// a no-op when integrity mode is off; the command package installs it
-// as the require loader's vetting hook.
+// and that content matches the blob committed at the verified HEAD. It
+// is a no-op when integrity mode is off; the command package installs
+// it as the require loader's vetting hook.
 func VerifyFile(absPath string, content []byte) error {
 	if mode == nil {
 		return nil
@@ -242,14 +269,14 @@ func (m *modeState) verify(absPath string, content []byte) error {
 	}
 	f, err := m.tree.File(filepath.ToSlash(rel))
 	if err != nil {
-		return fmt.Errorf("integrity: %s is not committed at %q (%s)", absPath, m.ref, m.commit.Hash)
+		return fmt.Errorf("integrity: %s is not committed at HEAD (%s)", absPath, m.commit.Hash)
 	}
 	committed, err := f.Contents()
 	if err != nil {
 		return fmt.Errorf("integrity: %w", err)
 	}
 	if committed != string(content) {
-		return fmt.Errorf("integrity: %s differs from its committed version at %q (%s)", absPath, m.ref, m.commit.Hash)
+		return fmt.Errorf("integrity: %s differs from its committed version at HEAD (%s)", absPath, m.commit.Hash)
 	}
 	return nil
 }

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -104,7 +104,7 @@ func setupRepo(t *testing.T, ns types.EnvType, commitOpts string) (dir, hash str
 }
 
 // signWith installs a signing policy from a PEM private key (the test
-// stand-in for --integrity-keys' ssh-agent signer) and returns the
+// stand-in for the allowed signers' ssh-agent signer) and returns the
 // function that removes it. git-commit, git-tag and state-save then sign.
 func signWith(t *testing.T, privPEM string) func() {
 	t.Helper()
@@ -117,10 +117,10 @@ func signWith(t *testing.T, privPEM string) func() {
 }
 
 // enable calls integrity.Enable and registers cleanup of the global mode.
-func enable(t *testing.T, script, ref, signers string) error {
+func enable(t *testing.T, script, signers string) error {
 	t.Helper()
 	t.Cleanup(integrity.Disable)
-	return integrity.Enable(script, ref, signers)
+	return integrity.Enable(script, signers)
 }
 
 func TestEnableAndVerify(t *testing.T) {
@@ -128,7 +128,7 @@ func TestEnableAndVerify(t *testing.T) {
 	dir, hash := setupRepo(t, ns, "")
 	script := filepath.Join(dir, "script.lisp")
 
-	if err := enable(t, script, hash, ""); err != nil {
+	if err := enable(t, script, ""); err != nil {
 		t.Fatalf("Enable: %v", err)
 	}
 	if !integrity.Active() {
@@ -165,23 +165,14 @@ func TestVerifyFileNoOpWhenInactive(t *testing.T) {
 	}
 }
 
-func TestEnableTagRef(t *testing.T) {
-	ns := newGitEnv(t)
-	dir, _ := setupRepo(t, ns, "")
-	evalLisp(t, ns, `(git-tag r "v1")`)
-	if err := enable(t, filepath.Join(dir, "script.lisp"), "v1", ""); err != nil {
-		t.Fatalf("Enable with lightweight tag: %v", err)
-	}
-}
-
 func TestEnableModifiedScript(t *testing.T) {
 	ns := newGitEnv(t)
-	dir, hash := setupRepo(t, ns, "")
+	dir, _ := setupRepo(t, ns, "")
 	script := filepath.Join(dir, "script.lisp")
 	if err := os.WriteFile(script, []byte("(assert-integrity) (def evil 1)\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := enable(t, script, hash, ""); err == nil || !strings.Contains(err.Error(), "differs") {
+	if err := enable(t, script, ""); err == nil || !strings.Contains(err.Error(), "differs") {
 		t.Fatalf("Enable(modified script) = %v, want 'differs' error", err)
 	}
 	if integrity.Active() {
@@ -189,7 +180,10 @@ func TestEnableModifiedScript(t *testing.T) {
 	}
 }
 
-func TestEnableHeadMoved(t *testing.T) {
+// TestEnableAfterLaterCommit pins the HEAD-anchored semantics: a later
+// commit moves HEAD, and verification simply anchors there — the pin
+// is the checkout, not an argument.
+func TestEnableAfterLaterCommit(t *testing.T) {
 	ns := newGitEnv(t)
 	dir, hash := setupRepo(t, ns, "")
 	if err := os.WriteFile(filepath.Join(dir, "later.txt"), []byte("x\n"), 0o644); err != nil {
@@ -197,9 +191,11 @@ func TestEnableHeadMoved(t *testing.T) {
 	}
 	evalLisp(t, ns, `(git-add r "later.txt")`)
 	evalLisp(t, ns, `(git-commit r "second" {:author `+author+`})`)
-	err := enable(t, filepath.Join(dir, "script.lisp"), hash, "")
-	if err == nil || !strings.Contains(err.Error(), "HEAD") {
-		t.Fatalf("Enable(old ref) = %v, want HEAD mismatch error", err)
+	if err := enable(t, filepath.Join(dir, "script.lisp"), ""); err != nil {
+		t.Fatalf("Enable(after later commit): %v", err)
+	}
+	if integrity.CommitHash() == hash {
+		t.Fatal("CommitHash() still reports the old commit; want the new HEAD")
 	}
 }
 
@@ -209,7 +205,7 @@ func TestEnableOutsideRepo(t *testing.T) {
 	if err := os.WriteFile(script, []byte("1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := enable(t, script, "HEAD", ""); err == nil ||
+	if err := enable(t, script, ""); err == nil ||
 		!strings.Contains(err.Error(), "not inside a git repository") {
 		t.Fatalf("Enable(no repo) = %v, want 'not inside a git repository'", err)
 	}
@@ -220,19 +216,24 @@ func TestEnableSignedCommit(t *testing.T) {
 	privPEM, authorized := testKey(t, "alice")
 	_, otherAuthorized := testKey(t, "mallory")
 	t.Cleanup(signWith(t, privPEM))
-	dir, hash := setupRepo(t, ns, "")
+	dir, _ := setupRepo(t, ns, "")
 	script := filepath.Join(dir, "script.lisp")
 
-	if err := enable(t, script, hash, authorized); err != nil {
+	if err := enable(t, script, authorized); err != nil {
 		t.Fatalf("Enable(signed commit, allowed key): %v", err)
 	}
+	if !integrity.Signed() || integrity.Signer() != "alice" {
+		t.Fatalf("Signed()/Signer() = %v/%q, want true/alice", integrity.Signed(), integrity.Signer())
+	}
 	integrity.Disable()
-	if err := enable(t, script, hash, otherAuthorized); err == nil {
+	if err := enable(t, script, otherAuthorized); err == nil {
 		t.Fatal("Enable(signed commit, wrong key) did not fail")
 	}
 }
 
 func TestEnableSignedTag(t *testing.T) {
+	// An unsigned HEAD commit verifies through a signed annotated tag
+	// pointing at it.
 	ns := newGitEnv(t)
 	privPEM, authorized := testKey(t, "alice")
 	dir, _ := setupRepo(t, ns, "")
@@ -241,14 +242,18 @@ func TestEnableSignedTag(t *testing.T) {
 	evalLisp(t, ns, `(git-tag r "v1" {:message "release" :tagger `+author+`})`)
 	clear()
 
-	if err := enable(t, script, "v1", authorized); err != nil {
+	if err := enable(t, script, authorized); err != nil {
 		t.Fatalf("Enable(signed tag, allowed key): %v", err)
 	}
-	integrity.Disable()
+}
 
-	// An unsigned annotated tag must be rejected when signers are required.
+func TestEnableUnsignedTagWithSigners(t *testing.T) {
+	// An unsigned annotated tag does not rescue an unsigned commit.
+	ns := newGitEnv(t)
+	_, authorized := testKey(t, "alice")
+	dir, _ := setupRepo(t, ns, "")
 	evalLisp(t, ns, `(git-tag r "v2" {:message "release" :tagger `+author+`})`)
-	if err := enable(t, script, "v2", authorized); err == nil ||
+	if err := enable(t, filepath.Join(dir, "script.lisp"), authorized); err == nil ||
 		!strings.Contains(err.Error(), "not signed") {
 		t.Fatalf("Enable(unsigned tag with signers) = %v, want 'not signed'", err)
 	}
@@ -257,10 +262,40 @@ func TestEnableSignedTag(t *testing.T) {
 func TestEnableUnsignedCommitWithSigners(t *testing.T) {
 	ns := newGitEnv(t)
 	_, authorized := testKey(t, "alice")
-	dir, hash := setupRepo(t, ns, "")
-	if err := enable(t, filepath.Join(dir, "script.lisp"), hash, authorized); err == nil ||
+	dir, _ := setupRepo(t, ns, "")
+	if err := enable(t, filepath.Join(dir, "script.lisp"), authorized); err == nil ||
 		!strings.Contains(err.Error(), "not signed") {
 		t.Fatalf("Enable(unsigned commit with signers) = %v, want 'not signed'", err)
+	}
+}
+
+func TestRepoName(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, _ := setupRepo(t, ns, "")
+	script := filepath.Join(dir, "script.lisp")
+	if err := enable(t, script, ""); err != nil {
+		t.Fatal(err)
+	}
+	// No origin remote: the repository root's basename.
+	if got := integrity.RepoName(); got != filepath.Base(dir) {
+		t.Fatalf("RepoName() = %q, want %q", got, filepath.Base(dir))
+	}
+	integrity.Disable()
+
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.CreateRemote(&gitconfig.RemoteConfig{
+		Name: "origin", URLs: []string{"git@github.com:jig/example.git"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := enable(t, script, ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := integrity.RepoName(); got != "git@github.com:jig/example.git" {
+		t.Fatalf("RepoName() = %q, want the origin URL", got)
 	}
 }
 
@@ -554,29 +589,34 @@ func TestStateSaveMessage(t *testing.T) {
 	}
 }
 
-// TestStateChainSignedUnderKeys verifies that under --integrity-keys every
-// state commit above the ref must be SSH-signed by a listed key: a signed
-// chain verifies, an unsigned state commit on top fails closed.
+// TestStateChainSignedUnderKeys verifies that with allowed signers every
+// state commit between HEAD and the release commit must be SSH-signed by
+// a listed key: a signed chain verifies (with the release commit as the
+// reported signer), an unsigned state commit on top fails closed.
 func TestStateChainSignedUnderKeys(t *testing.T) {
 	ns := newGitEnv(t)
 	privPEM, authorized := testKey(t, "release")
 
-	// Signed release commit + one signed state commit.
+	// Signed release commit + one signed state commit; HEAD is the
+	// state commit.
 	clear := signWith(t, privPEM)
-	dir, hash := setupRepo(t, ns, "")
+	dir, _ := setupRepo(t, ns, "")
 	t.Chdir(dir)
 	evalLisp(t, ns, `(state-save "db" {:n 1})`)
 	clear()
 
 	script := filepath.Join(dir, "script.lisp")
-	if err := enable(t, script, hash, authorized); err != nil {
+	if err := enable(t, script, authorized); err != nil {
 		t.Fatalf("Enable(signed state chain): %v", err)
+	}
+	if integrity.Signer() != "release" {
+		t.Fatalf("Signer() = %q, want the release commit's key comment", integrity.Signer())
 	}
 	integrity.Disable()
 
-	// An unsigned state commit on top must fail closed under --integrity-keys.
+	// An unsigned state commit on top must fail closed.
 	evalLisp(t, ns, `(state-save "db" {:n 2})`)
-	if err := enable(t, script, hash, authorized); err == nil ||
+	if err := enable(t, script, authorized); err == nil ||
 		!strings.Contains(err.Error(), "not signed by an allowed key") {
 		t.Fatalf("Enable(unsigned state commit) = %v, want 'not signed by an allowed key'", err)
 	}
@@ -584,9 +624,9 @@ func TestStateChainSignedUnderKeys(t *testing.T) {
 
 func TestStateUnderIntegrity(t *testing.T) {
 	ns := newGitEnv(t)
-	dir, hash := setupRepo(t, ns, "")
+	dir, _ := setupRepo(t, ns, "")
 	script := filepath.Join(dir, "script.lisp")
-	if err := enable(t, script, hash, ""); err != nil {
+	if err := enable(t, script, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -594,10 +634,10 @@ func TestStateUnderIntegrity(t *testing.T) {
 	evalLisp(t, ns, `(state-save "db" {:n 2})`)
 	expectTrue(t, ns, `(= 2 (get (state-load "db") :n))`)
 
-	// The original code ref stays valid across state commits: a restart
-	// with the same --integrity ref must verify.
+	// State commits move HEAD; a restart re-anchors there and the code
+	// (unchanged by state commits) still verifies.
 	integrity.Disable()
-	if err := integrity.Enable(script, hash, ""); err != nil {
+	if err := integrity.Enable(script, ""); err != nil {
 		t.Fatalf("Enable after state commits: %v", err)
 	}
 
@@ -619,33 +659,43 @@ func TestStateUnderIntegrity(t *testing.T) {
 	}
 }
 
-func TestEnableRejectsCodeCommitAfterRef(t *testing.T) {
-	ns := newGitEnv(t)
-	dir, hash := setupRepo(t, ns, "")
-	if err := os.WriteFile(filepath.Join(dir, "script.lisp"), []byte("(assert-integrity) 2\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	evalLisp(t, ns, `(git-add r "script.lisp")`)
-	evalLisp(t, ns, `(git-commit r "code change" {:author `+author+`})`)
-	err := enable(t, filepath.Join(dir, "script.lisp"), hash, "")
-	if err == nil || !strings.Contains(err.Error(), "outside .state/") {
-		t.Fatalf("Enable(ref below code commit) = %v, want 'outside .state/'", err)
-	}
-}
-
 func TestAssertIntegrityBuiltin(t *testing.T) {
 	ns := newGitEnv(t)
 	dir, hash := setupRepo(t, ns, "")
 
-	// Without --integrity the builtin throws (catchable).
+	// Without integrity mode the builtin throws (catchable).
 	if got := evalLisp(t, ns, `(try (assert-integrity) (catch e "caught"))`); got != "caught" {
 		t.Fatalf("assert-integrity without mode = %v, want caught throw", got)
 	}
 
-	if err := enable(t, filepath.Join(dir, "script.lisp"), hash, ""); err != nil {
+	if err := enable(t, filepath.Join(dir, "script.lisp"), ""); err != nil {
 		t.Fatal(err)
 	}
 	if got := evalLisp(t, ns, `(assert-integrity)`); got != hash {
 		t.Fatalf("assert-integrity = %v, want %q", got, hash)
+	}
+
+	// :with-signature demands the signature rule; this run had no
+	// allowed signers, so it throws (catchable), as does any unknown
+	// option.
+	if got := evalLisp(t, ns, `(try (assert-integrity :with-signature) (catch e "caught"))`); got != "caught" {
+		t.Fatalf("assert-integrity :with-signature without signers = %v, want caught throw", got)
+	}
+	if got := evalLisp(t, ns, `(try (assert-integrity :nonsense) (catch e "caught"))`); got != "caught" {
+		t.Fatalf("assert-integrity with unknown option = %v, want caught throw", got)
+	}
+}
+
+func TestAssertIntegrityWithSignature(t *testing.T) {
+	ns := newGitEnv(t)
+	privPEM, authorized := testKey(t, "alice")
+	t.Cleanup(signWith(t, privPEM))
+	dir, hash := setupRepo(t, ns, "")
+
+	if err := enable(t, filepath.Join(dir, "script.lisp"), authorized); err != nil {
+		t.Fatal(err)
+	}
+	if got := evalLisp(t, ns, `(assert-integrity :with-signature)`); got != hash {
+		t.Fatalf("assert-integrity :with-signature = %v, want %q", got, hash)
 	}
 }

--- a/lib/integrity/state.go
+++ b/lib/integrity/state.go
@@ -4,11 +4,11 @@ package integrity
 // canonical lisp data under <repo-root>/.state/<name>.lisp and commits
 // it in the same operation, so committed state is always the product of
 // a completed save; state-load reads it back as pure data (READ, never
-// EVAL). Under --integrity, state-load additionally requires the file
+// EVAL). Under lisp-integrity, state-load additionally requires the file
 // to byte-match its blob at the current HEAD — the commit the last
 // state-save created — so out-of-band edits fail closed. The mode's
 // startup check accepts these state-only commits above the code ref
-// (see verifyStateOnlyDescent), which keeps the original --integrity
+// (state commits touch only .state/), which keeps restarts verifying
 // ref valid across restarts.
 
 import (
@@ -37,7 +37,7 @@ const stateDir = ".state"
 var stateMu sync.Mutex
 
 // stateRepo returns the repository and worktree root the state store
-// lives in: the verified repository under --integrity, the repository
+// lives in: the verified repository under lisp-integrity, the repository
 // enclosing the working directory otherwise.
 func stateRepo(fnName string) (*gogit.Repository, string, error) {
 	if mode != nil {
@@ -152,7 +152,7 @@ func state_save(name string, value MalType, params ...MalType) (MalType, error) 
 		}
 		return nil, fmt.Errorf("state-save: %w", err)
 	}
-	// Sign the state commit when --integrity-keys installed a signing
+	// Sign the state commit when the allowed signers installed a signing
 	// policy (ssh-agent key); a no-op otherwise.
 	if hash, err = libgit.SignCommitIfPolicy(repo, hash); err != nil {
 		return nil, fmt.Errorf("state-save: sign commit: %w", err)

--- a/lib/log/log.go
+++ b/lib/log/log.go
@@ -33,6 +33,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/coreos/go-systemd/v22/journal"
 
@@ -253,6 +254,39 @@ func logAt(fnName string, l slog.Level, msg string, kv []MalType) (MalType, erro
 	}
 	s.logger.Log(context.Background(), l, msg, attrs...)
 	return nil, nil
+}
+
+// Record emits a runtime record (a Go-level API, not a lisp builtin):
+// msg at level l with the given string fields plus the run fields. It
+// bypasses LOG_LEVEL — attestation records always emit.
+func Record(l slog.Level, msg string, fields map[string]string) error {
+	mu.Lock()
+	defer mu.Unlock()
+	s, err := resolve()
+	if err != nil {
+		return err
+	}
+	if s.journald {
+		out := make(map[string]string, len(fields)+len(runFields)+1)
+		out["SYSLOG_IDENTIFIER"] = identifier
+		for k, v := range runFields {
+			out[fieldName(k)] = v
+		}
+		for k, v := range fields {
+			out[fieldName(k)] = v
+		}
+		return journalSend(msg, priority(l), out)
+	}
+	// Handle directly on the handler: Logger.Log would apply the
+	// LOG_LEVEL filter, and these records must always emit.
+	rec := slog.NewRecord(time.Now(), l, msg, 0)
+	for k, v := range runFields {
+		rec.AddAttrs(slog.String(k, v))
+	}
+	for k, v := range fields {
+		rec.AddAttrs(slog.String(k, v))
+	}
+	return s.logger.Handler().Handle(context.Background(), rec)
 }
 
 func logDebug(msg string, kv ...MalType) (MalType, error) {

--- a/lib/require/require.go
+++ b/lib/require/require.go
@@ -90,7 +90,7 @@ func load(rootEnv types.EnvType, cfg Config) error {
 
 // VerifyModule is an optional hook that vets every module file before
 // it is evaluated; a non-nil error aborts the require. The command
-// package installs it when running under --integrity, so the
+// package installs it when running under lisp-integrity, so the
 // verification of the script cascades to its requires.
 var VerifyModule func(absPath string, content []byte) error
 

--- a/lib/system/system.go
+++ b/lib/system/system.go
@@ -36,7 +36,7 @@ func Load(env EnvType) {
 	call.Doc(env, "setenv", "[name value]", "Sets the environment variable name to value.")
 	call.Doc(env, "unsetenv", "[name]", "Removes the environment variable name.")
 	call.Doc(env, "slurp", "[filename]", "Reads a file and returns its contents as a string.")
-	call.Doc(env, "slurp-source", "[filename]", "Reads a source file like slurp and, under --integrity, verifies it against the pinned commit; load-file builds on it.")
+	call.Doc(env, "slurp-source", "[filename]", "Reads a source file like slurp and, under lisp-integrity, verifies it against the verified HEAD commit; load-file builds on it.")
 	call.Doc(env, "spit", "[filename s & opts]", "Writes string s to a file, creating or truncating it; with :append true, appends instead.")
 	call.Doc(env, "chdir", "[path]",
 		"Changes the process working directory to path. Process-global: affects the working directory of all subsequent operations, including the .state store and git repository detection.")
@@ -96,13 +96,13 @@ func remove_all(path string) (MalType, error) {
 
 // VerifySource is an optional hook that vets a source file before
 // load-file (via slurp-source) evaluates it; a non-nil error aborts the
-// load. The command package installs it when running under --integrity,
+// load. The command package installs it when running under lisp-integrity,
 // so code loaded at runtime is verified like the script and its
 // requires. slurp itself is never hooked: it reads data, not code.
 var VerifySource func(absPath string, content []byte) error
 
 // slurp_source is slurp for files that will be evaluated as code:
-// identical, except that under --integrity the content is verified
+// identical, except that under lisp-integrity the content is verified
 // against the pinned commit. load-file builds on it.
 func slurp_source(fileName string) (MalType, error) {
 	v, err := slurp(fileName)


### PR DESCRIPTION
> **Stacked on #145** (journald destination for lib/log). Retarget to `develop` once #145 merges.

## Summary

Implements the INTEGRITY v2 model agreed in design discussion:

- **New `lisp-integrity` binary**, always-on: runs only script files (no REPL/`-e`/stdin/test/fmt/debug/DAP/LSP) and verifies the script — and, in cascade, every file loaded as code — against **`HEAD`**. `--integrity`/`--integrity-keys` are removed from `lisp`, which loses the mode entirely.
- **No ref argument**: pinning a release is a property of the checkout (`git checkout --detach <tag>`); state commits advance `HEAD` as children of the release, so restarts keep verifying.
- **Keys by presence**: `/etc/lisp/allowed_signers` (authorized_keys format, root-owned). When present, every run requires the HEAD chain SSH-signed — each state commit above the release, and the release commit itself or a signed annotated tag pointing at it. The same set drives ssh-agent signing of `git-commit`/`git-tag`/`state-save`.
- **Consent**: `proceed? [y/N]` after the green block; `-y` skips; non-TTY without `-y` fails closed (systemd units: `lisp-integrity -y …`).
- **Attestation**: start record (`COMMIT`/`REPO`/`TRACE_ID`/`ARGV`/`SIGNER`/`PROTECTED`) and deferred end record (`EXIT_CODE`, `PANIC`) to journald — required on Linux, XDG state-file fallback on macOS (`PROTECTED=false`) — and every `log-*` record carries the run fields. New `lib/log` `Record` Go API.
- `(assert-integrity :with-signature)` throws unless the signature rule was applied.
- **Docs**: INTEGRITY.md rewritten as the v2 spec (v1 changes summarised at the end); README, lib/integrity + lib/git READMEs, examples-integrity walkthroughs and demo.sh updated. 03-signed becomes a manual example — a demo must never install a trust anchor on a real host.

## Test plan

- `go test ./...` green; gofmt/vet clean; LANGUAGE.md regenerated.
- mode tests rewritten for HEAD anchoring (later commits re-anchor; signed commit/tag/state-chain; unsigned rejections; RepoName origin/basename; `:with-signature`).
- command tests: hermetic seams for journald/records/TTY/keys path; verified-run + tamper + consent-refusal + journald-refusal + arg validation; attestation records asserted (argv, exit codes).
- `cmd/lisp-integrity` env kept in sync with docgen/`lisp` by a dedicated test.
- Smoke-tested on a systemd host: green block, y/N, journal shows start/log/end records sharing a `TRACE_ID`; `demo.sh` passes end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)