### PR TITLE
Make state-save atomic on signing failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,13 @@ value did not parse, deferring the failure to an unrelated error deep
 inside the program; it now returns a read error naming the
 placeholder.
 
+### Fixed — `state-save` signing failures are atomic
+
+With an allowed-signers policy active, `state-save` now rolls back the
+temporary unsigned commit, index entry and `.state/` file write when SSH
+signing fails. A missing authorised ssh-agent key therefore returns an
+error without wedging the checkout at an unsigned state commit.
+
 ### Migration (embedders — Go code using jig/lisp)
 
 Scripts and lisp data files need no changes. Go code embedding the

--- a/INTEGRITY.md
+++ b/INTEGRITY.md
@@ -162,7 +162,7 @@ journalctl -t <script> TRACE_ID=<id> -o json
 |---|---|
 | `(assert-integrity)` | Throws unless running under `lisp-integrity`; returns the verified commit hash. Committed code uses it to demand the mode — effective as long as operators know the program is supposed to carry it. |
 | `(assert-integrity :with-signature)` | Additionally throws unless startup rule 3 was applied (an `/etc/lisp/allowed_signers` file existed and the chain verified). For code that must not run unsigned even on hosts lacking the keys file. |
-| `(state-save name value & [message])` | Writes `value` as canonical lisp data to `.state/name.lisp` and **commits it in the same operation**; returns the commit hash. The commit `message` defaults to `state: name`. With an allowed-signers set active, the commit is SSH-signed via ssh-agent (no per-call key). Saving an unchanged value is a no-op returning the current commit. Works with or without the mode; requires a Git repository. |
+| `(state-save name value & [message])` | Writes `value` as canonical lisp data to `.state/name.lisp` and **commits it in the same operation**; returns the commit hash. The commit `message` defaults to `state: name`. With an allowed-signers set active, the commit is SSH-signed via ssh-agent (no per-call key), and signing failure rolls the repository back to its pre-save HEAD, index and state file. Saving an unchanged value is a no-op returning the current commit. Works with or without the mode; requires a Git repository. |
 | `(state-load name)` / `(state-load name default)` | Reads the state back as pure data (READ, never EVAL — state cannot smuggle code). Returns `default`, or throws without one, when the state does not exist. Under the mode, enforces invariant 5. |
 | `(slurp-source path)` | `slurp` for files about to be evaluated: identical, plus invariant 4 under the mode. `load-file` builds on it. |
 
@@ -204,7 +204,10 @@ integrity envelope:
   inside `state-save`. Committed state is therefore always the product
   of a completed save. State commits are authored `state-save
   <state-save@lisp>`; they are Git-compatible SSH-signed when an
