### PR TITLE
feat(integrity): verified test runs — lisp-integrity --test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,11 @@ children of the release, so restarts keep verifying.
 - **`(assert-integrity)`** now suggests `lisp-integrity` in its error
   and gains **`(assert-integrity :with-signature)`**, which throws
   unless the signature rule was applied.
+- **`lisp-integrity --test DIR|FILE`** (with optional `--test-json`)
+  runs a deftest suite under the same guarantees: the mode anchors on
+  the repository enclosing the target and every test file — and, in
+  cascade, everything it loads — is verified against `HEAD` as it
+  loads; the attested exit code records which commit's tests passed.
 - INTEGRITY.md is rewritten as the v2 specification (v1 differences
   are summarised at its end).
 

--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -47,13 +47,19 @@ they cannot do is produce a *verified-looking* attestation for it.
 ```bash
 lisp-integrity script.lisp [args…]
 lisp-integrity -y service.lisp [args…]
+lisp-integrity -y --test ./tests [--test-json report.json]
 ```
 
-- Only script-file execution. No REPL, no `-e`, no stdin, no
-  `--test` / `--fmt` / `--debug`, no DAP/LSP servers, no environment
-  variables selecting behaviour (`LOG_LEVEL` for verbosity is the one
-  exception, inherited from `lib/log`). Use `lisp` for everything
-  else.
+- Only script-file execution and the verified test runner. No REPL,
+  no `-e`, no stdin, no `--fmt` / `--debug`, no DAP/LSP servers, no
+  environment variables selecting behaviour (`LOG_LEVEL` for
+  verbosity is the one exception, inherited from `lib/log`). Use
+  `lisp` for everything else.
+- `--test DIR|FILE` verifies and runs a deftest suite: the mode
+  anchors on the repository enclosing the target, and every test file
+  — and, in cascade, everything it loads — is verified against `HEAD`
+  as it loads. The attested exit code reflects the suite result, so a
+  CI run leaves an append-only record of *which commit's tests passed*.
 - After verification succeeds and the green block is printed,
   `lisp-integrity` asks for confirmation on the terminal
   (`proceed? [y/N]`) before evaluating anything.
@@ -81,7 +87,9 @@ At startup:
 
 1. The script must lie inside a Git repository with a resolvable
    `HEAD` commit `C`.
-2. The script must byte-match its blob in `C`'s tree.
+2. The script must byte-match its blob in `C`'s tree. (With `--test`
+   there is no entry script: the anchor is the repository enclosing
+   the target, and rule 4 covers each test file as it loads.)
 3. If `/etc/lisp/allowed_signers` exists: walking from `C` down
    through consecutive state-save commits (commits with one parent
    touching only state paths), each such commit must carry an SSH
@@ -122,8 +130,9 @@ Every record shares three fields:
 Records emitted by the runtime itself (exactly two, never more):
 
 - **start** — after verification and confirmation, before evaluation:
-  `MESSAGE="run started"`, `ARGV` (script and arguments, as JSON),
-  `SIGNER` when rule 3 applied, `PROTECTED`.
+  `MESSAGE="run started"`, `ARGV` (script and arguments — or
+  `["--test", target]` — as JSON), `SIGNER` when rule 3 applied,
+  `PROTECTED`.
 - **end** — from a deferred handler covering normal return, error and
   panic: `MESSAGE="run ended"`, `EXIT_CODE` (and `PANIC` on one). A
   start record with no matching end record means abnormal termination

--- a/README.md
+++ b/README.md
@@ -415,8 +415,13 @@ cannot be disabled; there is no REPL, no `-e`, no stdin mode:
 
 ```bash
 lisp-integrity service.lisp
-lisp-integrity -y service.lisp     # unattended (systemd units)
+lisp-integrity -y service.lisp        # unattended (systemd units)
+lisp-integrity -y --test ./tests      # verified test run (CI attestation)
 ```
+
+`--test` anchors on the repository and verifies every test file — and
+whatever it loads — against `HEAD` as it loads; the attested exit code
+records which commit's tests passed.
 
 Pinning a release is a property of the checkout, not of the
 invocation: deploy with `git checkout --detach v1.4.2` and every

--- a/command/integrity.go
+++ b/command/integrity.go
@@ -44,13 +44,15 @@ var (
 	stdinIsTerminal = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
 )
 
