### PR TITLE
feat(bat): detect extensionless scripts by shebang

### DIFF
--- a/tools/bat/jig-lisp.sublime-syntax
+++ b/tools/bat/jig-lisp.sublime-syntax
@@ -6,6 +6,9 @@
 name: jig/lisp
 file_extensions:
   - lisp
+# Extensionless scripts are recognised by their shebang (lisp or
+# lisp-integrity as the interpreter, directly or via env).
+first_line_match: '^#!.*\blisp(-integrity)?\b'
 scope: source.lisp
 
 contexts:


### PR DESCRIPTION
## Summary

The installed sublime-syntax only declared `file_extensions: [lisp]`, so an extensionless script with a `#!/usr/bin/env lisp` shebang rendered plain. A `first_line_match` (`^#!.*\blisp(-integrity)?\b`) makes bat's syntect engine pick the jig/lisp syntax for those — covering `lisp` and `lisp-integrity` as interpreters, direct or via `env`. Re-run `lisp --install-bat-syntax` to pick it up.

## Test plan

- `go test ./tools/bat/` green (install/idempotence unaffected — content-based).
- Verified live: after reinstalling the syntax, `bat` output for an extensionless shebang script is byte-identical to `bat -l lisp` on the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)