### PR TITLE
feat(version): lib/version — the version builtin identifies the embedder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,21 @@ Logging moves out of `lib/web` into `lib/log`. Migration:
 level), and `web-wrap-log` users write the one-liner middleware over
 `log-info` themselves (example in `lib/web/README.md`).
 
+### ⚠️ Changed — `(version)` moves to `lib/version` and identifies the embedder
+
+The `version` builtin leaves core for a new `lib/version` +
+`nsversion` namespace, and its hash-map gains `:main {:name
+:version}` — the running program itself: an embedder's module (from
+Go build info) or whatever the new `version.SetMain(name, ver)` Go
+API sets (e.g. values injected with `-ldflags -X`). `--version`
+prints that main identity first when it is not jig/lisp, so an
+embedder's REPL built on `command.Execute` reports itself correctly;
+jig/lisp and jig/scanner remain listed as components.
+
+Migration (embedders): load the namespace —
+`nsversion.Load(env)` — to keep the `(version)` builtin; core's
+`Versions()` helper moved to `lib/version` unchanged.
+
 ### ⚠️ Changed — integrity moves to the `lisp-integrity` binary
 
 `--integrity REF` and `--integrity-keys FILE` are **removed** from the

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -283,7 +283,6 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `vec` | `[coll]` | coll as a vector. |
 | `vector` | `[& items]` | Creates a vector of the given items. |
 | `vector?` | `[x]` | Whether x is a vector. |
-| `version` | `[]` | Interpreter build information as a hash-map. |
 | `when ⁽ᵐ⁾` | `[condition & body]` | Evaluates body in an implicit do when condition is truthy; otherwise nil. |
 | `with-meta` | `[obj m]` | Copy of obj with metadata m. |
 
@@ -577,6 +576,14 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-repla
 | `log-error` | `[msg & kv]` | Emits a structured log record at error level with alternating keyword/value attributes. Records go to systemd-journald, or to $XDG_STATE_HOME/lisp/<script>.log without it. |
 | `log-info` | `[msg & kv]` | Emits a structured log record at info level with alternating keyword/value attributes, e.g. (log-info "user created" :id 42). Records go to systemd-journald, or to $XDG_STATE_HOME/lisp/<script>.log without it. |
 | `log-warn` | `[msg & kv]` | Emits a structured log record at warn level with alternating keyword/value attributes. Records go to systemd-journald, or to $XDG_STATE_HOME/lisp/<script>.log without it. |
+
+### version
+
+Build information of the running program (the version builtin).
+
+| Name | Arguments | Description |
+| ---- | --------- | ----------- |
+| `version` | `[]` | Build information of the running program as a hash-map: :main {:name :version} (the program itself — an embedder's module, or its version.SetMain branding), :go-version, :build settings and :dependencies. |
 
 ⁽ᵐ⁾ = macro (arguments are not evaluated before the call).
 

--- a/cmd/lisp-integrity/main.go
+++ b/cmd/lisp-integrity/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jig/lisp/lib/system/nssystem"
 	"github.com/jig/lisp/lib/term/nsterm"
 	"github.com/jig/lisp/lib/test/nstest"
+	"github.com/jig/lisp/lib/version/nsversion"
 	"github.com/jig/lisp/lib/web/nsweb"
 	"github.com/jig/lisp/types"
 )
@@ -62,6 +63,7 @@ func libraries(scriptArgs []string) []library {
 
 		// new libraries on jig/lisp v0.6.0
 		{"log", nslog.Load},
+		{"version", nsversion.Load},
 	}
 }
 

--- a/cmd/lisp/main.go
+++ b/cmd/lisp/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jig/lisp/lib/system/nssystem"
 	"github.com/jig/lisp/lib/term/nsterm"
 	"github.com/jig/lisp/lib/test/nstest"
+	"github.com/jig/lisp/lib/version/nsversion"
 	"github.com/jig/lisp/lib/web/nsweb"
 	"github.com/jig/lisp/types"
 )
