### PR TITLE
feat(integrity): signature outcome always visible (signer fingerprint / signed-no notice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,13 @@ children of the release, so restarts keep verifying.
 - **`(assert-integrity)`** now suggests `lisp-integrity` in its error
   and gains **`(assert-integrity :with-signature)`**, which throws
   unless the signature rule was applied.
+- **Signature visibility**: the green block always carries a signature
+  line — `signer <comment> SHA256:<fingerprint>` when the rule
+  applied, a yellow `signed no (no /etc/lisp/allowed_signers)` notice
+  otherwise — and the start record always carries `SIGNED=true/false`
+  (plus `SIGNER`/`SIGNER_FINGERPRINT` when signed), so
+  consistency-only runs are visibly weaker and auditable
+  (`journalctl SIGNED=false`).
 - **`lisp-integrity --test DIR|FILE`** (with optional `--test-json`)
   runs a deftest suite under the same guarantees: the mode anchors on
   the repository enclosing the target and every test file — and, in

--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -95,8 +95,11 @@ At startup:
    touching only state paths), each such commit must carry an SSH
    signature by a listed key, and the first non-state commit under
    them — the **release commit** — must be signed itself or via an
-   annotated tag pointing at it. The release signer is reported in
-   the green block and the start record.
+   annotated tag pointing at it. The release signer (key comment and
+   SHA256 fingerprint) is reported in the green block and the start
+   record. Without the file the block still verifies consistency but
+   carries an explicit yellow `signed  no` line — a consistency-only
+   run is visibly weaker, never silently green.
 
 At runtime, while the mode is active:
 
@@ -131,8 +134,9 @@ Records emitted by the runtime itself (exactly two, never more):
 
 - **start** — after verification and confirmation, before evaluation:
   `MESSAGE="run started"`, `ARGV` (script and arguments — or
-  `["--test", target]` — as JSON), `SIGNER` when rule 3 applied,
-  `PROTECTED`.
+  `["--test", target]` — as JSON), `PROTECTED`, `SIGNED`
+  (always; filter unsigned runs with `journalctl SIGNED=false`), and
+  `SIGNER` + `SIGNER_FINGERPRINT` (SHA256) when rule 3 applied.
 - **end** — from a deferred handler covering normal return, error and
   panic: `MESSAGE="run ended"`, `EXIT_CODE` (and `PANIC` on one). A
   start record with no matching end record means abnormal termination

--- a/command/integrity.go
+++ b/command/integrity.go
@@ -126,7 +126,7 @@ func ExecuteIntegrity(cmdArgs []string, repl_env types.EnvType) error {
 		enableErr = integrity.Enable(parsedArgs.Script, keys)
 	}
 	if enableErr != nil {
-		return reportIntegrity(false, "", "", "", enableErr)
+		return reportIntegrity(false, "", "", "", "", false, enableErr)
 	}
 	require.VerifyModule = integrity.VerifyFile
 	system.VerifySource = integrity.VerifyFile
@@ -139,7 +139,8 @@ func ExecuteIntegrity(cmdArgs []string, repl_env types.EnvType) error {
 		libgit.SetSigningKeys(os.Getenv("SSH_AUTH_SOCK"), keys)
 	}
 
