### PR TITLE
fix(integrity): laconic no-such-file message instead of the red block

### DIFF
--- a/command/integrity.go
+++ b/command/integrity.go
@@ -101,6 +101,22 @@ func ExecuteIntegrity(cmdArgs []string, repl_env types.EnvType) error {
 		return fmt.Errorf("lisp-integrity requires a script file or --test (stdin is not supported)")
 	}
 
+	// A missing path is an operator typo, not an integrity failure:
+	// report it laconically instead of the red audit block.
+	target := parsedArgs.Script
+	if testMode {
+		target = parsedArgs.Test
+	}
+	if info, err := os.Stat(target); errors.Is(err, os.ErrNotExist) {
+		fmt.Fprintf(os.Stderr, "lisp-integrity: no such file: %s\n", target)
+		return ErrIntegrityReported
+	} else if err != nil {
+		return err
+	} else if !testMode && info.IsDir() {
+		fmt.Fprintf(os.Stderr, "lisp-integrity: %s is a directory, expected a script file\n", target)
+		return ErrIntegrityReported
+	}
+
 	// The audit trail must be protected before anything is attested:
 	// journald on Linux — or refuse; the XDG state file only on macOS
 	// (development convenience, explicitly weaker).
@@ -166,10 +182,8 @@ func ExecuteIntegrity(cmdArgs []string, repl_env types.EnvType) error {
 	if _, err := rand.Read(traceID); err != nil {
 		return err
 	}
-	target := parsedArgs.Script
 	argvList := append([]string{parsedArgs.Script}, parsedArgs.Args...)
 	if testMode {
-		target = parsedArgs.Test
 		argvList = []string{"--test", parsedArgs.Test}
 	}
 	liblog.SetIdentifier(strings.TrimSuffix(filepath.Base(filepath.Clean(target)), ".lisp"))

--- a/command/integrity_test.go
+++ b/command/integrity_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"errors"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -356,6 +357,65 @@ func TestExecuteIntegrityRequiresJournald(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "journald") {
 		t.Fatalf("ExecuteIntegrity without journald = %v, want refusal", err)
 	}
+}
+
+// TestExecuteIntegrityMissingFile pins the laconic typo path: a missing
+// script (or test target) is reported as "no such file" — never as an
+// integrity failure — and nothing is attested.
+func TestExecuteIntegrityMissingFile(t *testing.T) {
+	records := stubAttestation(t)
+	ns := newIntegrityEnv(t)
+
+	for _, cmdline := range [][]string{
+		{"lisp-integrity", "-y", "./nope.lisp"},
+		{"lisp-integrity", "-y", "--test", "./nope"},
+	} {
+		stderr := captureStderr(t, func() {
+			if err := ExecuteIntegrity(cmdline, ns); !errors.Is(err, ErrIntegrityReported) {
+				t.Errorf("ExecuteIntegrity(%v) = %v, want ErrIntegrityReported", cmdline, err)
+			}
+		})
+		if !strings.Contains(stderr, "lisp-integrity: no such file: ./nope") {
+			t.Errorf("stderr %q: want the laconic no-such-file line", stderr)
+		}
+		if strings.Contains(stderr, "integrity check failed") {
+			t.Errorf("stderr %q: must not print the red audit block for a typo", stderr)
+		}
+	}
+
+	// A directory where a script is expected is the same kind of typo.
+	dir := t.TempDir()
+	stderr := captureStderr(t, func() {
+		if err := ExecuteIntegrity([]string{"lisp-integrity", "-y", dir}, ns); !errors.Is(err, ErrIntegrityReported) {
+			t.Errorf("ExecuteIntegrity(dir) = %v, want ErrIntegrityReported", err)
+		}
+	})
+	if !strings.Contains(stderr, "is a directory") {
+		t.Errorf("stderr %q: want the directory notice", stderr)
+	}
+
+	if len(*records) != 0 {
+		t.Fatalf("typo runs must not be attested: %+v", *records)
+	}
+}
+
+// captureStderr runs f capturing os.Stderr.
+func captureStderr(t *testing.T, f func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+	f()
+	_ = w.Close()
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }
 
 func TestExecuteIntegrityArgValidation(t *testing.T) {


### PR DESCRIPTION
## Summary

`lisp-integrity ./xxxx.lisp` on a nonexistent path used to print the red `✗ integrity check failed` block — semantically wrong: nothing was verified, there was nothing to verify. Now the target is stat'ed up front and a typo gets a laconic line:

```
lisp-integrity: no such file: ./xxxx.lisp
```

- Applies to both the script form and `--test` targets; a directory passed where a script is expected gets `… is a directory, expected a script file`.
- Exit code 1, no audit block, and nothing attested to the journal for these runs.

## Test plan

- `go test ./...` green (34 packages); gofmt/vet clean.
- New test pins the message on stderr for script/`--test`/directory cases, asserts the red block is absent and that no attestation records are emitted.
- Verified manually: exact output `lisp-integrity: no such file: ./xxxx.lisp`, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)