### PR TITLE
feat(git): git-commits-since — where a commit sits relative to HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,16 @@ value did not parse, deferring the failure to an unrelated error deep
 inside the program; it now returns a read error naming the
 placeholder.
 
+### Added — `git-commits-since`
+
+`(git-commits-since repo rev)` reports where a commit sits relative to
+`HEAD`: a vector of the hashes stacked on top of `rev` in `HEAD`'s
+first-parent history, newest first — `[]` when `rev` is `HEAD` itself,
+`(count …)` its distance behind. Unknown revisions, and revisions off
+the first-parent chain (side branches, the non-mainline side of a
+merge), throw distinct errors. Combine with `git-show` to print the
+pending commits.
+
 ### ⚠️ Removed — the `.state/` store
 
 `state-save` and `state-load` are **removed**, together with the

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -519,6 +519,7 @@ Git operations backed by go-git: init/clone/commit/push, tags, and SSH signature
 | `git-clone` | `[url path & {:auth :branch :depth :single-branch :bare}]` | Clones url into path and returns a handle; see git-push for the :auth map. |
 | `git-close` | `[repo]` | Closes a repository handle. |
 | `git-commit` | `[repo msg & {:author {:name :email} :committer :all :allow-empty :amend}]` | Commits staged changes and returns the commit map. When the Go embedder has installed a signing policy the commit is SSH-signed (a signing failure rolls HEAD and the index back); under the lisp and lisp-integrity binaries no policy is installed and commits are unsigned (there is no per-call key option). |
+| `git-commits-since` | `[repo rev]` | Vector of the commit hashes stacked on top of rev in HEAD's first-parent history, newest first — [] when rev is HEAD itself, (count …) its distance behind. rev is a hash, branch or tag. Throws when rev is unknown, and when it exists but is not in the first-parent history (a side branch, or the non-mainline side of a merge). |
 | `git-fetch` | `[repo & {:auth :remote :refspecs :depth :prune :force}]` | Fetches from :remote (default origin); returns :ok or :up-to-date. |
 | `git-head` | `[repo]` | Returns {:name :branch :hash} for HEAD. |
 | `git-init` | `[path & {:bare :object-format}]` | Creates a repository at path and returns a handle; :object-format "sha256" for a SHA-256 repo. |