-	if err := reportIntegrity(true, integrity.RepoName(), integrity.CommitHash(), integrity.Signer(), nil); err != nil {
+	if err := reportIntegrity(true, integrity.RepoName(), integrity.CommitHash(),
+		integrity.Signer(), integrity.SignerFingerprint(), integrity.Signed(), nil); err != nil {
 		return err
 	}
 
@@ -184,9 +185,11 @@ func ExecuteIntegrity(cmdArgs []string, repl_env types.EnvType) error {
 	startFields := map[string]string{
 		"argv":      string(argv),
 		"protected": fmt.Sprintf("%t", protected),
+		"signed":    fmt.Sprintf("%t", integrity.Signed()),
 	}
-	if signer := integrity.Signer(); signer != "" {
-		startFields["signer"] = signer
+	if integrity.Signed() {
+		startFields["signer"] = integrity.Signer()
+		startFields["signer_fingerprint"] = integrity.SignerFingerprint()
 	}
 	if err := emitRecord(slog.LevelInfo, "run started", startFields); err != nil {
 		return err
@@ -229,20 +232,20 @@ func ExecuteIntegrity(cmdArgs []string, repl_env types.EnvType) error {
 // on mismatch, so a green block does not mean the whole run is
 // pre-verified. Returns nil on success, ErrIntegrityReported on
 // a terminal failure (already shown), or the cause when redirected.
-func reportIntegrity(ok bool, repo, commit, signer string, cause error) error {
+func reportIntegrity(ok bool, repo, commit, signer, fingerprint string, signed bool, cause error) error {
 	if !libterm.StderrIsTerminal() {
 		if !ok {
 			return cause // the normal error path reports it
 		}
-		attrs := []any{"repo", repo, "commit", commit}
-		if signer != "" {
-			attrs = append(attrs, "signer", signer)
+		attrs := []any{"repo", repo, "commit", commit, "signed", signed}
+		if signed {
+			attrs = append(attrs, "signer", signer, "signer_fingerprint", fingerprint)
 		}
 		slog.New(slog.NewJSONHandler(os.Stderr, nil)).Info("integrity: verified at HEAD", attrs...)
 		return nil
 	}
 
-	fmt.Fprint(os.Stderr, integrityBlock(ok, repo, commit, signer, cause))
+	fmt.Fprint(os.Stderr, integrityBlock(ok, repo, commit, signer, fingerprint, signed, cause))
 	if ok {
 		return nil
 	}
@@ -250,7 +253,11 @@ func reportIntegrity(ok bool, repo, commit, signer string, cause error) error {
 }
 
 // integrityBlock renders the coloured, one-field-per-line audit block.
-func integrityBlock(ok bool, repo, commit, signer string, cause error) string {
+// The signature line is always present: the signer's comment and key
+// fingerprint when the rule was applied, a yellow "signed no" notice
+// when the host has no allowed-signers set — consistency-only runs must
+// be visibly weaker, not silently green.
+func integrityBlock(ok bool, repo, commit, signer, fingerprint string, signed bool, cause error) string {
 	field := func(label, value string) string {
 		return fmt.Sprintf("    %-6s  %s\n", label, value)
 	}
@@ -259,10 +266,12 @@ func integrityBlock(ok bool, repo, commit, signer string, cause error) string {
 		return libterm.StderrStyle("red", true, "✗ integrity check failed") + "\n" +
 			libterm.StderrStyle("red", false, field("reason", reason))
 	}
-	body := field("repo", repo) + field("commit", commit)
-	if signer != "" {
-		body += field("signer", signer)
+	body := libterm.StderrStyle("green", false, field("repo", repo)+field("commit", commit))
+	if signed {
+		id := strings.TrimSpace(signer + " " + fingerprint)
+		body += libterm.StderrStyle("green", false, field("signer", id))
+	} else {
+		body += libterm.StderrStyle("yellow", false, field("signed", "no (no "+allowedSignersPath+")"))
 	}
-	return libterm.StderrStyle("green", true, "✓ integrity verified") + "\n" +
-		libterm.StderrStyle("green", false, body)
+	return libterm.StderrStyle("green", true, "✓ integrity verified") + "\n" + body
 }

--- a/command/integrity_test.go
+++ b/command/integrity_test.go
@@ -149,7 +149,7 @@ func TestExecuteIntegrityRunsVerifiedScript(t *testing.T) {
 		!strings.Contains(start.fields["argv"], `"two"`) {
 		t.Fatalf("unexpected start record: %+v", start)
 	}
-	if start.fields["protected"] != "true" || start.fields["signer"] != "" {
+	if start.fields["protected"] != "true" || start.fields["signed"] != "false" || start.fields["signer"] != "" {
 		t.Fatalf("unexpected start record fields: %+v", start.fields)
 	}
 	if end.msg != "run ended" || end.fields["exit_code"] != "0" || end.level != slog.LevelInfo {
@@ -393,8 +393,10 @@ func TestExecuteRejectsRemovedIntegrityFlags(t *testing.T) {
 // header plus one field per line on success, a red header plus reason on
 // failure. Asserts the text (robust to whether color is on).
 func TestIntegrityBlockFormat(t *testing.T) {
-	ok := integrityBlock(true, "git@github.com:jig/example.git", "abc123def", "alice", nil)
-	for _, want := range []string{"integrity verified", "repo", "example", "commit", "abc123def", "signer", "alice"} {
+	ok := integrityBlock(true, "git@github.com:jig/example.git", "abc123def",
+		"alice", "SHA256:duyD/5p/I/1Oxnka", true, nil)
+	for _, want := range []string{"integrity verified", "repo", "example", "commit", "abc123def",
+		"signer", "alice SHA256:duyD/5p/I/1Oxnka"} {
 		if !strings.Contains(ok, want) {
 			t.Errorf("success block missing %q:\n%s", want, ok)
 		}
@@ -403,12 +405,17 @@ func TestIntegrityBlockFormat(t *testing.T) {
 		t.Errorf("expected header + 3 fields (3 newlines), got %d:\n%s", n, ok)
 	}
 
-	noSigner := integrityBlock(true, "example", "abc", "", nil)
-	if strings.Contains(noSigner, "signer") {
-		t.Errorf("no signer line expected when signer is empty:\n%s", noSigner)
+	// Without allowed signers the block must say so — never silently
+	// omit the signature line.
+	unsigned := integrityBlock(true, "example", "abc", "", "", false, nil)
+	if !strings.Contains(unsigned, "signed") || !strings.Contains(unsigned, "no (no ") {
+		t.Errorf("unsigned block must carry an explicit 'signed no' line:\n%s", unsigned)
+	}
+	if strings.Contains(unsigned, "signer ") { // the label, not "allowed_signers"
+		t.Errorf("no signer line expected when unsigned:\n%s", unsigned)
 	}
 
-	fail := integrityBlock(false, "", "", "", errors.New("integrity: HEAD moved"))
+	fail := integrityBlock(false, "", "", "", "", false, errors.New("integrity: HEAD moved"))
 	for _, want := range []string{"integrity check failed", "reason", "HEAD moved"} {
 		if !strings.Contains(fail, want) {
 			t.Errorf("failure block missing %q:\n%s", want, fail)

--- a/lib/git/sign.go
+++ b/lib/git/sign.go
@@ -275,47 +275,51 @@ func gitVerifyTag(rv MalType, name string, allowedKeys string) (MalType, error) 
 
 // VerifyCommitSSH checks that commit c carries an SSH signature made by
 // one of the allowed public keys (authorized_keys-format lines, as
-// git-verify-commit) and returns the matching key's comment. Exported
-// for the integrity mode of the CLI.
-func VerifyCommitSSH(c *object.Commit, allowedKeys string) (signer string, err error) {
+// git-verify-commit) and returns the matching key's comment and its
+// SHA256 fingerprint. Exported for the integrity mode of the CLI.
+func VerifyCommitSSH(c *object.Commit, allowedKeys string) (signer, fingerprint string, err error) {
 	armored := c.SignatureSHA256
 	if armored == "" {
 		armored = c.Signature
 	}
 	if armored == "" {
-		return "", fmt.Errorf("commit %s is not signed", c.Hash)
+		return "", "", fmt.Errorf("commit %s is not signed", c.Hash)
 	}
 	v, err := verifySignature(c, armored, allowedKeys)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return signerOf(v), nil
+	signer, fingerprint = signerOf(v)
+	return signer, fingerprint, nil
 }
 
 // VerifyTagSSH is VerifyCommitSSH for annotated tag objects.
-func VerifyTagSSH(tag *object.Tag, allowedKeys string) (signer string, err error) {
+func VerifyTagSSH(tag *object.Tag, allowedKeys string) (signer, fingerprint string, err error) {
 	armored := tag.SignatureSHA256
 	if armored == "" {
 		armored = tag.Signature
 	}
 	if armored == "" {
-		return "", fmt.Errorf("tag %q is not signed", tag.Name)
+		return "", "", fmt.Errorf("tag %q is not signed", tag.Name)
 	}
 	v, err := verifySignature(tag, armored, allowedKeys)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return signerOf(v), nil
+	signer, fingerprint = signerOf(v)
+	return signer, fingerprint, nil
 }
 
-// signerOf extracts the :signer comment from a verifySignature result.
-func signerOf(v MalType) string {
+// signerOf extracts the :signer comment and :fingerprint from a
+// verifySignature result.
+func signerOf(v MalType) (signer, fingerprint string) {
 	m, ok := v.(HashMap)
 	if !ok {
-		return ""
+		return "", ""
 	}
 	s, _ := m.Items[KW("signer")].(string)
-	return s
+	f, _ := m.Items[KW("fingerprint")].(string)
+	return s, f
 }
 
 // verifySignature checks the armored SSH signature of a commit or tag

--- a/lib/integrity/mode.go
+++ b/lib/integrity/mode.go
@@ -45,6 +45,7 @@ type modeState struct {
 	repoRoot string
 	repoName string
 	signer   string
+	signerFP string
 	signed   bool
 	commit   *object.Commit
 	tree     *object.Tree
@@ -83,6 +84,16 @@ func Signer() string {
 		return ""
 	}
 	return mode.signer
+}
+
+// SignerFingerprint returns the SHA256 fingerprint of the key that
+// signed the verified anchor, or "" when inactive or no signers were
+// required.
+func SignerFingerprint() string {
+	if mode == nil {
+		return ""
+	}
+	return mode.signerFP
 }
 
 // Signed reports whether signature verification was performed (an
@@ -168,9 +179,9 @@ func enableAt(path, allowedSigners string) (*modeState, string, error) {
 		return nil, "", fmt.Errorf("integrity: HEAD does not resolve to a commit: %w", err)
 	}
 
-	signer := ""
+	signer, signerFP := "", ""
 	if allowedSigners != "" {
-		signer, err = verifyHeadSignature(repo, commit, allowedSigners)
+		signer, signerFP, err = verifyHeadSignature(repo, commit, allowedSigners)
 		if err != nil {
 			return nil, "", fmt.Errorf("integrity: %w", err)
 		}
@@ -185,6 +196,7 @@ func enableAt(path, allowedSigners string) (*modeState, string, error) {
 		repoRoot: root,
 		repoName: repoName(repo, root),
 		signer:   signer,
+		signerFP: signerFP,
 		signed:   allowedSigners != "",
 		commit:   commit,
 		tree:     tree,
@@ -227,34 +239,34 @@ func isStateOnly(commit *object.Commit) (bool, error) {
 // every state-save commit from HEAD down to the release commit under
 // them must be SSH-signed by an allowed key, and the release commit
 // must be signed itself or via a signed annotated tag pointing at it.
-// It returns the release signer's key comment.
-func verifyHeadSignature(repo *gogit.Repository, head *object.Commit, allowedSigners string) (string, error) {
+// It returns the release signer's key comment and SHA256 fingerprint.
+func verifyHeadSignature(repo *gogit.Repository, head *object.Commit, allowedSigners string) (signer, fingerprint string, err error) {
 	cur := head
 	for {
 		stateOnly, err := isStateOnly(cur)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 		if !stateOnly {
 			break
 		}
-		if _, err := libgit.VerifyCommitSSH(cur, allowedSigners); err != nil {
-			return "", fmt.Errorf("state commit %s is not signed by an allowed key: %w", cur.Hash, err)
+		if _, _, err := libgit.VerifyCommitSSH(cur, allowedSigners); err != nil {
+			return "", "", fmt.Errorf("state commit %s is not signed by an allowed key: %w", cur.Hash, err)
 		}
 		cur, err = cur.Parent(0)
 		if err != nil {
-			return "", err
+			return "", "", err
 		}
 	}
 	// cur is the release commit: its own signature, or a signed
 	// annotated tag targeting it.
-	signer, commitErr := libgit.VerifyCommitSSH(cur, allowedSigners)
+	signer, fingerprint, commitErr := libgit.VerifyCommitSSH(cur, allowedSigners)
 	if commitErr == nil {
-		return signer, nil
+		return signer, fingerprint, nil
 	}
 	tags, err := repo.TagObjects()
 	if err != nil {
-		return "", commitErr
+		return "", "", commitErr
 	}
 	defer tags.Close()
 	var tagErr error
@@ -266,16 +278,16 @@ func verifyHeadSignature(repo *gogit.Repository, head *object.Commit, allowedSig
 		if tag.Target != cur.Hash || tag.TargetType != plumbing.CommitObject {
 			continue
 		}
-		s, err := libgit.VerifyTagSSH(tag, allowedSigners)
+		s, f, err := libgit.VerifyTagSSH(tag, allowedSigners)
 		if err == nil {
-			return s, nil
+			return s, f, nil
 		}
 		tagErr = err
 	}
 	if tagErr != nil {
-		return "", fmt.Errorf("commit %s: %w (and no annotated tag pointing at it is signed by an allowed key: %v)", cur.Hash, commitErr, tagErr)
+		return "", "", fmt.Errorf("commit %s: %w (and no annotated tag pointing at it is signed by an allowed key: %v)", cur.Hash, commitErr, tagErr)
 	}
-	return "", fmt.Errorf("commit %s: %w", cur.Hash, commitErr)
+	return "", "", fmt.Errorf("commit %s: %w", cur.Hash, commitErr)
 }
 
 // VerifyFile checks that absPath lies inside the verified repository

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -260,6 +260,9 @@ func TestEnableSignedCommit(t *testing.T) {
 	if !integrity.Signed() || integrity.Signer() != "alice" {
 		t.Fatalf("Signed()/Signer() = %v/%q, want true/alice", integrity.Signed(), integrity.Signer())
 	}
+	if fp := integrity.SignerFingerprint(); !strings.HasPrefix(fp, "SHA256:") {
+		t.Fatalf("SignerFingerprint() = %q, want an SSH SHA256 fingerprint", fp)
+	}
 	integrity.Disable()
 	if err := enable(t, script, otherAuthorized); err == nil {
 		t.Fatal("Enable(signed commit, wrong key) did not fail")
@@ -464,7 +467,7 @@ func TestStateSaveSignedCommit(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				if _, err := libgit.VerifyCommitSSH(commit, authorized); err != nil {
+				if _, _, err := libgit.VerifyCommitSSH(commit, authorized); err != nil {
 					t.Fatalf("verify signed state commit: %v", err)
 				}
 				if commit.Author.Name != "state-save" || commit.Author.Email != "state-save@lisp" {


### PR DESCRIPTION
## Summary

Closes the observability gap where a run without `/etc/lisp/allowed_signers` came out green with no indication that the signature rule was never applied:

- The green block always carries a signature line — `signer alice SHA256:duyD/5p/…` (key comment + standard SSH SHA256 fingerprint, comparable against `ssh-add -l` / `ssh-keygen -lf`) when signed, or a **yellow** `signed  no (no /etc/lisp/allowed_signers)` notice when not. Consistency-only runs are visibly weaker, never silently green.
- The redirected JSON line and the journald start record always carry `signed=true/false`, plus `signer` and `signer_fingerprint` when signed. Audit: `journalctl SIGNED=false`.
- `lib/git`'s `VerifyCommitSSH`/`VerifyTagSSH` return the fingerprint (already computed by the verifier) alongside the signer comment; `integrity.SignerFingerprint()` exposes it.
- INTEGRITY.md and CHANGELOG updated.

The fingerprint (not a base64 prefix) was chosen deliberately: ed25519 authorized_keys blobs share their first ~25 base64 chars (the encoded algorithm header), so a prefix distinguishes almost nothing, while `SHA256:…` identifies the whole key in the format operators already compare against.

## Test plan

- `go test ./...` green; gofmt/vet clean.
- Block format test pins both variants (signer+fingerprint line; explicit `signed no` line when unsigned — with a guard against matching `allowed_signers` as "signer"). Signed-mode test asserts `SignerFingerprint()` is a `SHA256:` value; start-record test asserts `signed=false` present and no `signer` field.
- Visual check under a pseudo-TTY: green header, green repo/commit, yellow signed-no line, exactly as the approved mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)