### PR TITLE
feat(integrity): lisp-integrity --version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,9 @@ children of the release, so restarts keep verifying.
 - **`(assert-integrity)`** now suggests `lisp-integrity` in its error
   and gains **`(assert-integrity :with-signature)`**, which throws
   unless the signature rule was applied.
+- **`lisp-integrity --version`** reports version information like
+  `lisp --version` (main identity first for embedders) and refuses to
+  be combined with any other argument.
 - **Signature visibility**: the green block always carries a signature
   line — `signer <comment> SHA256:<fingerprint>` when the rule
   applied, a yellow `signed no (no /etc/lisp/allowed_signers)` notice

--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -50,7 +50,9 @@ lisp-integrity -y service.lisp [args…]
 lisp-integrity -y --test ./tests [--test-json report.json]
 ```
 
-- Only script-file execution and the verified test runner. No REPL,
+- `--version` reports version information (and accepts no other
+  argument). Otherwise: only script-file execution and the verified
+  test runner. No REPL,
   no `-e`, no stdin, no `--fmt` / `--debug`, no DAP/LSP servers, no
   environment variables selecting behaviour (`LOG_LEVEL` for
   verbosity is the one exception, inherited from `lib/log`). Use

--- a/command/command.go
+++ b/command/command.go
@@ -67,6 +67,29 @@ func PreParseArgs(cmdArgs []string) []string {
 	return parsedArgs.Args
 }
 
+// printVersion writes the version report to stdout: the program's own
+// identity first when it is not jig/lisp (an embedder's main module,
+// or its version.SetMain branding), then the jig/lisp and jig/scanner
+// components and the full Go build info. Shared by lisp's and
+// lisp-integrity's --version.
+func printVersion() {
+	lispVer, scannerVer, _ := libversion.Versions()
+	if lispVer == "" {
+		lispVer = "(unknown)"
+	}
+	if scannerVer == "" {
+		scannerVer = "(unknown)"
+	}
+	if name, ver := libversion.Main(); name != "" && name != "github.com/jig/lisp" {
+		fmt.Printf("%s %s\n", name, ver)
+	}
+	fmt.Printf("jig/lisp    %s\n", lispVer)
+	fmt.Printf("jig/scanner %s\n", scannerVer)
+	if versionInfo, ok := debug.ReadBuildInfo(); ok {
+		fmt.Println(versionInfo)
+	}
+}
+
 // Execute is the main function of a command line MAL interpreter.
 // args are usually the os.Args, and repl_env contains the environment filled
 // with the symbols required for the interpreter.
@@ -137,26 +160,7 @@ func Execute(cmdArgs []string, repl_env types.EnvType) error {
 
 	// Handle --version
 	if parsedArgs.Version {
-		lispVer, scannerVer, _ := libversion.Versions()
-		if lispVer == "" {
-			lispVer = "(unknown)"
-		}
-		if scannerVer == "" {
-			scannerVer = "(unknown)"
-		}
-		// An embedder's binary identifies itself first: the main module
-		// (or its version.SetMain branding) when it is not jig/lisp.
-		if name, ver := libversion.Main(); name != "" && name != "github.com/jig/lisp" {
-			fmt.Printf("%s %s\n", name, ver)
-		}
-		fmt.Printf("jig/lisp    %s\n", lispVer)
-		fmt.Printf("jig/scanner %s\n", scannerVer)
-
-		versionInfo, ok := debug.ReadBuildInfo()
-		if !ok {
-			return nil
-		}
-		fmt.Println(versionInfo)
+		printVersion()
 		return nil
 	}
 

--- a/command/integrity.go
+++ b/command/integrity.go
@@ -48,6 +48,7 @@ var (
 // its arguments and the consent flag — nothing else, by design (no
 // REPL, no -e, no environment overrides).
 type integrityArgs struct {
+	Version  bool     `arg:"-v,--version" help:"show version information (accepts no other arguments)"`
 	Yes      bool     `arg:"-y,--yes" help:"run without asking for confirmation (required when stdin is not a terminal)"`
 	Test     string   `arg:"-t,--test" help:"verify and run the test suite from a directory or a single test file" placeholder:"DIR|FILE"`
 	TestJSON string   `arg:"--test-json" help:"with --test, also write a JSON report to the given file" placeholder:"FILE"`
@@ -91,6 +92,17 @@ func ExecuteIntegrity(cmdArgs []string, repl_env types.EnvType) error {
 			return err
 		}
 	}
+	// --version is pure introspection: report and exit, refusing any
+	// other argument so it can never be half of a run invocation.
+	if parsedArgs.Version {
+		if parsedArgs.Yes || parsedArgs.Test != "" || parsedArgs.TestJSON != "" ||
+			parsedArgs.Script != "" || len(parsedArgs.Args) > 0 {
+			return fmt.Errorf("--version accepts no other arguments")
+		}
+		printVersion()
+		return nil
+	}
+
 	testMode := parsedArgs.Test != ""
 	switch {
 	case parsedArgs.TestJSON != "" && !testMode:

--- a/command/integrity_test.go
+++ b/command/integrity_test.go
@@ -418,6 +418,36 @@ func captureStderr(t *testing.T, f func()) string {
 	return string(data)
 }
 
+// TestExecuteIntegrityVersion pins --version: it reports like lisp's
+// and refuses to be combined with anything else.
+func TestExecuteIntegrityVersion(t *testing.T) {
+	records := stubAttestation(t)
+	ns := newIntegrityEnv(t)
+	out, err := captureStdout(t, func() error {
+		return ExecuteIntegrity([]string{"lisp-integrity", "--version"}, ns)
+	})
+	if err != nil {
+		t.Fatalf("ExecuteIntegrity --version: %v", err)
+	}
+	if !strings.Contains(out, "jig/lisp") || !strings.Contains(out, "jig/scanner") {
+		t.Fatalf("version output %q: want the component lines", out)
+	}
+	if len(*records) != 0 {
+		t.Fatalf("--version must not attest anything: %+v", *records)
+	}
+
+	for _, cmdline := range [][]string{
+		{"lisp-integrity", "--version", "x.lisp"},
+		{"lisp-integrity", "--version", "-y"},
+		{"lisp-integrity", "--version", "--test", "./tests"},
+	} {
+		if err := ExecuteIntegrity(cmdline, ns); err == nil ||
+			!strings.Contains(err.Error(), "no other arguments") {
+			t.Errorf("ExecuteIntegrity(%v) = %v, want the no-other-arguments error", cmdline, err)
+		}
+	}
+}
+
 func TestExecuteIntegrityArgValidation(t *testing.T) {
 	stubAttestation(t)
 	ns := newIntegrityEnv(t)


### PR DESCRIPTION
## Summary

- `lisp-integrity --version` now works, reporting the same as `lisp --version`: the main-module identity first when not jig/lisp (embedder branding via `version.SetMain` included), then jig/lisp, jig/scanner and the full Go build info. The printing moved to a `printVersion` helper shared by both binaries.
- It is pure introspection and deliberately strict: combined with any other argument (`-y`, a script, `--test`, …) it errors with `--version accepts no other arguments`, so it can never be half of a run invocation.
- INTEGRITY.md CLI section and CHANGELOG updated.

## Test plan

- `go test ./...` green; gofmt/vet clean.
- New test pins the output (component lines present), asserts nothing is attested, and covers the rejected combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)