@@ -58,6 +59,7 @@ func libraries(scriptArgs []string) []library {
 
 		// new libraries on jig/lisp v0.6.0
 		{"log", nslog.Load},
+		{"version", nsversion.Load},
 	}
 }
 

--- a/command/command.go
+++ b/command/command.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/alexflint/go-arg"
 	"github.com/jig/lisp"
-	"github.com/jig/lisp/lib/core"
 	liblog "github.com/jig/lisp/lib/log"
+	libversion "github.com/jig/lisp/lib/version"
 	"github.com/jig/lisp/repl"
 	"github.com/jig/lisp/tools/bat"
 	"github.com/jig/lisp/types"
@@ -137,12 +137,17 @@ func Execute(cmdArgs []string, repl_env types.EnvType) error {
 
 	// Handle --version
 	if parsedArgs.Version {
-		lispVer, scannerVer, _ := core.Versions()
+		lispVer, scannerVer, _ := libversion.Versions()
 		if lispVer == "" {
 			lispVer = "(unknown)"
 		}
 		if scannerVer == "" {
 			scannerVer = "(unknown)"
+		}
+		// An embedder's binary identifies itself first: the main module
+		// (or its version.SetMain branding) when it is not jig/lisp.
+		if name, ver := libversion.Main(); name != "" && name != "github.com/jig/lisp" {
+			fmt.Printf("%s %s\n", name, ver)
 		}
 		fmt.Printf("jig/lisp    %s\n", lispVer)
 		fmt.Printf("jig/scanner %s\n", scannerVer)

--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -59,6 +59,7 @@ var sectionBlurb = map[string]struct{ title, desc string }{
 	"cli":                 {"cli", "Command-line option parsing (clojure/tools.cli style)."},
 	"integrity":           {"integrity", "Attest and verify lisp source (formatting, hashing, Ed25519 signatures, the lisp-integrity mode)."},
 	"regexp":              {"regexp", "Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-replace and re-split."},
+	"version":             {"version", "Build information of the running program (the version builtin)."},
 }
 
 // entry is one documented symbol.

--- a/docgen/libraries.go
+++ b/docgen/libraries.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jig/lisp/lib/system/nssystem"
 	"github.com/jig/lisp/lib/term/nsterm"
 	"github.com/jig/lisp/lib/test/nstest"
+	"github.com/jig/lisp/lib/version/nsversion"
 	"github.com/jig/lisp/lib/web/nsweb"
 	"github.com/jig/lisp/types"
 )
@@ -51,6 +52,7 @@ func standardLibraries() []library {
 		{"term", nsterm.Load},
 		{"test", nstest.Load},
 		{"log", nslog.Load},
+		{"version", nsversion.Load},
 	}
 }
 

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -157,7 +156,6 @@ func Load(env EnvType) {
 	call.CallOverrideFN(env, "type?", istype)
 	call.Call(env, new_error, 1, 2)
 	call.Call(env, new_go_error)
-	call.Call(env, version)
 
 	call.Call(env, take)
 	call.Call(env, take_last)
@@ -303,66 +301,6 @@ func LoadInput(env EnvType) {
 	call.Call(env, exit, 0, 1)
 
 	loadInputDocs(env)
-}
-
-// moduleVersion returns the version of the module at importPath, looking
-// in both the main module and the dependencies: github.com/jig/lisp is
-// the main module when the binary is built from this repo, but a
-// dependency when jig/lisp is embedded in another Go program.
-func moduleVersion(bi *debug.BuildInfo, importPath string) string {
-	if bi.Main.Path == importPath {
-		return bi.Main.Version
-	}
-	for _, d := range bi.Deps {
-		if d.Path == importPath {
-			return d.Version
-		}
-	}
-	return ""
-}
-
-// Versions returns the jig/lisp, jig/scanner and Go toolchain versions of
-// the running binary, shared by the (version) builtin and --version. Each
-// value is "" when build information is unavailable.
-func Versions() (lispVer, scannerVer, goVer string) {
-	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "", "", ""
-	}
-	return moduleVersion(bi, "github.com/jig/lisp"),
-		moduleVersion(bi, "github.com/jig/scanner"),
-		bi.GoVersion
-}
-
-func version() (HashMap, error) {
-	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		return HashMap{}, nil
-	}
-	build := map[MalType]MalType{}
-	for _, s := range bi.Settings {
-		build[s.Key] = s.Value
-	}
-	deps := map[MalType]MalType{}
-	for _, d := range bi.Deps {
-		if d.Replace == nil {
-			deps[d.Path] = HashMap{Items: map[MalType]MalType{
-				KW("version"): d.Version,
-				KW("sum"):     d.Sum,
-			}}
-		} else {
-			deps[d.Path] = HashMap{Items: map[MalType]MalType{
-				KW("version"): d.Version,
-				KW("sum"):     d.Sum,
-				KW("replace"): d.Replace,
-			}}
-		}
-	}
-	return HashMap{Items: map[MalType]MalType{
-		KW("go-version"):   bi.GoVersion,
-		KW("build"):        HashMap{Items: build},
-		KW("dependencies"): HashMap{Items: deps},
-	}}, nil
 }
 
 func new_go_error(str string) (error, error) {

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -139,7 +139,6 @@ var coreDocs = []struct{ name, arglist, doc string }{
 	{"time-add", "[ms deltas]", "Shifts epoch milliseconds ms by the deltas hash-map. :years :months :days are calendar-aware (via UTC); :hours :minutes :seconds :milliseconds add a fixed duration. Missing keys are 0, values may be negative; an unknown key or non-integer value errors."},
 	{"time-before?", "[t1 t2]", "Reports whether epoch milliseconds t1 is strictly before t2."},
 	{"time-after?", "[t1 t2]", "Reports whether epoch milliseconds t1 is strictly after t2."},
-	{"version", "[]", "Interpreter build information as a hash-map."},
 
 	// Bytes, base64 & JSON
 	{"base64", "[bytes]", "Encodes a byte string to a base64 string."},

--- a/lib/core/input_test.go
+++ b/lib/core/input_test.go
@@ -1,0 +1,28 @@
+package core
+
+import (
+	"os"
+	"testing"
+)
+
+// TestReadLineEOF verifies readline returns nil at end of input (Ctrl-D),
+// so a REPL loop can tell EOF apart from an empty line and terminate.
+func TestReadLineEOF(t *testing.T) {
+	empty, err := os.CreateTemp(t.TempDir(), "stdin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = empty.Close() }()
+
+	old := os.Stdin
+	os.Stdin = empty // empty file → immediate EOF
+	defer func() { os.Stdin = old }()
+
+	got, err := readLine("")
+	if err != nil {
+		t.Fatalf("readLine at EOF: %v", err)
+	}
+	if got != nil {
+		t.Errorf("readLine at EOF = %v, want nil", got)
+	}
+}

--- a/lib/version/nsversion/nsversion.go
+++ b/lib/version/nsversion/nsversion.go
@@ -1,0 +1,13 @@
+// Package nsversion loads the version namespace into a jig/lisp
+// environment.
+package nsversion
+
+import (
+	"github.com/jig/lisp/lib/version"
+	"github.com/jig/lisp/types"
+)
+
+func Load(env types.EnvType) error {
+	version.Load(env)
+	return nil
+}

--- a/lib/version/version.go
+++ b/lib/version/version.go
@@ -1,0 +1,115 @@
+// Package version identifies the running program: the (version)
+// builtin returns the binary's build information as a hash-map, and
+// the Go API lets an embedder brand its own REPL or binary.
+//
+// By default the identity comes from Go build info: :main names the
+// main module (the embedder's module when jig/lisp is embedded, or
+// jig/lisp itself for the lisp binaries) and jig/lisp appears among
+// the dependencies. An embedder that versions its product some other
+// way (e.g. -ldflags -X) calls Set before loading the namespace.
+package version
+
+import (
+	"runtime/debug"
+
+	"github.com/jig/lisp/lib/call"
+	. "github.com/jig/lisp/types"
+)
+
+// overrideName/overrideVersion, when set, replace the main-module
+// identity everywhere it is reported.
+var overrideName, overrideVersion string
+
+// SetMain brands the running program: name and ver replace the main
+// module's path and version in (version)'s :main and in --version.
+// Call it before evaluating lisp code (typically from main, with
+// values injected via -ldflags -X).
+func SetMain(name, ver string) {
+	overrideName, overrideVersion = name, ver
+}
+
+// Main returns the running program's identity: the SetMain override when
+// present, otherwise the main module's path and version from build
+// info ("", "" when unavailable).
+func Main() (name, ver string) {
+	if overrideName != "" || overrideVersion != "" {
+		return overrideName, overrideVersion
+	}
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", ""
+	}
+	return bi.Main.Path, bi.Main.Version
+}
+
+// moduleVersion returns the version of the module at importPath, looking
+// in both the main module and the dependencies: github.com/jig/lisp is
+// the main module when the binary is built from this repo, but a
+// dependency when jig/lisp is embedded in another Go program.
+func moduleVersion(bi *debug.BuildInfo, importPath string) string {
+	if bi.Main.Path == importPath {
+		return bi.Main.Version
+	}
+	for _, d := range bi.Deps {
+		if d.Path == importPath {
+			return d.Version
+		}
+	}
+	return ""
+}
+
+// Versions returns the jig/lisp, jig/scanner and Go toolchain versions of
+// the running binary, shared by the (version) builtin and --version. Each
+// value is "" when build information is unavailable.
+func Versions() (lispVer, scannerVer, goVer string) {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", "", ""
+	}
+	return moduleVersion(bi, "github.com/jig/lisp"),
+		moduleVersion(bi, "github.com/jig/scanner"),
+		bi.GoVersion
+}
+
+func version() (HashMap, error) {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return HashMap{}, nil
+	}
+	mainName, mainVersion := Main()
+	build := map[MalType]MalType{}
+	for _, s := range bi.Settings {
+		build[s.Key] = s.Value
+	}
+	deps := map[MalType]MalType{}
+	for _, d := range bi.Deps {
+		if d.Replace == nil {
+			deps[d.Path] = HashMap{Items: map[MalType]MalType{
+				KW("version"): d.Version,
+				KW("sum"):     d.Sum,
+			}}
+		} else {
+			deps[d.Path] = HashMap{Items: map[MalType]MalType{
+				KW("version"): d.Version,
+				KW("sum"):     d.Sum,
+				KW("replace"): d.Replace,
+			}}
+		}
+	}
+	return HashMap{Items: map[MalType]MalType{
+		KW("main"): HashMap{Items: map[MalType]MalType{
+			KW("name"):    mainName,
+			KW("version"): mainVersion,
+		}},
+		KW("go-version"):   bi.GoVersion,
+		KW("build"):        HashMap{Items: build},
+		KW("dependencies"): HashMap{Items: deps},
+	}}, nil
+}
+
+// Load registers the version builtin.
+func Load(env EnvType) {
+	call.Call(env, version)
+	call.Doc(env, "version", "[]",
+		"Build information of the running program as a hash-map: :main {:name :version} (the program itself — an embedder's module, or its version.SetMain branding), :go-version, :build settings and :dependencies.")
+}

