### PR TITLE
feat(docgen): let an embedder document its own namespaces

### DIFF
--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -12,9 +12,10 @@
 //
 // A Go program that embeds the interpreter and adds namespaces of its
 // own can document them the same way by passing them as []Library to
-// MarkdownFor / SpliceFor / UpdateFileFor: they are loaded after the
-// standard libraries and rendered as further sections, so the embedder's
-// own LANGUAGE.md describes exactly the environment its binary builds.
+// MarkdownFor / SpliceFor / UpdateFileFor (and assert coverage with
+// SymbolsFor): they are loaded after the standard libraries and rendered
+// as further sections, so the embedder's own LANGUAGE.md describes
+// exactly the environment its binary builds.
 package docgen
 
 //go:generate go run ./gen.go -o ../LANGUAGE.md
@@ -99,9 +100,9 @@ func collect(extra []Library) ([]section, error) {
 	seen := map[string]bool{}
 	var sections []section
 
-	libs := standardLibraries()
-	for _, e := range extra {
-		libs = append(libs, library{name: e.Name, load: e.Load})
+	libs, err := mergeLibraries(extra)
+	if err != nil {
+		return nil, err
 	}
 	overrides := map[string]struct{ title, desc string }{}
 	for _, e := range extra {

--- a/docgen/docgen.go
+++ b/docgen/docgen.go
@@ -9,6 +9,12 @@
 // their arglist/doc in the types.Func value (attached with call.Doc);
 // lisp-defined functions and macros carry a docstring in their :doc
 // metadata and their parameter vector in the value itself.
+//
+// A Go program that embeds the interpreter and adds namespaces of its
+// own can document them the same way by passing them as []Library to
+// MarkdownFor / SpliceFor / UpdateFileFor: they are loaded after the
+// standard libraries and rendered as further sections, so the embedder's
+// own LANGUAGE.md describes exactly the environment its binary builds.
 package docgen
 
 //go:generate go run ./gen.go -o ../LANGUAGE.md
@@ -85,13 +91,24 @@ type section struct {
 
 // collect loads every library in order and returns one section per
 // library, each holding the symbols that library added to the
-// environment.
-func collect() ([]section, error) {
+// environment. extra are an embedder's libraries, documented after the
+// standard ones: they load last, so a symbol they rebind is still
+// attributed to the library that introduced it.
+func collect(extra []Library) ([]section, error) {
 	ns := env.NewEnv()
 	seen := map[string]bool{}
 	var sections []section
 
-	for _, lib := range standardLibraries() {
+	libs := standardLibraries()
+	for _, e := range extra {
+		libs = append(libs, library{name: e.Name, load: e.Load})
+	}
+	overrides := map[string]struct{ title, desc string }{}
+	for _, e := range extra {
+		overrides[e.Name] = struct{ title, desc string }{e.Title, e.Desc}
+	}
+
+	for _, lib := range libs {
 		if err := lib.load(ns); err != nil {
 			return nil, fmt.Errorf("load %q: %w", lib.name, err)
 		}
@@ -116,6 +133,9 @@ func collect() ([]section, error) {
 		sort.Slice(added, func(i, j int) bool { return added[i].name < added[j].name })
 
 		blurb := sectionBlurb[lib.name]
+		if o, ok := overrides[lib.name]; ok {
+			blurb.title, blurb.desc = o.title, o.desc
+		}
 		title := blurb.title
 		if title == "" {
 			title = lib.name
@@ -189,8 +209,12 @@ func malFuncDoc(f types.MalFunc) string {
 
 // Markdown renders the full generated reference block (without the
 // surrounding markers).
-func Markdown() (string, error) {
-	sections, err := collect()
+func Markdown() (string, error) { return MarkdownFor(nil) }
+
+// MarkdownFor renders the reference block for the standard libraries
+// plus an embedder's own, documented after them.
+func MarkdownFor(extra []Library) (string, error) {
+	sections, err := collect(extra)
 	if err != nil {
 		return "", err
 	}
@@ -275,7 +299,11 @@ func defaultDoc(doc string) string {
 // Splice replaces the text between BeginMarker and EndMarker in doc with
 // a freshly generated reference block, leaving the hand-written parts
 // untouched. It errors if the markers are missing or out of order.
-func Splice(doc string) (string, error) {
+func Splice(doc string) (string, error) { return SpliceFor(doc, nil) }
+
+// SpliceFor is Splice with an embedder's libraries documented alongside
+// the standard ones.
+func SpliceFor(doc string, extra []Library) (string, error) {
 	begin := strings.Index(doc, BeginMarker)
 	end := strings.Index(doc, EndMarker)
 	if begin == -1 || end == -1 {
@@ -284,7 +312,7 @@ func Splice(doc string) (string, error) {
 	if end < begin {
 		return "", fmt.Errorf("docgen: %q appears before %q", EndMarker, BeginMarker)
 	}
-	block, err := Markdown()
+	block, err := MarkdownFor(extra)
 	if err != nil {
 		return "", err
 	}
@@ -294,12 +322,16 @@ func Splice(doc string) (string, error) {
 // UpdateFile rewrites path in place, regenerating the block between the
 // markers. It is the entry point of the go:generate runner and reports
 // whether the file actually changed.
-func UpdateFile(path string) (changed bool, err error) {
+func UpdateFile(path string) (changed bool, err error) { return UpdateFileFor(path, nil) }
+
+// UpdateFileFor is UpdateFile with an embedder's libraries documented
+// alongside the standard ones.
+func UpdateFileFor(path string, extra []Library) (changed bool, err error) {
 	current, err := os.ReadFile(path)
 	if err != nil {
 		return false, err
 	}
-	updated, err := Splice(string(current))
+	updated, err := SpliceFor(string(current), extra)
 	if err != nil {
 		return false, err
 	}

--- a/docgen/docgen_test.go
+++ b/docgen/docgen_test.go
@@ -2,9 +2,12 @@ package docgen_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/jig/lisp/docgen"
+	"github.com/jig/lisp/lib/call"
+	"github.com/jig/lisp/types"
 )
 
 const langDoc = "../LANGUAGE.md"
@@ -36,5 +39,68 @@ func TestMarkdownRenders(t *testing.T) {
 	}
 	if len(md) < 1000 {
 		t.Fatalf("generated reference suspiciously short (%d bytes)", len(md))
+	}
+}
+
+// TestMarkdownForEmbedder checks the embedder path: an extra library is
+// rendered as its own section, with the title and description given, and
+// its symbols are attributed to it rather than to a standard library.
+func TestMarkdownForEmbedder(t *testing.T) {
+	load := func(ns types.EnvType) error {
+		call.CallOverrideFN(ns, "embedder-probe", embedderProbe)
+		call.Doc(ns, "embedder-probe", "[]", "Probe builtin used by the docgen test.")
+		return nil
+	}
+	md, err := docgen.MarkdownFor([]docgen.Library{{
+		Name:  "probe",
+		Load:  load,
+		Title: "probe",
+		Desc:  "Namespace added by an embedder.",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"### probe",
+		"Namespace added by an embedder.",
+		"embedder-probe",
+		"Probe builtin used by the docgen test.",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("generated reference is missing %q", want)
+		}
+	}
+
+	// Without the extra library none of it appears.
+	std, err := docgen.Markdown()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(std, "embedder-probe") {
+		t.Error("the standard reference must not contain the embedder's symbols")
+	}
+}
+
+func embedderProbe() (types.MalType, error) { return nil, nil }
+
+// TestSymbolsForIncludesEmbedder checks that SymbolsFor reports the
+// embedder's symbols on top of the standard ones.
+func TestSymbolsForIncludesEmbedder(t *testing.T) {
+	std, err := docgen.StandardSymbols()
+	if err != nil {
+		t.Fatal(err)
+	}
+	all, err := docgen.SymbolsFor([]docgen.Library{{
+		Name: "probe",
+		Load: func(ns types.EnvType) error {
+			call.CallOverrideFN(ns, "embedder-probe", embedderProbe)
+			return nil
+		},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != len(std)+1 {
+		t.Fatalf("SymbolsFor returned %d symbols, want %d", len(all), len(std)+1)
 	}
 }

--- a/docgen/docgen_test.go
+++ b/docgen/docgen_test.go
@@ -83,6 +83,34 @@ func TestMarkdownForEmbedder(t *testing.T) {
 
 func embedderProbe() (types.MalType, error) { return nil, nil }
 
+// TestMarkdownForRejectsBadLibraries pins the fail-closed guards: a
+// name colliding with a standard namespace (which would silently
+// hijack its section) and a nil loader both error instead of rendering.
+func TestMarkdownForRejectsBadLibraries(t *testing.T) {
+	noop := func(ns types.EnvType) error { return nil }
+	for _, tc := range []struct {
+		name string
+		lib  docgen.Library
+		want string
+	}{
+		{"standard-name collision", docgen.Library{Name: "log", Load: noop}, "collides"},
+		{"nil Load", docgen.Library{Name: "probe"}, "nil Load"},
+	} {
+		if _, err := docgen.MarkdownFor([]docgen.Library{tc.lib}); err == nil ||
+			!strings.Contains(err.Error(), tc.want) {
+			t.Errorf("%s: MarkdownFor = %v, want error containing %q", tc.name, err, tc.want)
+		}
+	}
+	// Duplicates within the extra list collide too.
+	dup := []docgen.Library{
+		{Name: "probe", Load: noop},
+		{Name: "probe", Load: noop},
+	}
+	if _, err := docgen.SymbolsFor(dup); err == nil || !strings.Contains(err.Error(), "collides") {
+		t.Errorf("duplicate extra names: SymbolsFor = %v, want a collision error", err)
+	}
+}
+
 // TestSymbolsForIncludesEmbedder checks that SymbolsFor reports the
 // embedder's symbols on top of the standard ones.
 func TestSymbolsForIncludesEmbedder(t *testing.T) {

--- a/docgen/libraries.go
+++ b/docgen/libraries.go
@@ -1,6 +1,8 @@
 package docgen
 
 import (
+	"fmt"
+
 	"github.com/jig/lisp/env"
 	"github.com/jig/lisp/lib/cli/nscli"
 	"github.com/jig/lisp/lib/concurrent/nsconcurrent"
@@ -73,14 +75,37 @@ func standardLibraries() []library {
 // the binary builds.
 func StandardSymbols() ([]string, error) { return SymbolsFor(nil) }
 
+// mergeLibraries appends an embedder's libraries to the standard list,
+// failing closed on a nil loader or a name that collides with a
+// namespace already listed (a silent collision would hijack that
+// section's heading and attribution).
+func mergeLibraries(extra []Library) ([]library, error) {
+	libs := standardLibraries()
+	names := map[string]bool{}
+	for _, l := range libs {
+		names[l.name] = true
+	}
+	for _, e := range extra {
+		if e.Load == nil {
+			return nil, fmt.Errorf("docgen: library %q has a nil Load", e.Name)
+		}
+		if names[e.Name] {
+			return nil, fmt.Errorf("docgen: library %q collides with an already listed namespace", e.Name)
+		}
+		names[e.Name] = true
+		libs = append(libs, library{name: e.Name, load: e.Load})
+	}
+	return libs, nil
+}
+
 // SymbolsFor is StandardSymbols with an embedder's libraries loaded too,
 // so an embedder can assert the same way that its reference documents
 // exactly the environment its binary builds.
 func SymbolsFor(extra []Library) ([]string, error) {
 	ns := env.NewEnv()
-	libs := standardLibraries()
-	for _, e := range extra {
-		libs = append(libs, library{name: e.Name, load: e.Load})
+	libs, err := mergeLibraries(extra)
+	if err != nil {
+		return nil, err
 	}
 	for _, lib := range libs {
 		if err := lib.load(ns); err != nil {

--- a/docgen/libraries.go
+++ b/docgen/libraries.go
@@ -27,6 +27,17 @@ type library struct {
 	load func(ns types.EnvType) error
 }
 
+// Library is a namespace an embedder wants documented alongside the
+// standard ones. Name identifies the library in the reference; Load
+// registers its symbols. Title and Desc override the section heading and
+// its one-line description, which otherwise fall back to Name and none.
+type Library struct {
+	Name  string
+	Load  func(ns types.EnvType) error
+	Title string
+	Desc  string
+}
+
 // standardLibraries lists the namespaces documented in LANGUAGE.md, in
 // load order. It deliberately mirrors cmd/lisp's own libraries() list so
 // the reference describes exactly what the binary ships; the two lists
@@ -60,9 +71,18 @@ func standardLibraries() []library {
 // names bound in the resulting environment. It exists so a test in the
 // cmd/lisp package can assert docgen documents exactly the environment
 // the binary builds.
-func StandardSymbols() ([]string, error) {
+func StandardSymbols() ([]string, error) { return SymbolsFor(nil) }
+
+// SymbolsFor is StandardSymbols with an embedder's libraries loaded too,
+// so an embedder can assert the same way that its reference documents
+// exactly the environment its binary builds.
+func SymbolsFor(extra []Library) ([]string, error) {
 	ns := env.NewEnv()
-	for _, lib := range standardLibraries() {
+	libs := standardLibraries()
+	for _, e := range extra {
+		libs = append(libs, library{name: e.Name, load: e.Load})
+	}
+	for _, lib := range libs {
 		if err := lib.load(ns); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
`LANGUAGE.md` is generated from the live interpreter so it cannot drift from the code — but that only worked for jig/lisp itself. `collect` walked a private, fixed list of libraries with no way in, so a Go program that embeds the interpreter and adds namespaces of its own had to choose between a hand-written reference that goes stale and duplicating the walk and the renderer.

## What this adds

`MarkdownFor`, `SpliceFor`, `UpdateFileFor` and `SymbolsFor`, taking the embedder's namespaces as `[]Library`:

```go
docgen.UpdateFileFor("LANGUAGE.md", []docgen.Library{
    {Name: "phasnoo", Load: nsphasnoo.Load, Title: "phasnoo", Desc: "PKI and X.509: keys, CSRs, certificates, CRLs…"},
})
```

The extra libraries load **after** the standard ones, so a symbol an embedder rebinds is still attributed to the library that introduced it. Each becomes its own section, with the title and description given.

`SymbolsFor` is there so an embedder can make the same assertion `cmd/lisp` does — that the reference documents exactly the environment its binary builds.

## Compatibility

The four existing functions delegate with a `nil` list, so behaviour is unchanged:

- `go generate ./...` regenerates `LANGUAGE.md` **byte-identical** (verified)
- `TestLanguageDocUpToDate` passes untouched
- full suite green (34 packages)

## Tests

Two new ones covering the embedder path: that an extra library is rendered as its own section with its title, description and documented builtins, that the standard reference does *not* contain them, and that `SymbolsFor` reports the embedder's symbols on top of the standard ones.

## Why

`pking/lisp` ships the interpreter with the PKIHub libraries pre-loaded — 52 documented builtins across PHASNoo, ZLint and BadKeys. With this it generates its own `LANGUAGE.md` covering both sets, in the same format and with the same staleness test, instead of a copy that silently ages.
