### PR TITLE
docs(examples): minimal HTTP server example

### DIFF
--- a/examples/httpserver.lisp
+++ b/examples/httpserver.lisp
@@ -1,0 +1,5 @@
+(def app
+  (web-router
+    [["/" {:get (fn [req] (web-text "OK"))}]]))
+
+(web-serve {:port 8080 :handler app})


### PR DESCRIPTION
## Summary

`examples/httpserver.lisp`: the smallest lib/web program — a router with `GET /` answering `OK` via `web-text`, served with `web-serve` on 8080. Verified live (200 on `/`, 404 elsewhere) and canonically formatted, so the formatter test that globs `examples/*.lisp` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)