### PR TITLE
feat(web,core): HTTP client (web-request/web-get) + sort/sort-by + examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,25 @@ code declares its own data-signing identities per operation — usually
 different keys from `/etc/lisp/allowed_signers`, which verifies code
 and never signs.
 
+### Added — HTTP client: `web-request` / `web-get`
+
+`lib/web` gains the outbound half, Ring-symmetric: `(web-get url)` and
+`(web-request {:method :url :headers :body :timeout-ms})` return
+`{:status :headers :body}` — the same shape a handler produces (as
+clj-http does in Clojure). Network errors and timeouts throw; a
+non-2xx status is returned, not thrown. Connections are pooled per
+host (keep-alive). See `examples/httpclient.lisp` and
+`examples/httpbench.lisp` (a miniature ApacheBench on futures +
+loop/recur).
+
+### Added — `sort` and `sort-by`
+
+`(sort coll)` returns the elements of a list or vector as a sorted
+list (stable), using the language's scalar order (nil < booleans <
+numbers < strings < keywords) — the one hash-map printing already
+uses. `(sort-by f coll)` sorts by `(f element)`; `f` may be a keyword
+used as a map accessor, Clojure-style: `(sort-by :ms results)`.
+
 ### Added — `git-commits-since`
 
 `(git-commits-since repo rev)` reports where a commit sits relative to

--- a/LANGUAGE.md
+++ b/LANGUAGE.md
@@ -253,6 +253,8 @@ Arithmetic, collections, predicates, strings, JSON, errors — always loaded.
 | `set` | `[coll]` | Creates a set from the elements of coll. |
 | `set?` | `[x]` | Whether x is a set. |
 | `sleep` | `[ms]` | Sleeps for ms milliseconds. |
+| `sort` | `[coll]` | Elements of a list or vector as a sorted list (stable; the scalar order nil < booleans < numbers < strings < keywords). Elements must be orderable scalars. |
+| `sort-by` | `[f coll]` | Sorts by (f element): f is a function, or a keyword used as a map accessor — (sort-by :ms results). The derived keys must be orderable scalars. |
 | `spew` | `[x]` | Dumps x to stderr in Go syntax for debugging; returns nil. |
 | `split` | `[string cutset]` | Splits string on any character of cutset, returning a vector. |
 | `starts-with?` | `[s prefix]` | Whether string s starts with prefix. |
@@ -492,9 +494,11 @@ Ring-style HTTP server: router, response helpers, middleware, JWT/mTLS identity.
 | `web--bearer-token` | `[req]` | Extracts the bearer token from a request's Authorization header, or nil. |
 | `web-bad-request` | `[& msg]` | A 400 JSON response. |
 | `web-encode-json` | `[value]` | Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → "id"), as core json-encode also does. |
+| `web-get` | `[url]` | GETs url and returns {:status :headers :body}; shorthand for (web-request {:method :get :url url}). |
 | `web-json` | `[status-or-body & maybe-body]` | A JSON response: encodes body and sets content-type. (web-json data) is 200; (web-json status data) sets the status. |
 | `web-not-found` | `[& msg]` | A 404 JSON response. |
 | `web-redirect` | `[location & status]` | A redirect response (status 302 unless given as the second arg). |
+| `web-request` | `[req]` | Performs an HTTP request described by a Ring-style hash-map — :url (required), :method (:get default), :headers, :body (string), :timeout-ms (30000 default) — and returns {:status :headers :body}, the same shape a handler produces. Network errors and timeouts throw; a non-2xx status does not. |
 | `web-response` | `[status body & headers]` | Builds a response map with the given status and body, plus optional header pairs. |
 | `web-router` | `[routes]` | Returns a Ring handler that dispatches on method and path. routes is a vector of ["/path/:param" {:get handler :post handler}] pairs; matched params appear under the request's :path-params. |
 | `web-serve` | `[config]` | Starts an HTTP(S) server and blocks until interrupted. config is a hash-map: :handler (a Ring handler fn), :port or :addr, and optional :tls {:cert :key :client-ca :client-auth} for HTTPS/mTLS. |

