### PR TITLE
fix(git): roll back git-commit and git-tag on signing failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,10 @@ With an allowed-signers policy active, `state-save` now rolls back the
 temporary unsigned commit, index entry and `.state/` file write when SSH
 signing fails. A missing authorised ssh-agent key therefore returns an
 error without wedging the checkout at an unsigned state commit.
+`git-commit` and annotated `git-tag` get the same guarantee: a signing
+failure restores HEAD and the index (the staged changes survive for a
+retry) or deletes the just-created tag, instead of leaving unsigned
+objects that every subsequent verified run would refuse.
 
 ### Migration (embedders — Go code using jig/lisp)
 

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -520,7 +520,7 @@ Git operations backed by go-git: init/clone/commit/push, tags, and SSH signature
 | `git-checkout` | `[repo ref & {:create :force}]` | Checks out a branch, tag or revision; :create true creates the branch first. |
 | `git-clone` | `[url path & {:auth :branch :depth :single-branch :bare}]` | Clones url into path and returns a handle; see git-push for the :auth map. |
 | `git-close` | `[repo]` | Closes a repository handle. |
-| `git-commit` | `[repo msg & {:author {:name :email} :committer :all :allow-empty :amend}]` | Commits staged changes and returns the commit map. When an allowed-signers set is active the commit is SSH-signed with the ssh-agent key listed there; otherwise it is unsigned (there is no per-call key option). |
+| `git-commit` | `[repo msg & {:author {:name :email} :committer :all :allow-empty :amend}]` | Commits staged changes and returns the commit map. When an allowed-signers set is active the commit is SSH-signed with the ssh-agent key listed there (a signing failure rolls HEAD and the index back); otherwise it is unsigned (there is no per-call key option). |
 | `git-fetch` | `[repo & {:auth :remote :refspecs :depth :prune :force}]` | Fetches from :remote (default origin); returns :ok or :up-to-date. |
 | `git-head` | `[repo]` | Returns {:name :branch :hash} for HEAD. |
 | `git-init` | `[path & {:bare :object-format}]` | Creates a repository at path and returns a handle; :object-format "sha256" for a SHA-256 repo. |
@@ -532,7 +532,7 @@ Git operations backed by go-git: init/clone/commit/push, tags, and SSH signature
 | `git-remotes` | `[repo]` | Returns a vector of {:name :urls} for the configured remotes. |
 | `git-show` | `[repo rev]` | Returns the commit map for rev (hash, "HEAD", branch or tag name). |
 | `git-status` | `[repo]` | Returns {:clean bool :files {path {:staging kw :worktree kw}}} for the worktree. |