-// integrityArgs is the lisp-integrity CLI: a script, its arguments and
-// the consent flag — nothing else, by design (no REPL, no -e, no
-// environment overrides).
+// integrityArgs is the lisp-integrity CLI: a script (or a test target),
+// its arguments and the consent flag — nothing else, by design (no
+// REPL, no -e, no environment overrides).
 type integrityArgs struct {
-	Yes    bool     `arg:"-y,--yes" help:"run without asking for confirmation (required when stdin is not a terminal)"`
-	Script string   `arg:"positional,required" help:"lisp script to execute"`
-	Args   []string `arg:"positional" help:"arguments to pass to the script"`
+	Yes      bool     `arg:"-y,--yes" help:"run without asking for confirmation (required when stdin is not a terminal)"`
+	Test     string   `arg:"-t,--test" help:"verify and run the test suite from a directory or a single test file" placeholder:"DIR|FILE"`
+	TestJSON string   `arg:"--test-json" help:"with --test, also write a JSON report to the given file" placeholder:"FILE"`
+	Script   string   `arg:"positional" help:"lisp script to execute"`
+	Args     []string `arg:"positional" help:"arguments to pass to the script"`
 }
 
 // PreParseIntegrityArgs extracts the script arguments before the
@@ -89,8 +91,14 @@ func ExecuteIntegrity(cmdArgs []string, repl_env types.EnvType) error {
 			return err
 		}
 	}