--- a/lib/version/version_test.go
+++ b/lib/version/version_test.go
@@ -1,7 +1,6 @@
-package core
+package version
 
 import (
-	"os"
 	"runtime/debug"
 	"strings"
 	"testing"
@@ -45,37 +44,41 @@ func TestVersions(t *testing.T) {
 }
 
 // TestVersionBuiltin checks the (version) builtin returns the expected
-// top-level structure.
+// top-level structure, :main included.
 func TestVersionBuiltin(t *testing.T) {
 	v, err := version()
 	if err != nil {
 		t.Fatalf("version(): %v", err)
 	}
-	for _, k := range []Keyword{KW("go-version"), KW("build"), KW("dependencies")} {
+	for _, k := range []Keyword{KW("main"), KW("go-version"), KW("build"), KW("dependencies")} {
 		if _, ok := v.Items[k]; !ok {
 			t.Errorf("version() is missing key :%s", k)
 		}
 	}
+	main, ok := v.Items[KW("main")].(HashMap)
+	if !ok {
+		t.Fatalf(":main is not a hash-map: %T", v.Items[KW("main")])
+	}
+	if name := main.Items[KW("name")]; name != "github.com/jig/lisp" {
+		t.Errorf(":main :name = %v, want the main module path", name)
+	}
 }
 
-// TestReadLineEOF verifies readline returns nil at end of input (Ctrl-D),
-// so a REPL loop can tell EOF apart from an empty line and terminate.
-func TestReadLineEOF(t *testing.T) {
-	empty, err := os.CreateTemp(t.TempDir(), "stdin")
+// TestSetMain checks the embedder branding override: it replaces the
+// main identity in Main() and in the builtin, and clears back.
+func TestSetMain(t *testing.T) {
+	SetMain("acme-repl", "v9.9.9")
+	t.Cleanup(func() { SetMain("", "") })
+
+	if name, ver := Main(); name != "acme-repl" || ver != "v9.9.9" {
+		t.Fatalf("Main() = %q %q, want the override", name, ver)
+	}
+	v, err := version()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = empty.Close() }()
-
-	old := os.Stdin
-	os.Stdin = empty // empty file → immediate EOF
-	defer func() { os.Stdin = old }()
-
-	got, err := readLine("")
-	if err != nil {
-		t.Fatalf("readLine at EOF: %v", err)
-	}
-	if got != nil {
-		t.Errorf("readLine at EOF = %v, want nil", got)
+	main := v.Items[KW("main")].(HashMap)
+	if main.Items[KW("name")] != "acme-repl" || main.Items[KW("version")] != "v9.9.9" {
+		t.Fatalf("builtin :main = %v, want the override", main.Items)
 	}
 }


### PR DESCRIPTION
## Summary

- The `version` builtin moves out of core into a new `lib/version` + `nsversion` namespace, fixing the embedder problem: `(version)` never reported the running program's own identity (`bi.Main` was omitted — an embedder's REPL appeared as nothing, jig/lisp as a mere dependency of itself).
- `(version)` gains `:main {:name :version}`: the main module from Go build info, or whatever `version.SetMain(name, ver)` sets (for `-ldflags -X` product branding). `core.Versions()` moved to `lib/version` unchanged.
- `--version` prints the main identity first when it is not jig/lisp, so an embedder's binary built on `command.Execute` reports itself; jig/lisp and jig/scanner remain listed as components.
- Registered in `cmd/lisp`, `cmd/lisp-integrity` and docgen (sync tests cover all three); `LANGUAGE.md` regenerated with a `version` section; CHANGELOG migration note under 0.6.0 (embedders add `nsversion.Load(env)`).

## Test plan

- `go test ./...` green; gofmt/vet clean.
- lib/version tests: moduleVersion main/dep/missing, `Versions()`, builtin structure including `:main` (name = main module path), and the `SetMain` override reflected in both `Main()` and the builtin. `TestReadLineEOF` stayed in core (input, not version).
- Validated with a real minimal embedder (separate module importing jig/lisp, `SetMain("acme-repl", "v1.2.3")` + `command.Execute`): `--version` prints `acme-repl v1.2.3` first, and `(get (version) :main)` returns `{:name "acme-repl" :version "v1.2.3"}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)