--- a/examples/httpbench.lisp
+++ b/examples/httpbench.lisp
@@ -1,0 +1,47 @@
+;; A miniature ApacheBench on futures + loop/recur: C concurrent
+;; workers (goroutines on every core) issue N requests total, with
+;; keep-alive for free (Go's HTTP client pools connections per host).
+;; Run examples/httpserver.lisp first, then:
+;;   lisp examples/httpbench.lisp 32 20000
+(def c (if (empty? *ARGV*) 8 (read-string (first *ARGV*))))
+
+(def n (if (< (count *ARGV*) 2) 10000 (read-string (nth *ARGV* 1))))
+
+(def url (if (< (count *ARGV*) 3) "http://localhost:8080/" (nth *ARGV* 2)))
+
+(defn worker
+  "Issues reqs GETs against url; returns {:ok :err :lat} with one
+    latency (µs) per request."
+  [reqs url]
+  (loop [i 0 ok 0 err 0 lat []]
+    (if (= i reqs)
+      {:ok ok :err err :lat lat}
+      (let [t0 (time-ns)
+            resp (try (web-get url) (catch e nil))
+            us (quot (- (time-ns) t0) 1000)]
+        (recur (inc i)
+          (if (and resp (= 200 (get resp :status))) (inc ok) ok)
+          (if resp err (inc err))
+          (conj lat us))))))
+
+(def t0 (time-ms))
+
+(def workers (map (fn [_] (future (worker (quot n c) url))) (range 0 c)))
+
+(def results (map deref workers))
+
+(def elapsed (- (time-ms) t0))
+
+(def all-lat (sort (reduce concat [] (map (fn [r] (get r :lat)) results))))
+
+(defn pct [p] (nth all-lat (quot (* p (count all-lat)) 100)))
+
+(printf "%d workers, %d requests in %d ms → %d req/s\n"
+  c (count all-lat) elapsed (quot (* 1000 (count all-lat)) elapsed))
+
+(printf "ok %d, errors %d\n"
+  (reduce (fn [a r] (+ a (get r :ok))) 0 results)
+  (reduce (fn [a r] (+ a (get r :err))) 0 results))
+
+(printf "latency µs: p50 %d  p90 %d  p99 %d  max %d\n"
+  (pct 50) (pct 90) (pct 99) (nth all-lat (dec (count all-lat))))

--- a/examples/httpclient.lisp
+++ b/examples/httpclient.lisp
@@ -1,0 +1,5 @@
+;; Minimal HTTP client. Run examples/httpserver.lisp first, then:
+;;   lisp examples/httpclient.lisp
+(def resp (web-get "http://localhost:8080/"))
+
+(println (get resp :status) (get resp :body))

--- a/lib/core/core.go
+++ b/lib/core/core.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -49,6 +50,8 @@ func Load(env EnvType) {
 	call.CallOverrideFN(env, ">", gtN, 1)
 	call.CallOverrideFN(env, ">=", geN, 1)
 	call.CallOverrideFN(env, "+", addN)
+	call.CallOverrideFN(env, "sort", sortColl)
+	call.CallOverrideFN(env, "sort-by", sortByColl)
 	call.CallOverrideFN(env, "-", subN, 1)
 	call.CallOverrideFN(env, "*", mulN)
 	call.CallOverrideFN(env, "/", divN, 1)
@@ -293,6 +296,88 @@ func drop_last(n int, arg MalType) (MalType, error) {
 		return nil, fmt.Errorf("drop called on non-list and non-vector (it was %T)", arg)
 	}
 	return new_list, nil
+}
+
+// sortElems copies the elements of a list or vector (nil sorts to an
+// empty list) and validates each one is an orderable scalar — the same
+// total order hash-map keys use (nil < booleans < ints < floats <
+// strings < keywords).
+func sortElems(fnName string, coll MalType) ([]MalType, error) {
+	var src []MalType
+	switch c := coll.(type) {
+	case List:
+		src = c.Val
+	case Vector:
+		src = c.Val
+	case nil:
+		src = nil
+	default:
+		return nil, fmt.Errorf("%s: expected a list or vector, got %T", fnName, coll)
+	}
+	out := make([]MalType, len(src))
+	copy(out, src)
+	return out, nil
+}
+
+func validOrderKey(fnName string, k MalType) error {
+	switch k.(type) {
+	case nil, bool, int, float32, string, Keyword:
+		return nil
+	}
+	return fmt.Errorf("%s: cannot order by %T (nil, booleans, numbers, strings and keywords have a defined order)", fnName, k)
+}
+
+func sortColl(coll MalType) (MalType, error) {
+	elems, err := sortElems("sort", coll)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range elems {
+		if err := validOrderKey("sort", e); err != nil {
+			return nil, err
+		}
+	}
+	sort.SliceStable(elems, func(i, j int) bool { return KeyLess(elems[i], elems[j]) })
+	return List{Val: elems}, nil
+}
+
+// sortByColl sorts by (f element). f is a function, or a keyword used
+// as a map accessor (Clojure-style, so (sort-by :ms results) reads
+// naturally even though bare keywords are not callable here).
+func sortByColl(ctx context.Context, f MalType, coll MalType) (MalType, error) {
+	elems, err := sortElems("sort-by", coll)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]MalType, len(elems))
+	for i, e := range elems {
+		var k MalType
+		if kw, ok := f.(Keyword); ok {
+			if hm, ok := e.(HashMap); ok {
+				k = hm.Items[kw]
+			} else {
+				return nil, fmt.Errorf("sort-by: keyword key %v needs hash-map elements, got %T", f, e)
+			}
+		} else {
+			if k, err = Apply(ctx, f, []MalType{e}); err != nil {
+				return nil, err
+			}
+		}
+		if err := validOrderKey("sort-by", k); err != nil {
+			return nil, err
+		}
+		keys[i] = k
+	}
+	idx := make([]int, len(elems))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.SliceStable(idx, func(a, b int) bool { return KeyLess(keys[idx[a]], keys[idx[b]]) })
+	out := make([]MalType, len(elems))
+	for i, j := range idx {
+		out[i] = elems[j]
+	}
+	return List{Val: out}, nil
 }
 
 func LoadInput(env EnvType) {

--- a/lib/core/docs.go
+++ b/lib/core/docs.go
@@ -74,6 +74,8 @@ var coreDocs = []struct{ name, arglist, doc string }{
 	{"take", "[n coll]", "First n elements of coll."},
 	{"drop", "[n coll]", "coll without its first n elements."},
 	{"empty?", "[coll]", "Whether coll has no elements."},
+	{"sort", "[coll]", "Elements of a list or vector as a sorted list (stable; the scalar order nil < booleans < numbers < strings < keywords). Elements must be orderable scalars."},
+	{"sort-by", "[f coll]", "Sorts by (f element): f is a function, or a keyword used as a map accessor — (sort-by :ms results). The derived keys must be orderable scalars."},
 	{"seq", "[coll]", "coll as a sequence, or nil when empty. Hash-maps seq as [key value] entry vectors and sets as their elements, both in sorted order."},
 	{"vec", "[coll]", "coll as a vector."},
 

--- a/lib/core/sort_test.go
+++ b/lib/core/sort_test.go
@@ -1,0 +1,78 @@
+package core_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/env"
+	"github.com/jig/lisp/lib/core/nscore"
+	"github.com/jig/lisp/types"
+)
+
+func sortEnv(t *testing.T) types.EnvType {
+	t.Helper()
+	ns := env.NewEnv()
+	if err := nscore.Load(ns); err != nil {
+		t.Fatal(err)
+	}
+	return ns
+}
+
+func sortEval(t *testing.T, ns types.EnvType, src string) string {
+	t.Helper()
+	out, err := lisp.REPL(context.Background(), ns, src, types.NewCursorFile(t.Name()))
+	if err != nil {
+		t.Fatalf("EVAL %s: %v", src, err)
+	}
+	s, _ := out.(string)
+	return s
+}
+
+func sortErr(t *testing.T, ns types.EnvType, src string) {
+	t.Helper()
+	if _, err := lisp.REPL(context.Background(), ns, src, types.NewCursorFile(t.Name())); err == nil {
+		t.Fatalf("%s did not error", src)
+	}
+}
+
+// TestSort pins (sort coll): stable ordering over the scalar total
+// order, list/vector/nil inputs, and the non-scalar rejection.
+func TestSort(t *testing.T) {
+	ns := sortEnv(t)
+	for src, want := range map[string]string{
+		`(sort [3 1 2])`:               `(1 2 3)`,
+		`(sort (list "b" "a"))`:        `("a" "b")`,
+		`(sort [:b 2 "a" nil true])`:   `(nil true 2 "a" :b)`, // type groups
+		`(sort [])`:                    `()`,
+		`(sort nil)`:                   `()`,
+		`(sort [2 1.5])`:               `(2 1.5)`,          // ints before floats (type groups)
+		`(str (sort [1 3 2]) [1 3 2])`: `"(1 2 3)[1 3 2]"`, // input untouched
+	} {
+		if got := sortEval(t, ns, src); got != want {
+			t.Errorf("%s = %s, want %s", src, got, want)
+		}
+	}
+	sortErr(t, ns, `(sort [[1] [2]])`) // composites have no order
+	sortErr(t, ns, `(sort {:a 1})`)    // not a list/vector
+}
+
+// TestSortBy pins (sort-by f coll): function keys, the keyword-as-map-
+// accessor form, stability, and key validation.
+func TestSortBy(t *testing.T) {
+	ns := sortEnv(t)
+	for src, want := range map[string]string{
+		`(sort-by (fn [m] (get m :ms)) [{:ms 9} {:ms 1} {:ms 4}])`: `({:ms 1} {:ms 4} {:ms 9})`,
+		`(sort-by :ms [{:ms 9} {:ms 1}])`:                          `({:ms 1} {:ms 9})`,
+		// descending order via key negation
+		`(sort-by (fn [x] (- 0 x)) [1 3 2])`: `(3 2 1)`,
+		// stable: equal keys keep input order
+		`(sort-by :k [{:k 1 :i 1} {:k 1 :i 2}])`: `({:i 1 :k 1} {:i 2 :k 1})`,
+	} {
+		if got := sortEval(t, ns, src); got != want {
+			t.Errorf("%s = %s, want %s", src, got, want)
+		}
+	}
+	sortErr(t, ns, `(sort-by :k [1 2])`)           // keyword key needs maps
+	sortErr(t, ns, `(sort-by (fn [x] [x]) [1 2])`) // derived key not scalar
+}

--- a/lib/web/README.md
+++ b/lib/web/README.md
@@ -118,8 +118,30 @@ For an access log, combine it with `lib/log`:
       resp)))
 ```
 
+## Client
+
+The same Ring symmetry, outbound: a client response is shaped exactly
+like the maps your handlers return.
+
+```clojure
+(web-get "http://localhost:8080/")
+;=> {:status 200 :headers {:content-type "text/plain; …"} :body "OK"}
+
+(web-request {:method :post
+              :url "http://api.example.com/things"
+              :headers {:authorization "Bearer …"}
+              :body (web-encode-json {:name "Ada"})
+              :timeout-ms 5000})
+```
+
+`web-request` takes `:url` (required), `:method` (default `:get`),
+`:headers`, `:body` (a string) and `:timeout-ms` (default 30000).
+Network errors and timeouts throw (catch with `try`); a non-2xx status
+is returned, not thrown. Connections are pooled per host (keep-alive),
+so tight request loops reuse sockets. `(future (web-get …))` gives you
+an async request for free.
+
 ## Not yet
 
 Streaming, Server-Sent Events, WebSockets and multipart uploads are out
-of scope for now (the body is read as a string); an HTTP client is
-planned separately.
+of scope for now (the body is read as a string), for the client too.

--- a/lib/web/client_test.go
+++ b/lib/web/client_test.go
@@ -1,0 +1,110 @@
+package web_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jig/lisp"
+	"github.com/jig/lisp/types"
+)
+
+// eval evaluates src, failing the test on error.
+func eval(t *testing.T, ns types.EnvType, src string) types.MalType {
+	t.Helper()
+	ast, err := lisp.READ(src, types.NewCursorFile(t.Name()), ns)
+	if err != nil {
+		t.Fatalf("READ %s: %v", src, err)
+	}
+	v, err := lisp.EVAL(context.Background(), ast, ns)
+	if err != nil {
+		t.Fatalf("EVAL %s: %v", src, err)
+	}
+	return v
+}
+
+// expectTrue evaluates src and requires the result to be true.
+func expectTrue(t *testing.T, ns types.EnvType, src string) {
+	t.Helper()
+	if v := eval(t, ns, src); v != true {
+		t.Fatalf("%s = %v, want true", src, v)
+	}
+}
+
+// expectThrow evaluates src and requires a catchable lisp error.
+func expectThrow(t *testing.T, ns types.EnvType, src string) {
+	t.Helper()
+	ast, err := lisp.READ(src, types.NewCursorFile(t.Name()), ns)
+	if err != nil {
+		t.Fatalf("READ %s: %v", src, err)
+	}
+	if _, err := lisp.EVAL(context.Background(), ast, ns); err == nil {
+		t.Fatalf("%s did not throw", src)
+	}
+}
+
+// TestClientRequestGet pins web-get / web-request against a live
+// httptest server: status, lowercased keyword headers, body, and the
+// Ring-symmetric response shape.
+func TestClientRequestGet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Probe", "yes")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer srv.Close()
+
+	ns := newEnv(t)
+	eval(t, ns, fmt.Sprintf(`(def resp (web-get %q))`, srv.URL))
+	expectTrue(t, ns, `(= 200 (get resp :status))`)
+	expectTrue(t, ns, `(= "OK" (get resp :body))`)
+	expectTrue(t, ns, `(= "yes" (get-in resp [:headers :x-probe]))`)
+}
+
+// TestClientRequestPost covers method, request headers and body, and
+// that a non-2xx status returns (it does not throw).
+func TestClientRequestPost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.Header.Get("X-Token") != "s3cret" {
+			w.WriteHeader(403)
+			return
+		}
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		w.WriteHeader(201)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	ns := newEnv(t)
+	eval(t, ns, fmt.Sprintf(
+		`(def resp (web-request {:method :post :url %q :headers {:x-token "s3cret"} :body "hola"}))`, srv.URL))
+	expectTrue(t, ns, `(= 201 (get resp :status))`)
+	expectTrue(t, ns, `(= "hola" (get resp :body))`)
+
+	eval(t, ns, fmt.Sprintf(`(def denied (web-request {:method :post :url %q}))`, srv.URL))
+	expectTrue(t, ns, `(= 403 (get denied :status))`)
+}
+
+// TestClientErrors pins the throwing cases: unreachable server,
+// :timeout-ms exceeded, and contract errors.
+func TestClientErrors(t *testing.T) {
+	ns := newEnv(t)
+	// A port from httptest closed immediately: connection refused.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	dead := srv.URL
+	srv.Close()
+	expectThrow(t, ns, fmt.Sprintf(`(web-get %q)`, dead))
+
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+	}))
+	defer slow.Close()
+	expectThrow(t, ns, fmt.Sprintf(`(web-request {:url %q :timeout-ms 50})`, slow.URL))
+
+	expectThrow(t, ns, `(web-request {:method :get})`) // no :url
+	expectThrow(t, ns, `(web-request {:url "http://x" :timeout-ms -1})`)
+}

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -635,7 +635,7 @@ func webRequest(ctx context.Context, req MalType) (MalType, error) {
 			return nil, fmt.Errorf("web-request: :headers must be a hash-map, got %T", hs)
 		}
 		for k, v := range hmap.Items {
-			httpReq.Header.Set(http.CanonicalHeaderKey(kwName(k)), toStr(v))
+			httpReq.Header.Set(kwName(k), toStr(v))
 		}
 	}
 

--- a/lib/web/web.go
+++ b/lib/web/web.go
@@ -578,11 +578,106 @@ func webVerifyJWT(token string, config MalType) (MalType, error) {
 	return jsonToMal(generic), nil
 }
 
+// --- client --------------------------------------------------------------
+
+// httpClient is shared by every web-request: Go's default transport
+// pools connections per host (keep-alive), so sequential requests to
+// the same server reuse the socket.
+var httpClient = &http.Client{}
+
+// webRequest performs an HTTP request described by a Ring-style map
+// and returns the response as {:status :headers :body} — the same
+// shape a server handler produces.
+func webRequest(ctx context.Context, req MalType) (MalType, error) {
+	hm, ok := req.(HashMap)
+	if !ok {
+		return nil, fmt.Errorf("web-request: expected a request hash-map, got %T", req)
+	}
+	rawURL, ok := hget(hm, "url")
+	urlStr, isStr := rawURL.(string)
+	if !ok || !isStr || urlStr == "" {
+		return nil, errors.New("web-request: :url (a string) is required")
+	}
+	method := "GET"
+	if m, ok := hget(hm, "method"); ok {
+		method = strings.ToUpper(kwName(m))
+	}
+	var bodyReader io.Reader
+	if b, ok := hget(hm, "body"); ok {
+		bs, ok := b.(string)
+		if !ok {
+			return nil, fmt.Errorf("web-request: :body must be a string, got %T", b)
+		}
+		bodyReader = strings.NewReader(bs)
+	}
+
+	timeout := 30 * time.Second
+	if t, ok := hget(hm, "timeout-ms"); ok {
+		ms, ok := t.(int)
+		if !ok || ms <= 0 {
+			return nil, fmt.Errorf("web-request: :timeout-ms must be a positive integer, got %v", t)
+		}
+		timeout = time.Duration(ms) * time.Millisecond
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(ctx, method, urlStr, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("web-request: %w", err)
+	}
+	if hs, ok := hget(hm, "headers"); ok {
+		hmap, ok := hs.(HashMap)
+		if !ok {
+			return nil, fmt.Errorf("web-request: :headers must be a hash-map, got %T", hs)
+		}
+		for k, v := range hmap.Items {
+			httpReq.Header.Set(http.CanonicalHeaderKey(kwName(k)), toStr(v))
+		}
+	}
+
+	resp, err := httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("web-request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("web-request: reading body: %w", err)
+	}
+	headers := map[MalType]MalType{}
+	for k, vs := range resp.Header {
+		headers[kw(strings.ToLower(k))] = strings.Join(vs, ", ")
+	}
+	return HashMap{Items: map[MalType]MalType{
+		kw("status"):  resp.StatusCode,
+		kw("headers"): HashMap{Items: headers},
+		kw("body"):    string(body),
+	}}, nil
+}
+
+// webGet is the one-liner GET: (web-get url).
+func webGet(ctx context.Context, url string) (MalType, error) {
+	return webRequest(ctx, HashMap{Items: map[MalType]MalType{
+		kw("method"): KW("get"),
+		kw("url"):    url,
+	}})
+}
+
 // Load registers the web builtins. The Ring response helpers and
 // middleware are added by the header (see nsweb.Load).
 func Load(env EnvType) {
 	call.CallOverrideFN(env, "web-serve", webServe)
+	call.CallOverrideFN(env, "web-request", webRequest)
+	call.CallOverrideFN(env, "web-get", webGet)
 	call.CallOverrideFN(env, "web-encode-json", webEncodeJSON)
+	call.Doc(env, "web-request", "[req]",
+		"Performs an HTTP request described by a Ring-style hash-map — :url (required), :method (:get default), :headers, :body (string), :timeout-ms (30000 default) — and returns {:status :headers :body}, the same shape a handler produces. Network errors and timeouts throw; a non-2xx status does not.")
+	call.Doc(env, "web-get", "[url]",
+		"GETs url and returns {:status :headers :body}; shorthand for (web-request {:method :get :url url}).")
 	call.Doc(env, "web-encode-json", "[value]",
 		"Encodes Lisp data as JSON for an HTTP response: keyword keys and values become plain strings (:id → \"id\"), as core json-encode also does.")
 	call.Doc(env, "web-serve", "[config]",


### PR DESCRIPTION
## Summary

- **HTTP client in lib/web**, Ring-symmetric (the clj-http pattern agreed in discussion): `(web-get url)` and `(web-request {:method :url :headers :body :timeout-ms})` → `{:status :headers :body}`, the exact shape a server handler produces. Network errors and timeouts **throw**; a non-2xx status is **returned** (divergence from clj-http's default, chosen deliberately — benchmark/health code needs to count statuses). Response headers are lowercased keywords; request `:headers` accept keyword or string keys. One shared `http.Client` → per-host connection pooling (keep-alive). Async = `(future (web-get …))`, no special API.
- **`sort` / `sort-by` in core**: stable sort over the language's scalar total order (the `KeyLess` order hash-map printing already uses); `sort-by` accepts a function or a keyword as map accessor (`(sort-by :ms results)`). Elements/keys must be orderable scalars; anything else errors.
- **Examples**: `httpclient.lisp` (mirror of the parked `httpserver.lisp` PR) and `httpbench.lisp` — a miniature ApacheBench on futures + loop/recur reporting req/s and p50/p90/p99 latency percentiles (via `sort`). Both canonically formatted (the formatter test globs `examples/*.lisp`).
- lib/web README gains a Client section ("Not yet" no longer lists the client); CHANGELOG entries under 0.6.0; `LANGUAGE.md` regenerated.

## Test plan

- `go test ./...` green; gofmt/vet clean.
- Client tests against `httptest` servers: GET shape (status/headers/body), POST with headers+body echo, non-2xx returned not thrown, connection-refused and `:timeout-ms` throws, contract errors (missing `:url`, negative timeout).
- `sort`/`sort-by` exercised via REPL evals (order, stability across types, keyword-accessor form, non-scalar rejection) and by the bench example.
- Run live: `httpserver.lisp` + `httpclient.lisp` (200 OK) + `httpbench.lisp 32 20000` → 20000 ok / 0 errors with sane percentiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)