### PR TITLE
docs(language): section blurbs for web/git/term/test/log; Running fixes

### DIFF
--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -20,8 +20,9 @@ this file is generated from the interpreter's own documentation metadata
 lisp script.lisp            # run a file
 lisp -e "(+ 1 2)"           # evaluate one expression and print it
 lisp                        # REPL (Ctrl-D to exit)
-lisp --test DIR             # run every *_test.mal under DIR
+lisp --test DIR             # run every *_test.lisp (and legacy *_test.mal) under DIR
 lisp --fmt script.lisp      # canonical formatting
+lisp-integrity script.lisp  # verified & attested run (separate binary; see INTEGRITY.md)
 ```
 
 Command-line arguments after the script are visible to it as the list
@@ -486,6 +487,8 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-repla
 
 ### web
 
+Ring-style HTTP server: router, response helpers, middleware, JWT/mTLS identity.
+
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
 | `web--bearer-token` | `[req]` | Extracts the bearer token from a request's Authorization header, or nil. |
@@ -506,6 +509,8 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-repla
 | `web-wrap-recover` | `[handler]` | Middleware: turns any error escaping the handler into a 500 JSON response instead of dropping the connection. |
 
 ### git
+
+Git operations backed by go-git: init/clone/commit/push, tags, and SSH signature verification.
 
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
@@ -537,6 +542,8 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-repla
 
 ### term
 
+Terminal styling (ANSI colors, NO_COLOR-aware) and width detection.
+
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
 | `term-blue` | `[s]` | — |
@@ -554,6 +561,8 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-repla
 
 ### test
 
+Clojure-style unit testing: deftest / is / are; run with `lisp --test`.
+
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |
 | `are ⁽ᵐ⁾` | `[argv expr & rows]` | Template assertion: substitutes each row of values for argv in expr and asserts every instance, e.g. (are [x y] (= x y) 2 (+ 1 1) 4 (* 2 2)). |
@@ -569,6 +578,8 @@ Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-repla
 | `with-out-str ⁽ᵐ⁾` | `[& body]` | Evaluates body capturing standard output and returns it as a string (Clojure-style); output from concurrent goroutines is captured too. |
 
 ### log
+
+Structured logging: log-debug / log-info / log-warn / log-error emit records to systemd-journald (or $XDG_STATE_HOME/lisp/<script>.log without it), filtered by the LOG_LEVEL environment variable (debug/info/warn/error, default info).
 
 | Name | Arguments | Description |
 | ---- | --------- | ----------- |

--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -59,6 +59,11 @@ var sectionBlurb = map[string]struct{ title, desc string }{
 	"cli":                 {"cli", "Command-line option parsing (clojure/tools.cli style)."},
 	"integrity":           {"integrity", "Attest and verify lisp source (formatting, hashing, Ed25519 signatures, the lisp-integrity mode)."},
 	"regexp":              {"regexp", "Regular expressions (Go RE2): re-pattern, re-matches / re-find, re-seq, re-replace and re-split."},
+	"web":                 {"web", "Ring-style HTTP server: router, response helpers, middleware, JWT/mTLS identity."},
+	"git":                 {"git", "Git operations backed by go-git: init/clone/commit/push, tags, and SSH signature verification."},
+	"term":                {"term", "Terminal styling (ANSI colors, NO_COLOR-aware) and width detection."},
+	"test":                {"test", "Clojure-style unit testing: deftest / is / are; run with `lisp --test`."},
+	"log":                 {"log", "Structured logging: log-debug / log-info / log-warn / log-error emit records to systemd-journald (or $XDG_STATE_HOME/lisp/<script>.log without it), filtered by the LOG_LEVEL environment variable (debug/info/warn/error, default info)."},
 	"version":             {"version", "Build information of the running program (the version builtin)."},
 }
 


### PR DESCRIPTION
## Summary

- The generated reference showed **bare headings** for `web`, `git`, `term`, `test` and `log` (missing `sectionBlurb` entries). All five get a one-line description; the `log` one names the four level functions (`log-debug` / `log-info` / `log-warn` / `log-error`), the destination and the `LOG_LEVEL` filter, so the section is self-describing without reading the whole table.
- Running section: `--test` now says `*_test.lisp` (plus legacy `*_test.mal`), and a `lisp-integrity` pointer line links the separate binary to INTEGRITY.md.
- `LANGUAGE.md` regenerated; `TestLanguageDocUpToDate` green.

## Test plan

- `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)