-	if parsedArgs.Script == "" || parsedArgs.Script == "-" {
-		return fmt.Errorf("lisp-integrity requires a script file (stdin is not supported)")
+	testMode := parsedArgs.Test != ""
+	switch {
+	case parsedArgs.TestJSON != "" && !testMode:
+		return fmt.Errorf("--test-json requires --test")
+	case testMode && parsedArgs.Script != "":
+		return fmt.Errorf("--test cannot be combined with a script file")
+	case !testMode && (parsedArgs.Script == "" || parsedArgs.Script == "-"):
+		return fmt.Errorf("lisp-integrity requires a script file or --test (stdin is not supported)")
 	}
 
 	// The audit trail must be protected before anything is attested:
@@ -108,8 +116,17 @@ func ExecuteIntegrity(cmdArgs []string, repl_env types.EnvType) error {
 		return fmt.Errorf("reading %s: %w", allowedSignersPath, err)
 	}
 
-	if err := integrity.Enable(parsedArgs.Script, keys); err != nil {
-		return reportIntegrity(false, "", "", "", err)
+	// A script anchors on itself (verified at startup); a test target
+	// anchors on its repository, and every test file is verified as it
+	// loads (runTests reads through load-file, which is hooked).
+	var enableErr error
+	if testMode {
+		enableErr = integrity.EnableDir(parsedArgs.Test, keys)
+	} else {
+		enableErr = integrity.Enable(parsedArgs.Script, keys)
+	}
+	if enableErr != nil {
+		return reportIntegrity(false, "", "", "", enableErr)
 	}
 	require.VerifyModule = integrity.VerifyFile
 	system.VerifySource = integrity.VerifyFile
@@ -148,13 +165,19 @@ func ExecuteIntegrity(cmdArgs []string, repl_env types.EnvType) error {
 	if _, err := rand.Read(traceID); err != nil {
 		return err
 	}
-	liblog.SetIdentifier(strings.TrimSuffix(filepath.Base(parsedArgs.Script), ".lisp"))
+	target := parsedArgs.Script
+	argvList := append([]string{parsedArgs.Script}, parsedArgs.Args...)
+	if testMode {
+		target = parsedArgs.Test
+		argvList = []string{"--test", parsedArgs.Test}
+	}
+	liblog.SetIdentifier(strings.TrimSuffix(filepath.Base(filepath.Clean(target)), ".lisp"))
 	liblog.SetRunFields(map[string]string{
 		"commit":   integrity.CommitHash(),
 		"repo":     integrity.RepoName(),
 		"trace_id": hex.EncodeToString(traceID),
 	})
-	argv, err := json.Marshal(append([]string{parsedArgs.Script}, parsedArgs.Args...))
+	argv, err := json.Marshal(argvList)
 	if err != nil {
 		return err
 	}
@@ -181,23 +204,30 @@ func ExecuteIntegrity(cmdArgs []string, repl_env types.EnvType) error {
 		_ = emitRecord(endLevel, "run ended", fields)
 	}()
 
-	result, err := runScript(context.Background(), repl_env, parsedArgs.Script, nil,
-		types.NewCursorHere(parsedArgs.Script, -3, 1))
-	if err != nil {
-		return err
+	if testMode {
+		if err := runTests(parsedArgs.Test, parsedArgs.TestJSON, repl_env); err != nil {
+			return err
+		}
+	} else {
+		result, err := runScript(context.Background(), repl_env, parsedArgs.Script, nil,
+			types.NewCursorHere(parsedArgs.Script, -3, 1))
+		if err != nil {
+			return err
+		}
+		fmt.Println(result)
 	}
 	exitCode, endLevel = "0", slog.LevelInfo
-	fmt.Println(result)
 	return nil
 }
 
 // reportIntegrity writes the audit outcome to stderr. On an interactive
 // terminal it prints a human-readable block — green when integrity is
 // satisfied, red when not; when stderr is redirected it emits a
-// machine-readable JSON line instead. The block attests the entry
-// script only: each require/load-file is verified as it loads and
-// aborts the run on mismatch, so a green block does not mean the whole
-// run is pre-verified. Returns nil on success, ErrIntegrityReported on
+// machine-readable JSON line instead. The block attests the anchor
+// (and, in script mode, the entry script) only: each require/load-file
+// — test files included — is verified as it loads and aborts the run
+// on mismatch, so a green block does not mean the whole run is
+// pre-verified. Returns nil on success, ErrIntegrityReported on
 // a terminal failure (already shown), or the cause when redirected.
 func reportIntegrity(ok bool, repo, commit, signer string, cause error) error {
 	if !libterm.StderrIsTerminal() {
@@ -208,7 +238,7 @@ func reportIntegrity(ok bool, repo, commit, signer string, cause error) error {
 		if signer != "" {
 			attrs = append(attrs, "signer", signer)
 		}
-		slog.New(slog.NewJSONHandler(os.Stderr, nil)).Info("integrity: entry script verified at HEAD", attrs...)
+		slog.New(slog.NewJSONHandler(os.Stderr, nil)).Info("integrity: verified at HEAD", attrs...)
 		return nil
 	}
 

--- a/command/integrity_test.go
+++ b/command/integrity_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jig/lisp/lib/require/nsrequire"
 	"github.com/jig/lisp/lib/system"
 	"github.com/jig/lisp/lib/system/nssystem"
+	"github.com/jig/lisp/lib/test/nstest"
 	"github.com/jig/lisp/types"
 )
 
@@ -191,6 +192,133 @@ func TestExecuteIntegrityRejectsTamperedModule(t *testing.T) {
 	}
 }
 
+// gitRepoWithTests builds a repository whose tests/ dir holds a passing
+// deftest suite that also requires a module — exercising the verified
+// load cascade under --test.
+func gitRepoWithTests(t *testing.T) (dir string) {
+	t.Helper()
+	dir = t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "tests"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	suite := "(require \"util\")\n(deftest util-works\n  (is (= \"hola\" (util/hello))))\n"
+	if err := os.WriteFile(filepath.Join(dir, "tests", "suite_test.lisp"), []byte(suite), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, ".lisp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".lisp", "util.lisp"), []byte(`(def hello (fn [] "hola"))`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git := func(args ...string) string { return runGit(t, dir, args...) }
+	git("init", "-q")
+	git("add", "-A")
+	git("commit", "-q", "-m", "first")
+
+	t.Chdir(dir)
+	t.Cleanup(func() {
+		integrity.Disable()
+		require.VerifyModule = nil
+		system.VerifySource = nil
+	})
+	return dir
+}
+
+// newIntegrityTestEnv is newIntegrityEnv plus the test namespace
+// (deftest/is) the --test mode needs.
+func newIntegrityTestEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := newIntegrityEnv(t)
+	if err := nstest.Load(ns); err != nil {
+		t.Fatal(err)
+	}
+	return ns
+}
+
+func TestExecuteIntegrityRunsVerifiedTests(t *testing.T) {
+	records := stubAttestation(t)
+	gitRepoWithTests(t)
+	ns := newIntegrityTestEnv(t)
+	out, err := captureStdout(t, func() error {
+		return ExecuteIntegrity([]string{"lisp-integrity", "-y", "--test", "./tests"}, ns)
+	})
+	if err != nil {
+		t.Fatalf("ExecuteIntegrity --test: %v", err)
+	}
+	if !strings.Contains(out, "PASS: 1 tests") {
+		t.Fatalf("output %q: want the suite to pass", out)
+	}
+	if len(*records) != 2 {
+		t.Fatalf("expected start+end records, got %d: %+v", len(*records), *records)
+	}
+	start, end := (*records)[0], (*records)[1]
+	if !strings.Contains(start.fields["argv"], `"--test"`) || !strings.Contains(start.fields["argv"], `"./tests"`) {
+		t.Fatalf("unexpected start argv: %+v", start.fields)
+	}
+	if end.fields["exit_code"] != "0" || end.level != slog.LevelInfo {
+		t.Fatalf("unexpected end record: %+v", end)
+	}
+}
+
+func TestExecuteIntegrityRejectsTamperedTest(t *testing.T) {
+	records := stubAttestation(t)
+	dir := gitRepoWithTests(t)
+	tampered := "(require \"util\")\n(deftest util-works\n  (is (= \"evil\" (util/hello))))\n"
+	if err := os.WriteFile(filepath.Join(dir, "tests", "suite_test.lisp"), []byte(tampered), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ns := newIntegrityTestEnv(t)
+	_, err := captureStdout(t, func() error {
+		return ExecuteIntegrity([]string{"lisp-integrity", "-y", "--test", "./tests"}, ns)
+	})
+	if err == nil || !strings.Contains(err.Error(), "integrity") {
+		t.Fatalf("ExecuteIntegrity with tampered test = %v, want integrity error", err)
+	}
+	end := (*records)[len(*records)-1]
+	if end.fields["exit_code"] != "1" {
+		t.Fatalf("unexpected end record after tamper: %+v", end)
+	}
+}
+
+func TestExecuteIntegrityRejectsTamperedTestModule(t *testing.T) {
+	stubAttestation(t)
+	dir := gitRepoWithTests(t)
+	if err := os.WriteFile(filepath.Join(dir, ".lisp", "util.lisp"), []byte(`(def hello (fn [] "evil"))`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ns := newIntegrityTestEnv(t)
+	_, err := captureStdout(t, func() error {
+		return ExecuteIntegrity([]string{"lisp-integrity", "-y", "--test", "./tests"}, ns)
+	})
+	if err == nil || !strings.Contains(err.Error(), "integrity") {
+		t.Fatalf("ExecuteIntegrity with tampered module = %v, want integrity error", err)
+	}
+}
+
+func TestExecuteIntegrityFailingSuiteExitsNonZero(t *testing.T) {
+	records := stubAttestation(t)
+	dir := gitRepoWithTests(t)
+	failing := "(deftest fails\n  (is (= 1 2)))\n"
+	if err := os.WriteFile(filepath.Join(dir, "tests", "suite_test.lisp"), []byte(failing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git := func(args ...string) string { return runGit(t, dir, args...) }
+	git("add", "-A")
+	git("commit", "-q", "-m", "failing suite")
+	ns := newIntegrityTestEnv(t)
+	_, err := captureStdout(t, func() error {
+		return ExecuteIntegrity([]string{"lisp-integrity", "-y", "--test", "./tests"}, ns)
+	})
+	if err == nil || !strings.Contains(err.Error(), "test(s) failed") {
+		t.Fatalf("ExecuteIntegrity with failing suite = %v, want suite failure", err)
+	}
+	end := (*records)[len(*records)-1]
+	if end.fields["exit_code"] != "1" || end.level != slog.LevelError {
+		t.Fatalf("unexpected end record for failing suite: %+v", end)
+	}
+}
+
 func TestExecuteAssertIntegrityUnderPlainLisp(t *testing.T) {
 	gitRepoWithScript(t)
 	ns := newIntegrityEnv(t)
@@ -234,12 +362,14 @@ func TestExecuteIntegrityArgValidation(t *testing.T) {
 	stubAttestation(t)
 	ns := newIntegrityEnv(t)
 	for _, cmdline := range [][]string{
-		{"lisp-integrity"},                        // no script
-		{"lisp-integrity", "-y", "-"},             // stdin
-		{"lisp-integrity", "-e", "1", "x.lisp"},   // unknown flag
-		{"lisp-integrity", "--fmt", "x.lisp"},     // unknown flag
-		{"lisp-integrity", "--test", ".", "x.l"},  // unknown flag
-		{"lisp-integrity", "--integrity", "HEAD"}, // v1 flag is gone
+		{"lisp-integrity"},                            // no script
+		{"lisp-integrity", "-y", "-"},                 // stdin
+		{"lisp-integrity", "-e", "1", "x.lisp"},       // unknown flag
+		{"lisp-integrity", "--fmt", "x.lisp"},         // unknown flag
+		{"lisp-integrity", "--test", ".", "x.lisp"},   // test + script
+		{"lisp-integrity", "--test-json", "r.json"},   // test-json alone
+		{"lisp-integrity", "--integrity", "HEAD"},     // v1 flag is gone
+		{"lisp-integrity", "--debug", "-y", "x.lisp"}, // unknown flag
 	} {
 		if err := ExecuteIntegrity(cmdline, ns); err == nil {
 			t.Errorf("ExecuteIntegrity(%v) did not fail", cmdline)

--- a/lib/integrity/mode.go
+++ b/lib/integrity/mode.go
@@ -109,49 +109,9 @@ func repoName(repo *gogit.Repository, root string) string {
 // additionally require the HEAD chain to be SSH-signed by them (see
 // verifyHeadSignature).
 func Enable(scriptPath, allowedSigners string) error {
-	abs, err := filepath.Abs(scriptPath)
+	m, abs, err := enableAt(scriptPath, allowedSigners)
 	if err != nil {
-		return fmt.Errorf("integrity: %w", err)
-	}
-	repo, err := gogit.PlainOpenWithOptions(filepath.Dir(abs), &gogit.PlainOpenOptions{DetectDotGit: true})
-	if err != nil {
-		return fmt.Errorf("integrity: %s is not inside a git repository", abs)
-	}
-	wt, err := repo.Worktree()
-	if err != nil {
-		return fmt.Errorf("integrity: %w", err)
-	}
-	root := wt.Filesystem().Root()
-
-	head, err := repo.Head()
-	if err != nil {
-		return fmt.Errorf("integrity: %w", err)
-	}
-	commit, err := repo.CommitObject(head.Hash())
-	if err != nil {
-		return fmt.Errorf("integrity: HEAD does not resolve to a commit: %w", err)
-	}
-
-	signer := ""
-	if allowedSigners != "" {
-		signer, err = verifyHeadSignature(repo, commit, allowedSigners)
-		if err != nil {
-			return fmt.Errorf("integrity: %w", err)
-		}
-	}
-
-	tree, err := commit.Tree()
-	if err != nil {
-		return fmt.Errorf("integrity: %w", err)
-	}
-	m := &modeState{
-		repo:     repo,
-		repoRoot: root,
-		repoName: repoName(repo, root),
-		signer:   signer,
-		signed:   allowedSigners != "",
-		commit:   commit,
-		tree:     tree,
+		return err
 	}
 	content, err := os.ReadFile(abs)
 	if err != nil {
@@ -162,6 +122,73 @@ func Enable(scriptPath, allowedSigners string) error {
 	}
 	mode = m
 	return nil
+}
+
+// EnableDir anchors integrity mode on the repository enclosing target
+// (a directory, or a file whose directory is used) without verifying
+// an entry script: every code file is verified as it loads through the
+// VerifyFile cascade instead. The test runner mode uses it — test
+// files reach evaluation via load-file, which is hooked.
+func EnableDir(target, allowedSigners string) error {
+	m, _, err := enableAt(target, allowedSigners)
+	if err != nil {
+		return err
+	}
+	mode = m
+	return nil
+}
+
+// enableAt builds the verification context anchored at HEAD of the
+// repository enclosing path, without installing it.
+func enableAt(path, allowedSigners string) (*modeState, string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("integrity: %w", err)
+	}
+	openFrom := filepath.Dir(abs)
+	if info, err := os.Stat(abs); err == nil && info.IsDir() {
+		openFrom = abs
+	}
+	repo, err := gogit.PlainOpenWithOptions(openFrom, &gogit.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		return nil, "", fmt.Errorf("integrity: %s is not inside a git repository", abs)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		return nil, "", fmt.Errorf("integrity: %w", err)
+	}
+	root := wt.Filesystem().Root()
+
+	head, err := repo.Head()
+	if err != nil {
+		return nil, "", fmt.Errorf("integrity: %w", err)
+	}
+	commit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		return nil, "", fmt.Errorf("integrity: HEAD does not resolve to a commit: %w", err)
+	}
+
+	signer := ""
+	if allowedSigners != "" {
+		signer, err = verifyHeadSignature(repo, commit, allowedSigners)
+		if err != nil {
+			return nil, "", fmt.Errorf("integrity: %w", err)
+		}
+	}
+
+	tree, err := commit.Tree()
+	if err != nil {
+		return nil, "", fmt.Errorf("integrity: %w", err)
+	}
+	return &modeState{
+		repo:     repo,
+		repoRoot: root,
+		repoName: repoName(repo, root),
+		signer:   signer,
+		signed:   allowedSigners != "",
+		commit:   commit,
+		tree:     tree,
+	}, abs, nil
 }
 
 // isStateOnly reports whether commit has exactly one parent and

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -199,6 +199,41 @@ func TestEnableAfterLaterCommit(t *testing.T) {
 	}
 }
 
+// TestEnableDir anchors on a directory without an entry script; files
+// still verify (or fail) through VerifyFile as they load.
+func TestEnableDir(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, hash := setupRepo(t, ns, "")
+
+	t.Cleanup(integrity.Disable)
+	if err := integrity.EnableDir(filepath.Join(dir, ".lisp"), ""); err != nil {
+		t.Fatalf("EnableDir: %v", err)
+	}
+	if got := integrity.CommitHash(); got != hash {
+		t.Fatalf("CommitHash() = %q, want %q", got, hash)
+	}
+
+	module := filepath.Join(dir, ".lisp", "util.lisp")
+	content, err := os.ReadFile(module)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := integrity.VerifyFile(module, content); err != nil {
+		t.Fatalf("VerifyFile(committed module): %v", err)
+	}
+	if err := integrity.VerifyFile(module, append(content, "(def evil 1)\n"...)); err == nil {
+		t.Fatal("VerifyFile(modified module) did not fail")
+	}
+}
+
+func TestEnableDirOutsideRepo(t *testing.T) {
+	t.Cleanup(integrity.Disable)
+	if err := integrity.EnableDir(t.TempDir(), ""); err == nil ||
+		!strings.Contains(err.Error(), "not inside a git repository") {
+		t.Fatalf("EnableDir(no repo) = %v, want 'not inside a git repository'", err)
+	}
+}
+
 func TestEnableOutsideRepo(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "script.lisp")


### PR DESCRIPTION
## Summary

- `lisp-integrity --test DIR|FILE` (plus optional `--test-json FILE`) runs a deftest suite under the integrity guarantees. Rationale: "attest that the committed test suite is what passed" is a legitimate production/CI use of the attestation model.
- New `integrity.EnableDir`: anchors the mode on the repository enclosing the target with no entry script. No new verification machinery was needed for the files themselves — `runTests` already loads each test file through `load-file` → `slurp-source` → `VerifyFile`, so every test file (and everything it requires/loads) is byte-checked against `HEAD` as it loads, and a tampered file aborts the run.
- Attestation: `ARGV=["--test", target]`, end record's `EXIT_CODE` reflects the suite result (0 pass / 1 fail or integrity abort). Consent prompt and journald requirements unchanged.
- Arg validation: `--test` and a script file are mutually exclusive; `--test-json` requires `--test`; everything else (`--fmt`, `--debug`, …) remains an unknown flag.
- Docs: INTEGRITY.md (CLI + invariant + attestation), README, CHANGELOG under 0.6.0.

## Test plan

- `go test ./...` green; gofmt/vet clean.
- New tests: `EnableDir` anchor + cascade (lib), verified suite passes with attested exit 0, tampered test file and tampered required module both abort with integrity errors and attested exit 1, failing (committed) suite exits non-zero with error-level end record, and the new arg-validation matrix.
- Smoke-tested on a systemd host: pass and tamper runs both attested in journald with `ARGV=["--test","./tests"]` and correct `EXIT_CODE`/`PRIORITY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)