-| `git-tag` | `[repo name & {:at :message :tagger {:name :email}}]` | Creates a tag at HEAD (or :at rev); :message makes it annotated. When an allowed-signers set is active an annotated tag is SSH-signed with the ssh-agent key listed there. |
+| `git-tag` | `[repo name & {:at :message :tagger {:name :email}}]` | Creates a tag at HEAD (or :at rev); :message makes it annotated. When an allowed-signers set is active an annotated tag is SSH-signed with the ssh-agent key listed there (a signing failure deletes the tag again). |
 | `git-tag-verified?` | `[repo name allowed-keys]` | (git-tag-verified? repo name allowed-keys) is true when the tag's SSH signature verifies against allowed-keys. |
 | `git-tags` | `[repo]` | Returns a vector of {:name :hash :target :annotated} for all tags. |
 | `git-verified?` | `[repo rev allowed-keys]` | (git-verified? repo rev allowed-keys) is true when the commit's SSH signature verifies against allowed-keys. |

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -98,7 +98,7 @@ func Load(env EnvType) {
 	call.Doc(env, "git-add", "[repo path & {:all :glob}]",
 		"Stages path (\".\" for everything); :all true stages all modified/deleted files, :glob true treats path as a glob pattern.")
 	call.Doc(env, "git-commit", "[repo msg & {:author {:name :email} :committer :all :allow-empty :amend}]",
-		"Commits staged changes and returns the commit map. When an allowed-signers set is active the commit is SSH-signed with the ssh-agent key listed there; otherwise it is unsigned (there is no per-call key option).")
+		"Commits staged changes and returns the commit map. When an allowed-signers set is active the commit is SSH-signed with the ssh-agent key listed there (a signing failure rolls HEAD and the index back); otherwise it is unsigned (there is no per-call key option).")
 	call.Doc(env, "git-log", "[repo & {:max :from :all :path}]",
 		"Returns a vector of commit maps from HEAD (or :from rev), newest first.")
 	call.Doc(env, "git-show", "[repo rev]",
@@ -114,7 +114,7 @@ func Load(env EnvType) {
 	call.Doc(env, "git-checkout", "[repo ref & {:create :force}]",
 		"Checks out a branch, tag or revision; :create true creates the branch first.")
 	call.Doc(env, "git-tag", "[repo name & {:at :message :tagger {:name :email}}]",
-		"Creates a tag at HEAD (or :at rev); :message makes it annotated. When an allowed-signers set is active an annotated tag is SSH-signed with the ssh-agent key listed there.")
+		"Creates a tag at HEAD (or :at rev); :message makes it annotated. When an allowed-signers set is active an annotated tag is SSH-signed with the ssh-agent key listed there (a signing failure deletes the tag again).")
 	call.Doc(env, "git-tags", "[repo]",
 		"Returns a vector of {:name :hash :target :annotated} for all tags.")
 	call.Doc(env, "git-remote-add", "[repo name url]",
@@ -305,6 +305,10 @@ func gitCommit(rv MalType, msg string, params ...MalType) (MalType, error) {
 	if err != nil {
 		return nil, err
 	}
+	snapshot, err := NewRepoSnapshot(r.repo)
+	if err != nil {
+		return nil, err
+	}
 	hash, err := wt.Commit(msg, commitOpts)
 	if err != nil {
 		return nil, err
@@ -313,8 +317,13 @@ func gitCommit(rv MalType, msg string, params ...MalType) (MalType, error) {
 	// the ssh-agent), never a per-call key. It is done after the fact
 	// (see resignCommit) so the signature lands in the header matching
 	// the repo's object format; go-git's own Signer always writes gpgsig.
+	// A signing failure rolls HEAD and the index back so the unsigned
+	// commit is not left behind (it would wedge every verified run).
 	if hash, err = signCommitIfPolicy(r, hash); err != nil {
-		return nil, err
+		if rollbackErr := snapshot.Restore(r.repo); rollbackErr != nil {
+			return nil, fmt.Errorf("git-commit: sign: %w (rollback failed: %v)", err, rollbackErr)
+		}
+		return nil, fmt.Errorf("git-commit: sign: %w", err)
 	}
 	c, err := r.repo.CommitObject(hash)
 	if err != nil {
@@ -594,10 +603,14 @@ func gitTag(rv MalType, name string, params ...MalType) (MalType, error) {
 		return nil, err
 	}
 	// Only annotated tags carry a signature; a lightweight tag is just a
-	// ref and is left unsigned even when a signing policy is active.
+	// ref and is left unsigned even when a signing policy is active. A
+	// signing failure deletes the just-created unsigned tag.
 	if annotated {
 		if ref, err = signTagIfPolicy(r, ref); err != nil {
-			return nil, err
+			if rollbackErr := r.repo.DeleteTag(name); rollbackErr != nil {
+				return nil, fmt.Errorf("git-tag: sign: %w (rollback failed: %v)", err, rollbackErr)
+			}
+			return nil, fmt.Errorf("git-tag: sign: %w", err)
 		}
 	}
 	return HashMap{Items: map[MalType]MalType{

--- a/lib/git/git_test.go
+++ b/lib/git/git_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -383,4 +384,80 @@ func TestGitCLIInterop(t *testing.T) {
 			}
 		})
 	}
+}
+
+// failSigning installs a signing policy whose resolution always fails —
+// the shape of an ssh-agent without any allowed key — and clears it
+// when the (sub)test ends.
+func failSigning(t *testing.T) {
+	t.Helper()
+	libgit.SetSigner(func() (gossh.Signer, error) {
+		return nil, errors.New("no ssh-agent key is listed in the allowed signers")
+	})
+	t.Cleanup(libgit.ClearSigner)
+}
+
+// TestCommitRollsBackWhenSigningFails pins git-commit's atomicity: a
+// signing failure must leave HEAD and the staged index exactly as
+// before the call, on a branch and on a detached HEAD.
+func TestCommitRollsBackWhenSigningFails(t *testing.T) {
+	ns := newEnv(t)
+	dir := t.TempDir()
+	eval(t, ns, fmt.Sprintf(`(def r (git-init %q))`, dir))
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	eval(t, ns, `(git-add r "a.txt")`)
+	first := eval(t, ns, `(get (git-commit r "first" {:author `+author+`}) :hash)`).(string)
+
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("two\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	eval(t, ns, `(git-add r "a.txt")`)
+
+	failSigning(t)
+	expectThrow(t, ns, `(git-commit r "second" {:author `+author+`})`)
+	expectTrue(t, ns, fmt.Sprintf(`(= %q (get (git-head r) :hash))`, first))
+
+	// The staged change survived the rollback: fixing the agent and
+	// retrying commits it.
+	libgit.ClearSigner()
+	second := eval(t, ns, `(get (git-commit r "second" {:author `+author+`}) :hash)`).(string)
+	if second == first {
+		t.Fatal("retry after rollback did not commit the staged change")
+	}
+
+	// Detached HEAD: same guarantee.
+	eval(t, ns, fmt.Sprintf(`(git-checkout r %q)`, first))
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("three\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	eval(t, ns, `(git-add r "a.txt")`)
+	failSigning(t)
+	expectThrow(t, ns, `(git-commit r "third" {:author `+author+`})`)
+	expectTrue(t, ns, fmt.Sprintf(`(= %q (get (git-head r) :hash))`, first))
+}
+
+// TestTagRollsBackWhenSigningFails pins git-tag's atomicity: a signing
+// failure must not leave an unsigned annotated tag behind.
+func TestTagRollsBackWhenSigningFails(t *testing.T) {
+	ns := newEnv(t)
+	dir := t.TempDir()
+	eval(t, ns, fmt.Sprintf(`(def r (git-init %q))`, dir))
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	eval(t, ns, `(git-add r "a.txt")`)
+	eval(t, ns, `(git-commit r "first" {:author `+author+`})`)
+
+	failSigning(t)
+	expectThrow(t, ns, `(git-tag r "v1" {:message "rel" :tagger `+author+`})`)
+	expectTrue(t, ns, `(= [] (git-tags r))`)
+
+	// A lightweight tag never signs, so it succeeds under the failing
+	// policy; retrying the annotated one after fixing the agent works.
+	eval(t, ns, `(git-tag r "lw")`)
+	libgit.ClearSigner()
+	eval(t, ns, `(git-tag r "v1" {:message "rel" :tagger `+author+`})`)
+	expectTrue(t, ns, `(= 2 (count (git-tags r)))`)
 }

--- a/lib/git/snapshot.go
+++ b/lib/git/snapshot.go
@@ -1,0 +1,102 @@
+package git
+
+// RepoSnapshot captures HEAD and the index so an operation that
+// commits before signing (git-commit, state-save) can roll back to the
+// pre-operation state when the signing step fails — instead of leaving
+// an unsigned commit at HEAD, which an allowed-signers policy would
+// then refuse on every subsequent verified run.
+
+import (
+	"errors"
+	"fmt"
+
+	gogit "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	gitindex "github.com/go-git/go-git/v6/plumbing/format/index"
+)
+
+// RepoSnapshot is the pre-operation HEAD and index of a repository.
+type RepoSnapshot struct {
+	head     *plumbing.Reference
+	headHash plumbing.Hash
+	hasHead  bool
+	index    *gitindex.Index
+}
+
+// NewRepoSnapshot captures the repository's current HEAD (symbolic,
+// detached or unborn) and a copy of its index.
+func NewRepoSnapshot(repo *gogit.Repository) (*RepoSnapshot, error) {
+	directHead, err := repo.Storer.Reference(plumbing.HEAD)
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return nil, err
+	}
+	resolvedHead, err := repo.Head()
+	hasHead := err == nil
+	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
+		return nil, err
+	}
+	var headHash plumbing.Hash
+	if hasHead {
+		headHash = resolvedHead.Hash()
+	}
+	idx, err := repo.Storer.Index()
+	if err != nil {
+		return nil, err
+	}
+	return &RepoSnapshot{
+		head:     directHead,
+		headHash: headHash,
+		hasHead:  hasHead,
+		index:    cloneIndex(idx),
+	}, nil
+}
+
+// Restore puts HEAD and the index back to the snapshot. The rolled-back
+// commit object stays in the object store, unreachable.
+func (s *RepoSnapshot) Restore(repo *gogit.Repository) error {
+	var errs []error
+	if err := s.restoreHead(repo); err != nil {
+		errs = append(errs, fmt.Errorf("HEAD: %w", err))
+	}
+	if err := repo.Storer.SetIndex(s.index); err != nil {
+		errs = append(errs, fmt.Errorf("index: %w", err))
+	}
+	return errors.Join(errs...)
+}
+
+func (s *RepoSnapshot) restoreHead(repo *gogit.Repository) error {
+	if s.head == nil {
+		return nil
+	}
+	name := s.head.Name()
+	if s.head.Type() == plumbing.SymbolicReference {
+		name = s.head.Target()
+		if err := repo.Storer.SetReference(s.head); err != nil {
+			return err
+		}
+	}
+	if s.hasHead {
+		return repo.Storer.SetReference(plumbing.NewHashReference(name, s.headHash))
+	}
+	return repo.Storer.RemoveReference(name)
+}
+
+// cloneIndex copies the index entries; the cached-tree extension is
+// dropped rather than shared, so a restore never writes a stale TREE
+// extension mutated by the rolled-back operation.
+func cloneIndex(idx *gitindex.Index) *gitindex.Index {
+	if idx == nil {
+		return nil
+	}
+	clone := *idx
+	clone.Cache = nil
+	clone.Entries = make([]*gitindex.Entry, len(idx.Entries))
+	for i, entry := range idx.Entries {
+		if entry == nil {
+			continue
+		}
+		entryClone := *entry
+		clone.Entries[i] = &entryClone
+	}
+	return &clone
+}

--- a/lib/integrity/state.go
+++ b/lib/integrity/state.go
@@ -22,8 +22,6 @@ import (
 	"time"
 
 	gogit "github.com/go-git/go-git/v6"
-	"github.com/go-git/go-git/v6/plumbing"
-	gitindex "github.com/go-git/go-git/v6/plumbing/format/index"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/jig/lisp/internal/gogitutil"
 	libgit "github.com/jig/lisp/lib/git"
@@ -170,10 +168,7 @@ func state_save(name string, value MalType, params ...MalType) (MalType, error) 
 }
 
 type stateSaveSnapshot struct {
-	head      *plumbing.Reference
-	headHash  plumbing.Hash
-	hasHead   bool
-	index     *gitindex.Index
+	repo      *libgit.RepoSnapshot
 	file      stateFileSnapshot
 	emptyDirs []string
 }
@@ -185,20 +180,7 @@ type stateFileSnapshot struct {
 }
 
 func newStateSaveSnapshot(repo *gogit.Repository, abs string) (*stateSaveSnapshot, error) {
-	directHead, err := repo.Storer.Reference(plumbing.HEAD)
-	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
-		return nil, err
-	}
-	resolvedHead, err := repo.Head()
-	hasHead := err == nil
-	if err != nil && !errors.Is(err, plumbing.ErrReferenceNotFound) {
-		return nil, err
-	}
-	var headHash plumbing.Hash
-	if hasHead {
-		headHash = resolvedHead.Hash()
-	}
-	idx, err := repo.Storer.Index()
+	repoSnap, err := libgit.NewRepoSnapshot(repo)
 	if err != nil {
 		return nil, err
 	}
@@ -207,10 +189,7 @@ func newStateSaveSnapshot(repo *gogit.Repository, abs string) (*stateSaveSnapsho
 		return nil, err
 	}
 	return &stateSaveSnapshot{
-		head:      directHead,
-		headHash:  headHash,
-		hasHead:   hasHead,
-		index:     cloneIndex(idx),
+		repo:      repoSnap,
 		file:      file,
 		emptyDirs: missingStateParents(abs),
 	}, nil
@@ -231,22 +210,6 @@ func snapshotStateFile(abs string) (stateFileSnapshot, error) {
 	return stateFileSnapshot{exists: true, data: data, mode: info.Mode().Perm()}, nil
 }
 
-func cloneIndex(idx *gitindex.Index) *gitindex.Index {
-	if idx == nil {
-		return nil
-	}
-	clone := *idx
-	clone.Entries = make([]*gitindex.Entry, len(idx.Entries))
-	for i, entry := range idx.Entries {
-		if entry == nil {
-			continue
-		}
-		entryClone := *entry
-		clone.Entries[i] = &entryClone
-	}
-	return &clone
-}
-
 func missingStateParents(abs string) []string {
 	var dirs []string
 	for dir := filepath.Dir(abs); ; dir = filepath.Dir(dir) {
@@ -265,33 +228,13 @@ func missingStateParents(abs string) []string {
 
 func (s *stateSaveSnapshot) restore(repo *gogit.Repository, abs string) error {
 	var errs []error
-	if err := s.restoreHead(repo); err != nil {
-		errs = append(errs, fmt.Errorf("HEAD: %w", err))
-	}
-	if err := repo.Storer.SetIndex(s.index); err != nil {
-		errs = append(errs, fmt.Errorf("index: %w", err))
+	if err := s.repo.Restore(repo); err != nil {
+		errs = append(errs, err)
 	}
 	if err := s.restoreFile(abs); err != nil {
 		errs = append(errs, fmt.Errorf("worktree: %w", err))
 	}
 	return errors.Join(errs...)
-}
-
-func (s *stateSaveSnapshot) restoreHead(repo *gogit.Repository) error {
-	if s.head == nil {
-		return nil
-	}
-	name := s.head.Name()
-	if s.head.Type() == plumbing.SymbolicReference {
-		name = s.head.Target()
-		if err := repo.Storer.SetReference(s.head); err != nil {
-			return err
-		}
-	}
-	if s.hasHead {
-		return repo.Storer.SetReference(plumbing.NewHashReference(name, s.headHash))
-	}
-	return repo.Storer.RemoveReference(name)
 }
 
 func (s *stateSaveSnapshot) restoreFile(abs string) error {


### PR DESCRIPTION
## Summary

Follow-up to #156, extending the same atomicity to the git builtins (flagged in its review): `git-commit` and annotated `git-tag` create the object unsigned and re-sign afterwards, so with an allowed-signers policy active and an agent without a listed key, a failure left an unsigned commit at `HEAD` — which becomes the anchor every subsequent `lisp-integrity` run refuses (same DoS shape as the state-save case) — or a stray unsigned tag.

- **`lib/git.RepoSnapshot`**: the HEAD+index snapshot/restore moves out of `state.go` into `lib/git`, exported, covering symbolic, detached and unborn HEAD identically for both callers; `state-save` now delegates to it (its file/dirs handling stays local).
- `cloneIndex` also **drops the cached-tree extension** instead of sharing the pointer, so a restore can never write a TREE extension mutated by the rolled-back operation (nit #2 from the #156 review).
- `git-commit`: signing failure restores HEAD and the index — **staged changes survive**, so fixing the agent and retrying just works.
- `git-tag`: signing failure deletes the just-created unsigned tag; lightweight tags are unaffected (they never sign).
- Docstrings note the rollback (`LANGUAGE.md` regenerated); CHANGELOG's 0.6.0 atomicity entry extended.

## Test plan

- `go test ./...` green; gofmt/vet clean; the #156 state-save rollback tests keep passing through the shared helper.
- New tests: commit rollback on a **branch** and on a **detached HEAD** (covering review nit #3), staged-index survival proven by a successful retry after clearing the failing signer, and tag rollback (annotated deleted; lightweight unaffected; retry works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)