-  allowed-signers set is active (ssh-agent key), unsigned otherwise.
+  allowed-signers set is active (ssh-agent key), unsigned otherwise. If
+  that signing step fails, `state-save` restores the pre-save HEAD,
+  index and state file before returning the error, so an unsigned state
+  commit is not left at `HEAD`.
 - **Crash recovery** — a save interrupted between write and commit
   leaves the file differing from `HEAD`; the next `state-load` under
   the mode fails closed and the operator resolves it (commit the

--- a/lib/integrity/mode_test.go
+++ b/lib/integrity/mode_test.go
@@ -5,8 +5,10 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -535,6 +537,120 @@ func TestStateSaveSignedCommit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStateSaveRollsBackWhenSigningFails(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, _ := setupRepo(t, ns, "")
+	t.Chdir(dir)
+
+	first := evalLisp(t, ns, `(state-save "db" {:n 1})`).(string)
+	statePath := filepath.Join(dir, ".state", "db.lisp")
+	originalState, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalIndexData := indexBlobContents(t, repo, ".state/db.lisp")
+
+	libgit.SetSigner(func() (gossh.Signer, error) {
+		return nil, errors.New("no ssh-agent key is listed in the allowed signers")
+	})
+	t.Cleanup(libgit.ClearSigner)
+
+	if err := evalErr(t, ns, `(state-save "db" {:n 2})`); !strings.Contains(err.Error(), "sign commit") {
+		t.Fatalf("state-save with failing signer = %v, want sign commit error", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if head.Hash().String() != first {
+		t.Fatalf("HEAD = %s, want pre-save commit %s", head.Hash(), first)
+	}
+	restoredState, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(restoredState) != string(originalState) {
+		t.Fatalf("worktree state = %q, want restored %q", restoredState, originalState)
+	}
+	if got := indexBlobContents(t, repo, ".state/db.lisp"); got != originalIndexData {
+		t.Fatalf("index state = %q, want restored %q", got, originalIndexData)
+	}
+
+	// Re-saving the unchanged value remains a no-op and does not require a signer.
+	if got := evalLisp(t, ns, `(state-save "db" {:n 1})`).(string); got != first {
+		t.Fatalf("unchanged save = %s, want existing HEAD %s", got, first)
+	}
+}
+
+func TestStateSaveRemovesNewStateFileWhenSigningFails(t *testing.T) {
+	ns := newGitEnv(t)
+	dir, release := setupRepo(t, ns, "")
+	t.Chdir(dir)
+	repo, err := gogit.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	libgit.SetSigner(func() (gossh.Signer, error) {
+		return nil, errors.New("no ssh-agent key is listed in the allowed signers")
+	})
+	t.Cleanup(libgit.ClearSigner)
+
+	if err := evalErr(t, ns, `(state-save "db" {:n 1})`); !strings.Contains(err.Error(), "sign commit") {
+		t.Fatalf("state-save with failing signer = %v, want sign commit error", err)
+	}
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if head.Hash().String() != release {
+		t.Fatalf("HEAD = %s, want release commit %s", head.Hash(), release)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".state", "db.lisp")); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("state file after rollback = %v, want absent", err)
+	}
+	idx, err := repo.Storer.Index()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := idx.Entry(".state/db.lisp"); err == nil {
+		t.Fatal("index still contains rolled-back state file")
+	}
+}
+
+func indexBlobContents(t *testing.T, repo *gogit.Repository, path string) string {
+	t.Helper()
+	idx, err := repo.Storer.Index()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := idx.Entry(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, err := repo.BlobObject(entry.Hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rd, err := blob.Reader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(rd)
+	if closeErr := rd.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }
 
 // TestStateSaveIdempotentUnchanged verifies that saving a byte-identical

--- a/lib/integrity/state.go
+++ b/lib/integrity/state.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	gogit "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	gitindex "github.com/go-git/go-git/v6/plumbing/format/index"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/jig/lisp/internal/gogitutil"
 	libgit "github.com/jig/lisp/lib/git"
@@ -117,6 +119,10 @@ func state_save(name string, value MalType, params ...MalType) (MalType, error) 
 	}
 
 	abs := filepath.Join(root, filepath.FromSlash(rel))
+	snapshot, err := newStateSaveSnapshot(repo, abs)
+	if err != nil {
+		return nil, fmt.Errorf("state-save: %w", err)
+	}
 	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
 		return nil, fmt.Errorf("state-save: %w", err)
 	}
@@ -155,9 +161,160 @@ func state_save(name string, value MalType, params ...MalType) (MalType, error) 
 	// Sign the state commit when the allowed signers installed a signing
 	// policy (ssh-agent key); a no-op otherwise.
 	if hash, err = libgit.SignCommitIfPolicy(repo, hash); err != nil {
+		if rollbackErr := snapshot.restore(repo, abs); rollbackErr != nil {
+			return nil, fmt.Errorf("state-save: sign commit: %w (rollback failed: %v)", err, rollbackErr)
+		}
 		return nil, fmt.Errorf("state-save: sign commit: %w", err)
 	}
 	return hash.String(), nil
+}
+
+type stateSaveSnapshot struct {
+	head      *plumbing.Reference
+	headHash  plumbing.Hash
+	hasHead   bool
+	index     *gitindex.Index
+	file      stateFileSnapshot
+	emptyDirs []string
+}
+
+type stateFileSnapshot struct {
+	exists bool
+	data   []byte
+	mode   fs.FileMode
+}
+
+func newStateSaveSnapshot(repo *gogit.Repository, abs string) (*stateSaveSnapshot, error) {
+	directHead, err := repo.Storer.Reference(plumbing.HEAD)
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return nil, err
+	}
+	resolvedHead, err := repo.Head()
+	hasHead := err == nil
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return nil, err
+	}
+	var headHash plumbing.Hash
+	if hasHead {
+		headHash = resolvedHead.Hash()
+	}
+	idx, err := repo.Storer.Index()
+	if err != nil {
+		return nil, err
+	}
+	file, err := snapshotStateFile(abs)
+	if err != nil {
+		return nil, err
+	}
+	return &stateSaveSnapshot{
+		head:      directHead,
+		headHash:  headHash,
+		hasHead:   hasHead,
+		index:     cloneIndex(idx),
+		file:      file,
+		emptyDirs: missingStateParents(abs),
+	}, nil
+}
+
+func snapshotStateFile(abs string) (stateFileSnapshot, error) {
+	info, err := os.Stat(abs)
+	if errors.Is(err, fs.ErrNotExist) {
+		return stateFileSnapshot{}, nil
+	}
+	if err != nil {
+		return stateFileSnapshot{}, err
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return stateFileSnapshot{}, err
+	}
+	return stateFileSnapshot{exists: true, data: data, mode: info.Mode().Perm()}, nil
+}
+
+func cloneIndex(idx *gitindex.Index) *gitindex.Index {
+	if idx == nil {
+		return nil
+	}
+	clone := *idx
+	clone.Entries = make([]*gitindex.Entry, len(idx.Entries))
+	for i, entry := range idx.Entries {
+		if entry == nil {
+			continue
+		}
+		entryClone := *entry
+		clone.Entries[i] = &entryClone
+	}
+	return &clone
+}
+
+func missingStateParents(abs string) []string {
+	var dirs []string
+	for dir := filepath.Dir(abs); ; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(dir); errors.Is(err, fs.ErrNotExist) {
+			dirs = append(dirs, dir)
+		}
+		if filepath.Base(dir) == stateDir {
+			break
+		}
+		if parent := filepath.Dir(dir); parent == dir {
+			break
+		}
+	}
+	return dirs
+}
+
+func (s *stateSaveSnapshot) restore(repo *gogit.Repository, abs string) error {
+	var errs []error
+	if err := s.restoreHead(repo); err != nil {
+		errs = append(errs, fmt.Errorf("HEAD: %w", err))
+	}
+	if err := repo.Storer.SetIndex(s.index); err != nil {
+		errs = append(errs, fmt.Errorf("index: %w", err))
+	}
+	if err := s.restoreFile(abs); err != nil {
+		errs = append(errs, fmt.Errorf("worktree: %w", err))
+	}
+	return errors.Join(errs...)
+}
+
+func (s *stateSaveSnapshot) restoreHead(repo *gogit.Repository) error {
+	if s.head == nil {
+		return nil
+	}
+	name := s.head.Name()
+	if s.head.Type() == plumbing.SymbolicReference {
+		name = s.head.Target()
+		if err := repo.Storer.SetReference(s.head); err != nil {
+			return err
+		}
+	}
+	if s.hasHead {
+		return repo.Storer.SetReference(plumbing.NewHashReference(name, s.headHash))
+	}
+	return repo.Storer.RemoveReference(name)
+}
+
+func (s *stateSaveSnapshot) restoreFile(abs string) error {
+	if s.file.exists {
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(abs, s.file.data, s.file.mode)
+	}
+	if err := os.Remove(abs); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	for _, dir := range s.emptyDirs {
+		if err := os.Remove(dir); err != nil && !errors.Is(err, fs.ErrNotExist) && !dirHasEntries(dir) {
+			return err
+		}
+	}
+	return nil
+}
+
+func dirHasEntries(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	return err == nil && len(entries) > 0
 }
 
 func state_load(name string, defaultValue ...MalType) (MalType, error) {


### PR DESCRIPTION
## Summary

`state-save` wrote `.state/<name>.lisp`, committed it unsigned, and only then rewrote that commit with an SSH signature. With `/etc/lisp/allowed_signers` active but ssh-agent lacking a listed key, signing failed after the unsigned state commit was already at `HEAD`.

## Reproduction and impact

Reproduce with a signed release commit whose key is listed in `/etc/lisp/allowed_signers`, then run `(state-save "ca" [1 2 3])` under `lisp-integrity` while ssh-agent only holds an unlisted key. The command errors with `state-save: sign commit: no ssh-agent key is listed in the allowed signers`, but the temporary unsigned `state: ca` commit remains at `HEAD`.

That wedges the checkout: subsequent `lisp-integrity` runs fail closed because the state commit is unsigned. This is a denial of service by anyone who can write to the working copy, but not an integrity break because unsigned state is still never accepted.

## Fix

`state-save` now snapshots the pre-save HEAD, index, existing state file, and any newly-created `.state/` parent directories before writing. It still creates the commit before signing so the existing `gogit.ErrEmptyCommit` no-op path keeps returning the current HEAD without requiring a signer. If `SignCommitIfPolicy` fails, the snapshot is restored, making the unsigned commit unreachable and returning the worktree/index state to what the operator had before retrying.

`INTEGRITY.md` and `CHANGELOG.md` document the rollback behavior.

## Verification

- Added regression tests covering signing failure while replacing an existing state file and while creating a new state file.
- Confirmed the new rollback test failed before the fix: `HEAD = 74e9025..., want pre-save commit c269b3...`.
- `go test ./lib/integrity -run 'TestStateSaveRollsBackWhenSigningFails|TestStateSaveRemovesNewStateFileWhenSigningFails' -count=1`
- `go test ./...`