--- a/lib/git/git.go
+++ b/lib/git/git.go
@@ -72,6 +72,7 @@ func Load(env EnvType) {
 	call.CallOverrideFN(env, "git-commit", gitCommit, 2, 3)
 	call.CallOverrideFN(env, "git-log", gitLog, 1, 2)
 	call.CallOverrideFN(env, "git-show", gitShow)
+	call.CallOverrideFN(env, "git-commits-since", gitCommitsSince)
 	call.CallOverrideFN(env, "git-status", gitStatus)
 	call.CallOverrideFN(env, "git-head", gitHead)
 	call.CallOverrideFN(env, "git-branch", gitBranch, 2, 3)
@@ -103,6 +104,8 @@ func Load(env EnvType) {
 		"Returns a vector of commit maps from HEAD (or :from rev), newest first.")
 	call.Doc(env, "git-show", "[repo rev]",
 		"Returns the commit map for rev (hash, \"HEAD\", branch or tag name).")
+	call.Doc(env, "git-commits-since", "[repo rev]",
+		"Vector of the commit hashes stacked on top of rev in HEAD's first-parent history, newest first — [] when rev is HEAD itself, (count …) its distance behind. rev is a hash, branch or tag. Throws when rev is unknown, and when it exists but is not in the first-parent history (a side branch, or the non-mainline side of a merge).")
 	call.Doc(env, "git-status", "[repo]",
 		"Returns {:clean bool :files {path {:staging kw :worktree kw}}} for the worktree.")
 	call.Doc(env, "git-head", "[repo]",
@@ -651,6 +654,40 @@ func gitTags(rv MalType) (MalType, error) {
 		return nil, err
 	}
 	return Vector{Val: out}, nil
+}
+
+// gitCommitsSince walks HEAD's first-parent chain down to rev and
+// returns the hashes stacked on top of it, newest first. [] means rev
+// is HEAD; the walk fails when rev is unknown or not on the chain, so
+// a caller can tell "current", "N behind" and "not deployed" apart.
+func gitCommitsSince(rv MalType, rev string) (MalType, error) {
+	r, err := asRepo("git-commits-since", rv)
+	if err != nil {
+		return nil, err
+	}
+	target, err := commitAt(r, rev)
+	if err != nil {
+		return nil, fmt.Errorf("git-commits-since: unknown revision %q: %w", rev, err)
+	}
+	head, err := r.repo.Head()
+	if err != nil {
+		return nil, fmt.Errorf("git-commits-since: %w", err)
+	}
+	cur, err := r.repo.CommitObject(head.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("git-commits-since: %w", err)
+	}
+	since := []MalType{}
+	for cur.Hash != target.Hash {
+		since = append(since, cur.Hash.String())
+		if cur.NumParents() == 0 {
+			return nil, fmt.Errorf("git-commits-since: %s is not in the first-parent history of HEAD", target.Hash)
+		}
+		if cur, err = cur.Parent(0); err != nil {
+			return nil, fmt.Errorf("git-commits-since: %w", err)
+		}
+	}
+	return Vector{Val: since}, nil
 }
 
 // resolve turns a revision string (hash, HEAD, branch, tag, ...) into a hash.

--- a/lib/git/git_test.go
+++ b/lib/git/git_test.go
@@ -461,3 +461,40 @@ func TestTagRollsBackWhenSigningFails(t *testing.T) {
 	eval(t, ns, `(git-tag r "v1" {:message "rel" :tagger `+author+`})`)
 	expectTrue(t, ns, `(= 2 (count (git-tags r)))`)
 }
+
+// TestCommitsSince pins the git-commits-since contract: [] at HEAD,
+// newest-first hashes for an ancestor, tag revs resolve, and the two
+// error modes (unknown revision; exists but off the first-parent chain)
+// are distinct.
+func TestCommitsSince(t *testing.T) {
+	ns := newEnv(t)
+	dir := t.TempDir()
+	eval(t, ns, fmt.Sprintf(`(def r (git-init %q))`, dir))
+	commit := func(n string) string {
+		if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte(n+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		eval(t, ns, `(git-add r "a.txt")`)
+		return eval(t, ns, `(get (git-commit r "`+n+`" {:author `+author+`}) :hash)`).(string)
+	}
+	first := commit("one")
+	eval(t, ns, `(git-tag r "v1")`)
+	second := commit("two")
+	third := commit("three")
+
+	expectTrue(t, ns, fmt.Sprintf(`(= [] (git-commits-since r %q))`, third))
+	expectTrue(t, ns, `(= [] (git-commits-since r "HEAD"))`)
+	expectTrue(t, ns, fmt.Sprintf(`(= [%q] (git-commits-since r %q))`, third, second))
+	expectTrue(t, ns, fmt.Sprintf(`(= [%q %q] (git-commits-since r %q))`, third, second, first))
+	expectTrue(t, ns, fmt.Sprintf(`(= [%q %q] (git-commits-since r "v1"))`, third, second))
+	expectTrue(t, ns, fmt.Sprintf(`(= 2 (count (git-commits-since r %q)))`, first))
+
+	expectThrow(t, ns, `(git-commits-since r "0000000000000000000000000000000000000000")`)
+	expectThrow(t, ns, `(git-commits-since r "no-such-branch")`)
+
+	// A commit on a side branch exists but is not first-parent history.
+	eval(t, ns, `(git-branch r "side" {:checkout true})`)
+	sideHash := commit("side-work")
+	eval(t, ns, `(git-checkout r "master")`)
+	expectThrow(t, ns, fmt.Sprintf(`(git-commits-since r %q)`, sideHash))
+}


### PR DESCRIPTION
## Summary

- `(git-commits-since repo rev)`: vector of the commit hashes stacked on top of `rev` in `HEAD`'s **first-parent** history, newest first — `[]` when `rev` is `HEAD`, `(count …)` its distance behind. `rev` accepts a hash, branch or tag (resolved like `git-show`).
- Two distinct error modes: revision **unknown** to the repository, vs revision that exists but is **off the first-parent chain** (a side branch, or the non-mainline side of a merge) — so "current", "N behind" and "not deployed here" are all distinguishable.
- First-parent (not any-ancestor) was the agreed semantic: it makes the returned vector a well-defined chain ("the commits piled on top of yours on the mainline"), which is the deployment question the function answers. Print the pending ones with `(map (fn [h] (git-show r h)) …)`.
- Docstring + CHANGELOG under 0.6.0; `LANGUAGE.md` regenerated.

## Test plan

- `go test ./...` green; gofmt/vet clean.
- Contract test: `[]` at `HEAD` (by hash and by name), newest-first ordering at distances 1 and 2, tag revs, `count` = distance, unknown-hash and unknown-name throws, and the side-branch throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)